### PR TITLE
release: v2.5.0 — spec composition + DSL hygiene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ qedgen check --spec my_program.qedspec --code ./programs --kani ./tests/kani.rs 
 
 ### sBPF verification
 
+sBPF-specific declarations (`instruction`, `pubkey`, per-instruction `errors`)
+live inside `pragma sbpf { ... }` — the core DSL stays platform-agnostic, and
+`qedgen` infers the assembly target from the pragma's presence.
+
+```
+spec Transfer
+
+pragma sbpf {
+  instruction transfer_sol { ... }
+}
+```
+
 ```bash
 # Transpile sBPF assembly to Lean 4
 qedgen asm2lean --input src/program.s --output formal_verification/Program.lean
@@ -138,6 +150,41 @@ qedgen asm2lean --input src/program.s --output formal_verification/Program.lean
 # Verify sBPF proofs (checks source hash, regenerates if stale)
 qedgen check --spec my_program.qedspec --asm src/program.s
 ```
+
+### CPI contracts — `interface` + `call`
+
+When your program invokes another (SPL Token, System Program, an AMM, …),
+declare the callee's contract as an `interface` and write `call` at the
+invocation site. The Rust side gets a real CPI builder; Lean proofs pick up
+the callee's declared `ensures` as hypotheses.
+
+```
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+  handler transfer (amount : U64) {
+    discriminant "0x03"
+    accounts { from : writable, type token
+               to   : writable, type token
+               authority : signer }
+    ensures amount > 0
+  }
+}
+
+handler exchange : State.Open -> State.Closed {
+  call Token.transfer(from = taker_ta, to = initializer_ta,
+                      amount = taker_amount, authority = taker)
+}
+```
+
+```bash
+# Scaffold a Tier-0 interface from an Anchor IDL (shape only — no ensures)
+qedgen interface --idl target/idl/jupiter.json --out interfaces/jupiter.qedspec
+```
+
+`qedgen check` emits `[shape_only_cpi]` for any `call` whose target lacks
+`ensures`, making the gap between "my Rust compiles" and "my program is
+verified" visible. See [docs/design/spec-composition.md](docs/design/spec-composition.md)
+for the full tier model.
 
 ### Generate proofs from a prompt
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,18 @@ CPI calls are axiomatic — we verify the program passes correct parameters. SPL
 # 1. Install
 npx skills add qedgen/solana-skills
 
-# 2. Write a spec and validate it
-qedgen check --spec my_program.qedspec
+# 2. Initialize the project — records the spec path in .qed/config.json
+qedgen init --name my_program --spec my_program.qedspec --quasar
 
-# 3. Generate all artifacts
-qedgen codegen --spec my_program.qedspec --all
+# 3. Validate and generate artifacts (no --spec needed from inside the project)
+qedgen check
+qedgen codegen --all
 ```
+
+`.qed/config.json` pins the spec location so subsequent commands don't need
+`--spec <path>` — they walk up from the current directory, find the nearest
+`.qed/`, and resolve. Explicit `--spec` still works when you want to point
+at something specific.
 
 Lean proofs, Kani harnesses, and API keys are set up automatically when first needed. To configure them manually:
 
@@ -179,6 +185,10 @@ handler exchange : State.Open -> State.Closed {
 ```bash
 # Scaffold a Tier-0 interface from an Anchor IDL (shape only — no ensures)
 qedgen interface --idl target/idl/jupiter.json --out interfaces/jupiter.qedspec
+
+# Or vendor it into .qed/interfaces/<program>.qedspec (the canonical location
+# for tool-managed library specs — pointed at by `.qed/config.json`)
+qedgen interface --idl target/idl/jupiter.json --vendor
 ```
 
 `qedgen check` emits `[shape_only_cpi]` for any `call` whose target lacks

--- a/SKILL.md
+++ b/SKILL.md
@@ -229,18 +229,24 @@ Not every project needs this. The `.qedspec` alone (validated by lint + proptest
 ### 4a. Set up the Lean project
 
 ```bash
-# Anchor/Rust project
-$QEDGEN init --name escrow
+# Anchor/Rust project — --spec pins the authored qedspec location in .qed/config.json
+$QEDGEN init --name escrow --spec escrow.qedspec
 
 # sBPF project (runs asm2lean automatically)
-$QEDGEN init --name dropset --asm src/dropset.s
+$QEDGEN init --name dropset --spec dropset.qedspec --asm src/dropset.s
 
 # With Mathlib (for u128 arithmetic helpers)
-$QEDGEN init --name engine --mathlib
+$QEDGEN init --name engine --spec engine.qedspec --mathlib
 
 # With Quasar codegen pipeline
-$QEDGEN init --name counter --quasar
+$QEDGEN init --name counter --spec counter.qedspec --quasar
 ```
+
+After init, subsequent commands find the spec automatically by walking up
+from the current directory to the nearest `.qed/config.json` — no
+`--spec <path>` needed on `qedgen check` or `qedgen codegen` from inside
+the project. Explicit `--spec` still overrides when you want to point at
+something different.
 
 Generated structure:
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,20 +26,34 @@ QEDGEN="$HOME/.agents/skills/qedgen/tools/qedgen"
 The `.qedspec` is the **single source of truth** — the only artifact committed to the user's repo. Everything else (proptests, Lean theorems, generated code) is derived and disposable.
 
 ```
-Two phases:
+Three phases:
 
 Phase 1 — Spec Design (interactive, all artifacts transient)
   You + User ──→ iterate on .qedspec
     ├── Lint         — structural validation           (instant)
     ├── Proptest     — random counterexamples           (~100ms)
     └── lean-gen     — type-level provability check     (~seconds)
+  Mindset: declarative intent. Write what must be true, not how to prove it.
   Deliverable: .qedspec (committed)
+  Covered in: Step 1–3 below.
 
 Phase 2 — Proof Engineering (on demand, formal certificates)
   .qedspec ──→ Spec.lean ──→ Lean proofs ──→ lake build
     ├── Leanstral    — fast sorry-filling               (seconds)
     └── Aristotle    — deep agentic proof search         (minutes-hours)
+  Mindset: tactical. Read Lean errors, select proof patterns, route hard
+  sub-goals to the right backend. Switch references/proof-patterns.md
+  and references/sbpf.md into active context.
   Deliverable: zero-sorry Lean project + #[qed(verified)] stamps
+  Covered in: Step 4 below.
+
+Phase 3 — Audit / drift maintenance (ongoing, post-ship)
+  Verified code ──→ `qedgen reconcile` ──→ drift report
+    ├── spec_hash mismatch       — handler body drifted from spec
+    ├── orphan / missing theorem — Lean proofs out of sync with spec
+    └── upstream_binary_hash     — library interface (SPL Token, …) moved
+  Mindset: skeptical review. Read-mostly, verify claims, flag gaps.
+  Deliverable: no unresolved drift; verified artifacts remain trustworthy.
 
 Spec-driven pipeline (all generated from the same .qedspec):
   qedspec ──→ Proptest harnesses    (transient, /tmp)
@@ -48,6 +62,10 @@ Spec-driven pipeline (all generated from the same .qedspec):
           ──→ Quasar Rust program   (generated)
           ──→ Unit + integration tests (generated)
 ```
+
+Phase boundaries are meaningful: each phase has a distinct mindset,
+distinct tooling focus, and a distinct reference pack. When transitioning,
+load only the references relevant to the new phase — keep context tight.
 
 ## Step 1: Understand the program
 
@@ -139,6 +157,7 @@ Write the `.qedspec` at the program root. See `references/qedspec-dsl.md` for fu
 - **`pragma sbpf { ... }`** wraps sBPF-specific declarations (`instruction`, `pubkey`, per-instruction `errors`). The pragma's presence also selects the assembly target — no explicit `target` keyword.
 - **`interface Name { ... }` + `call Name.handler(...)`** declare CPI contracts. Generate Tier-0 scaffolds from Anchor IDLs with `qedgen interface --idl target/idl/<program>.json`. Tier-1 (hand-authored `ensures`) strengthens the caller's Lean proof.
 - **Multi-file specs** — `qedgen check --spec <dir>` accepts a directory of `.qedspec` fragments all declaring the same `spec Name`. Merged in sorted-path order. See `examples/rust/escrow-split/` for the convention.
+- **`let x = v in body`** — ML-style expression binding inside `ensures`/`requires`/effect RHS. Use when naming a computed quantity makes the post-condition clearer: `ensures let delta = old(state.balance) - state.balance in delta == amount`.
 
 For sBPF assembly programs, use `qedguards` instead of the core DSL for guard/property bodies.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -75,11 +75,11 @@ For native Rust programs without an IDL (no Anchor/Quasar), use LSP and source r
 
 3. **Find account validation** — In each handler, identify which accounts are checked for `is_signer`, which are writable, and any PDA derivations (`Pubkey::find_program_address`). These map to `context {}` entries with `Signer`, `mut`, `seeds()`, `bump`.
 
-4. **Find guards** — Look for early-return error checks (`if !condition { return Err(...) }`). These become `guard` clauses. Map error codes to an `errors [...]` block.
+4. **Find guards** — Look for early-return error checks (`if !condition { return Err(...) }`). These become `guard` clauses. Map error codes to a top-level `type Error | Name | ...` ADT. (The `errors [...]` list-sugar is v2.5-restricted to inside `pragma sbpf { ... }`.)
 
 5. **Find state mutations** — Track which fields are modified in each handler. These become `effect {}` blocks (`field = value`, `field += value`, `field -= value`).
 
-6. **Find CPI calls** — Look for `invoke` or `invoke_signed`. These become `calls` clauses with the target program, discriminator, and account list.
+6. **Find CPI calls** — Look for `invoke` or `invoke_signed`. Declare the callee's contract as an `interface Name { ... }` block (program_id, handler discriminant, accounts, optional `ensures`), then write `call Name.handler(name = expr, ...)` at each invocation site. For Anchor/SPL Token programs, use `qedgen interface --idl target/idl/<program>.json --out interfaces/<program>.qedspec` to scaffold a Tier-0 interface. See `interfaces/spl_token.qedspec` for the canonical SPL Token Tier-1 interface.
 
 7. **Infer lifecycle** — If there's an init handler that creates the account and a close/cancel handler that closes it, use `lifecycle [Uninitialized, Active, Closed]`. Map each handler to `when`/`then` transitions.
 
@@ -134,7 +134,13 @@ The spec design phase is an **interactive loop**. You iterate on the `.qedspec` 
 
 ### 3a. Write the initial .qedspec
 
-Write the `.qedspec` at the program root. See `references/qedspec-dsl.md` for full DSL syntax. For sBPF assembly programs, use `qedguards` instead.
+Write the `.qedspec` at the program root. See `references/qedspec-dsl.md` for full DSL syntax. Key v2.5 constructs:
+
+- **`pragma sbpf { ... }`** wraps sBPF-specific declarations (`instruction`, `pubkey`, per-instruction `errors`). The pragma's presence also selects the assembly target — no explicit `target` keyword.
+- **`interface Name { ... }` + `call Name.handler(...)`** declare CPI contracts. Generate Tier-0 scaffolds from Anchor IDLs with `qedgen interface --idl target/idl/<program>.json`. Tier-1 (hand-authored `ensures`) strengthens the caller's Lean proof.
+- **Multi-file specs** — `qedgen check --spec <dir>` accepts a directory of `.qedspec` fragments all declaring the same `spec Name`. Merged in sorted-path order. See `examples/rust/escrow-split/` for the convention.
+
+For sBPF assembly programs, use `qedguards` instead of the core DSL for guard/property bodies.
 
 Present the spec to the user and get confirmation before proceeding to validation.
 
@@ -502,6 +508,33 @@ environment oracle_update {
 **Auto-overflow** — operations with `add` effects automatically generate overflow safety obligations in both Lean and Kani.
 
 **`qedgen check --coverage`** — prints a verification matrix (operations × properties) showing coverage gaps.
+
+### v2.5 spec features
+
+**`pragma <name> { ... }`** — platform-specific namespace. sBPF constructs
+(`instruction`, `pubkey`, list-form `errors`) are pragma-only; they won't
+parse at the top level. `pragma sbpf { ... }` also selects the assembly
+target (no explicit `target` keyword — that was removed in v2.5).
+
+**`interface Name { ... }` + `call Target.handler(name = expr, ...)`** —
+declarative CPI contracts. Three tiers: shape-only (Tier 0, from IDL),
+hand-authored `ensures` (Tier 1, e.g. SPL Token library at
+`interfaces/spl_token.qedspec`), and imported qedspec (Tier 2, v2.6+).
+`qedgen check` emits `[shape_only_cpi]` for calls to Tier-0 interfaces —
+the visible gap between "my Rust compiles" and "my program is verified."
+
+**`qedgen interface --idl <path>`** — scaffold a Tier-0 interface from an
+Anchor IDL. Honest output: no `ensures` (IDL doesn't carry semantics),
+TODO-stubbed `upstream` block (author fills in after running harnesses
+against the deployed program).
+
+**Multi-file specs** — `qedgen check --spec <dir>` accepts a directory of
+fragments. Every `.qedspec` under the path must declare the same `spec
+Name`; items merge in sorted-path order. Convention: `state.qedspec`,
+`handlers/<name>.qedspec`, `properties.qedspec`, `interfaces/*.qedspec`.
+
+**`let x = v in body`** — ML-style expression binding inside
+`ensures`/`requires`/effect RHS. Lowers to Lean's `let x := v; body`.
 
 See `references/qedspec-dsl.md` for full syntax reference.
 

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Quasar codegen"

--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -97,6 +97,10 @@ pub enum TopItem {
     /// `instruction Name { ... }` — sBPF instruction block with layouts,
     /// guards, and properties.
     Instruction(InstructionDecl),
+    /// `interface Name { program_id "...", upstream { ... }, handler h(args) { ... } }`
+    /// Declares a callee's public contract so a caller can `call Name.h(...)`
+    /// with backend-appropriate artifacts. See docs/design/spec-composition.md §2.
+    Interface(InterfaceDecl),
 }
 
 // ============================================================================
@@ -307,6 +311,66 @@ pub enum HandlerClause {
 pub struct AccountDescriptor {
     pub name: String,
     pub attrs: Vec<AccountAttr>,
+}
+
+// ============================================================================
+// Interface declarations (callee contracts for CPI)
+// ============================================================================
+
+/// `interface Name { program_id "...", upstream { ... }, handler h(args) { ... } }`
+///
+/// Contract for a program we CPI into. Shape-only (Tier 0), hand-authored
+/// effects (Tier 1), or imported from another qedspec (Tier 2) — the AST is
+/// the same shape, backends decide how much they can emit based on whether
+/// `requires`/`ensures` are populated.
+#[derive(Debug, Clone)]
+pub struct InterfaceDecl {
+    pub name: String,
+    pub doc: Option<String>,
+    pub program_id: Option<String>,
+    pub upstream: Option<UpstreamDecl>,
+    pub handlers: Vec<InterfaceHandlerDecl>,
+}
+
+/// `upstream { package "...", version "...", binary_hash "...", ... }` —
+/// pins a library interface to the exact upstream program it was verified
+/// against. `binary_hash` is authoritative; the rest is informational.
+#[derive(Debug, Clone, Default)]
+pub struct UpstreamDecl {
+    pub package: Option<String>,
+    pub version: Option<String>,
+    pub source: Option<String>,
+    pub binary_hash: Option<String>,
+    pub idl_hash: Option<String>,
+    /// Which backends were actually run (e.g. ["proptest", "kani"]).
+    /// `"lean"` appears only when the program is genuinely proven, not
+    /// merely axiomatized — no overclaiming.
+    pub verified_with: Vec<String>,
+    pub verified_at: Option<String>,
+}
+
+/// A handler inside an `interface` block. Structurally a subset of
+/// `HandlerDecl`: no pre/post transition, no `effect`, no `emits` (callee
+/// state is opaque to the caller; callee events are the callee's business).
+#[derive(Debug, Clone)]
+pub struct InterfaceHandlerDecl {
+    pub name: String,
+    pub doc: Option<String>,
+    pub params: Vec<TypedField>,
+    pub clauses: Vec<Node<InterfaceHandlerClause>>,
+}
+
+/// Clauses allowed inside an interface-handler body.
+#[derive(Debug, Clone)]
+pub enum InterfaceHandlerClause {
+    /// `discriminant 0xABCD` or `discriminant name` — instruction selector.
+    Discriminant(String),
+    Accounts(Vec<AccountDescriptor>),
+    Requires {
+        guard: Node<Expr>,
+        on_fail: Option<String>,
+    },
+    Ensures(Node<Expr>),
 }
 
 #[derive(Debug, Clone)]

--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -305,6 +305,28 @@ pub enum HandlerClause {
     Invariant(String),
     /// `include schema_name` — forward-compat; phase 1 rejects.
     Include(String),
+    /// `call Interface.handler(name = expr, ...)` — terminal CPI invocation.
+    /// Resolves against a top-level `interface` block; backends emit
+    /// tier-appropriate artifacts (CPI builder in Rust, hypotheses/rewrites
+    /// in Lean when the interface declares ensures). See
+    /// docs/design/spec-composition.md §2.
+    Call(CallExpr),
+}
+
+/// `call Target.handler(arg1 = v1, arg2 = v2, ...)` parsed form.
+#[derive(Debug, Clone)]
+pub struct CallExpr {
+    /// Qualified name of the target. Usually `Interface.handler` (len 2),
+    /// but longer paths are accepted — the resolver decides.
+    pub target: QualifiedPath,
+    /// Keyword arguments, in source order. Positional args are not allowed.
+    pub args: Vec<CallArg>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CallArg {
+    pub name: String,
+    pub value: Node<Expr>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -81,8 +81,6 @@ pub enum TopItem {
     Event(EventDecl),
     /// `environment name { mutates/constraint }` — external state.
     Environment(EnvironmentDecl),
-    /// `target assembly` or `target quasar` — codegen target hint.
-    Target(String),
     /// `program_id "..."` — explicit program ID.
     ProgramId(String),
     /// `assembly "..."` — sBPF assembly file path.

--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -83,8 +83,6 @@ pub enum TopItem {
     Environment(EnvironmentDecl),
     /// `program_id "..."` — explicit program ID.
     ProgramId(String),
-    /// `assembly "..."` — sBPF assembly file path.
-    Assembly(String),
     /// `type Name = <type_ref>` — type alias, expands to its target.
     TypeAlias(TypeAliasDecl),
     /// `pubkey NAME [u64, u64, u64, u64]` — 4-chunk U64 pubkey literal (sBPF sugar).

--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -628,6 +628,15 @@ pub enum Expr {
         base: Box<Node<Expr>>,
         field: String,
     },
+    /// `let name = value in body` — ML-style expression-level binding.
+    /// Derives a value once and references it by `name` in `body`. Lowers
+    /// to Lean's `let name := value; body` and to a Rust block
+    /// `{ let name = value; body }`.
+    Let {
+        name: String,
+        value: Box<Node<Expr>>,
+        body: Box<Node<Expr>>,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -101,6 +101,23 @@ pub enum TopItem {
     /// Declares a callee's public contract so a caller can `call Name.h(...)`
     /// with backend-appropriate artifacts. See docs/design/spec-composition.md §2.
     Interface(InterfaceDecl),
+    /// `pragma <name> { <top_item>* }` — platform-specific namespace.
+    ///
+    /// Keeps the core DSL platform-agnostic while letting target-specific
+    /// constructs (sBPF `instruction`/`pubkey`/layouts, eventually Anchor
+    /// or Quasar extensions) live in clearly scoped blocks. Target
+    /// inference reads `ParsedSpec.pragmas` — presence of `sbpf` selects
+    /// the assembly target with no explicit `target` keyword.
+    Pragma(PragmaDecl),
+}
+
+/// Platform-specific namespace. Parser accepts arbitrary `TopItem`s inside;
+/// the adapter restricts which items are valid per pragma name.
+#[derive(Debug, Clone)]
+pub struct PragmaDecl {
+    pub name: String,
+    pub doc: Option<String>,
+    pub items: Vec<Node<TopItem>>,
 }
 
 // ============================================================================

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -581,9 +581,9 @@ pub struct ParsedSpec {
     /// of { ... }` referenced from `Map[N] Account` ends up here.
     pub sum_types: Vec<ParsedSumType>,
 
-    /// Target mode: "assembly" (sBPF) or "quasar" (Rust).
-    #[allow(dead_code)]
-    pub target: Option<String>,
+    // Target mode was an explicit `target assembly|quasar` keyword; as of
+    // v2.5 it's derived from `has_pragma("sbpf")` at the call site via
+    // `ParsedSpec::is_assembly_target()`. One less source of truth.
 
     // sBPF-specific fields
     /// Assembly source path (present means sBPF mode).
@@ -628,11 +628,16 @@ pub struct ParsedSpec {
 }
 
 impl ParsedSpec {
-    /// True iff the spec declared `pragma <name> { ... }`. Consumer lands
-    /// in the next commit (target-inference from pragma presence).
-    #[allow(dead_code)]
+    /// True iff the spec declared `pragma <name> { ... }`.
     pub fn has_pragma(&self, name: &str) -> bool {
         self.pragmas.iter().any(|p| p == name)
+    }
+
+    /// Target inference: `pragma sbpf` present → assembly target.
+    /// Falls back to the legacy signal (assembly path + instructions
+    /// present) so partially-migrated specs don't silently shift mode.
+    pub fn is_assembly_target(&self) -> bool {
+        self.has_pragma("sbpf") || (self.assembly_path.is_some() && !self.instructions.is_empty())
     }
 }
 

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -627,9 +627,23 @@ pub fn check(spec_path: &Path, proofs_dir: &Path) -> Result<Vec<PropertyStatus>>
     Ok(results)
 }
 
-/// Parse a spec file from disk. Only .qedspec format is supported.
-/// Uses chumsky for parsing + a typed AST → ParsedSpec adapter.
+/// Parse a spec from disk. Only .qedspec format is supported.
+///
+/// `path` may be either:
+///   - a single `.qedspec` file (original behaviour), or
+///   - a directory containing one or more `.qedspec` files. Every file in the
+///     directory (recursively) must declare the same `spec Name`; their top
+///     items are merged in alphabetically-sorted source-path order.
+///
+/// The multi-file form is convention-based: no new grammar, no `import`/
+/// `module` keywords. A program's spec is simply spread across files that all
+/// start with `spec <Name>`. Fragments live naturally under `handlers/`,
+/// `properties/`, etc.
 pub fn parse_spec_file(path: &Path) -> Result<ParsedSpec> {
+    if path.is_dir() {
+        return parse_spec_dir(path);
+    }
+
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
     if ext != "qedspec" {
         anyhow::bail!(
@@ -647,9 +661,113 @@ pub fn parse_spec_file(path: &Path) -> Result<ParsedSpec> {
             .map(|e| format!("  {:?}", e))
             .collect::<Vec<_>>()
             .join("\n");
-        anyhow::anyhow!("parse error:\n{}", msg)
+        anyhow::anyhow!("parse error in {}:\n{}", path.display(), msg)
     })?;
     Ok(crate::chumsky_adapter::adapt(&typed))
+}
+
+/// Load every `.qedspec` file under `dir` (recursively), parse each, validate
+/// they all declare the same `spec Name`, and merge their top items into a
+/// single typed AST. Files are visited in alphabetically-sorted path order so
+/// the resulting `ParsedSpec` — and every artifact downstream of it — is
+/// deterministic.
+fn parse_spec_dir(dir: &Path) -> Result<ParsedSpec> {
+    let mut files = Vec::new();
+    collect_qedspec_files(dir, &mut files)?;
+    files.sort();
+
+    anyhow::ensure!(
+        !files.is_empty(),
+        "no .qedspec files found under {}",
+        dir.display()
+    );
+
+    let mut merged_name: Option<String> = None;
+    let mut merged_items: Vec<crate::ast::Node<crate::ast::TopItem>> = Vec::new();
+
+    for file in &files {
+        let src =
+            std::fs::read_to_string(file).with_context(|| format!("reading {}", file.display()))?;
+        let typed = crate::chumsky_parser::parse(&src).map_err(|errs| {
+            let msg = errs
+                .iter()
+                .map(|e| format!("  {:?}", e))
+                .collect::<Vec<_>>()
+                .join("\n");
+            anyhow::anyhow!("parse error in {}:\n{}", file.display(), msg)
+        })?;
+
+        match &merged_name {
+            None => merged_name = Some(typed.name.clone()),
+            Some(existing) if existing != &typed.name => {
+                anyhow::bail!(
+                    "spec name mismatch in {}: declared `spec {}`, but a sibling \
+                     file declares `spec {}`. Every .qedspec fragment in a \
+                     multi-file spec directory must declare the same name.",
+                    file.display(),
+                    typed.name,
+                    existing,
+                );
+            }
+            _ => {}
+        }
+
+        merged_items.extend(typed.items);
+    }
+
+    let merged = crate::ast::Spec {
+        name: merged_name.expect("non-empty files implies non-empty name"),
+        items: merged_items,
+    };
+    Ok(crate::chumsky_adapter::adapt(&merged))
+}
+
+/// Read the source text of a spec path — single file or directory of
+/// fragments — as one contiguous string, joining fragments in the same
+/// sorted-path order the loader uses. Consumers that scan the raw text
+/// (e.g. `spec_hash_for_handler`) must go through this helper so the hash
+/// they compute is identical to what the proc-macro will compute at compile
+/// time.
+pub fn read_spec_source(path: &Path) -> Result<String> {
+    if path.is_dir() {
+        let mut files = Vec::new();
+        collect_qedspec_files(path, &mut files)?;
+        files.sort();
+        let mut out = String::new();
+        for f in &files {
+            let src =
+                std::fs::read_to_string(f).with_context(|| format!("reading {}", f.display()))?;
+            out.push_str(&src);
+            if !src.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+        Ok(out)
+    } else {
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))
+    }
+}
+
+/// Recursive collector for `.qedspec` files under a directory, depth-first.
+/// Silently skips non-UTF8 paths (pathologically rare in a source tree).
+fn collect_qedspec_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) -> Result<()> {
+    let entries =
+        std::fs::read_dir(dir).with_context(|| format!("reading dir {}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading entry in {}", dir.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("stat {}", path.display()))?;
+        if file_type.is_dir() {
+            collect_qedspec_files(&path, out)?;
+        } else if file_type.is_file()
+            && path.extension().and_then(|e| e.to_str()) == Some("qedspec")
+        {
+            out.push(path);
+        }
+    }
+    Ok(())
 }
 
 /// Generate the full list of expected properties with intent descriptions.
@@ -3305,6 +3423,86 @@ mod tests {
                 .iter()
                 .filter(|w| w.rule == "write_without_read")
                 .collect::<Vec<_>>()
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Multi-file spec loader
+    // ──────────────────────────────────────────────────────────────────────
+
+    const SPEC_ROOT: &str = r#"
+spec Demo
+
+type State
+  | Active of { count : U64 }
+"#;
+
+    const SPEC_INC: &str = r#"
+spec Demo
+
+/// Increments count
+handler inc (x : U64) : State.Active -> State.Active {
+  effect { count += x }
+}
+"#;
+
+    const SPEC_DEC: &str = r#"
+spec Demo
+
+handler dec (x : U64) : State.Active -> State.Active {
+  effect { count -= x }
+}
+"#;
+
+    #[test]
+    fn multi_file_spec_merges_handlers_across_fragments() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("demo.qedspec"), SPEC_ROOT).unwrap();
+        std::fs::create_dir_all(dir.path().join("handlers")).unwrap();
+        std::fs::write(dir.path().join("handlers/inc.qedspec"), SPEC_INC).unwrap();
+        std::fs::write(dir.path().join("handlers/dec.qedspec"), SPEC_DEC).unwrap();
+
+        let parsed = parse_spec_file(dir.path()).unwrap();
+        assert_eq!(parsed.program_name, "Demo");
+        let names: Vec<_> = parsed.handlers.iter().map(|h| h.name.as_str()).collect();
+        assert!(names.contains(&"inc"), "got handlers: {:?}", names);
+        assert!(names.contains(&"dec"), "got handlers: {:?}", names);
+    }
+
+    #[test]
+    fn multi_file_spec_rejects_name_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.qedspec"), SPEC_ROOT).unwrap();
+        std::fs::write(
+            dir.path().join("b.qedspec"),
+            "spec Other\n\nhandler noop : State.Active -> State.Active { effect {} }\n",
+        )
+        .unwrap();
+
+        let err = parse_spec_file(dir.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("spec name mismatch"),
+            "expected name-mismatch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn multi_file_spec_source_matches_single_file_concat() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("1.qedspec"), SPEC_ROOT).unwrap();
+        std::fs::write(dir.path().join("2.qedspec"), SPEC_INC).unwrap();
+
+        // read_spec_source must emit fragments in sorted-path order so
+        // spec_hash_for_handler finds handler bodies regardless of which
+        // fragment they live in.
+        let src = read_spec_source(dir.path()).unwrap();
+        assert!(
+            src.contains("type State"),
+            "root fragment missing in merged source"
+        );
+        assert!(
+            src.contains("handler inc"),
+            "handler fragment missing in merged source"
         );
     }
 }

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -620,6 +620,20 @@ pub struct ParsedSpec {
     /// docs/design/spec-composition.md §2. Tier-0 interfaces have no
     /// `requires`/`ensures` on their handlers; Tier-1/Tier-2 do.
     pub interfaces: Vec<ParsedInterface>,
+
+    /// Names of `pragma <name> { ... }` blocks that appeared in the spec.
+    /// Used for target inference (`sbpf` → assembly target) and for
+    /// platform-scoped feature flags in backends.
+    pub pragmas: Vec<String>,
+}
+
+impl ParsedSpec {
+    /// True iff the spec declared `pragma <name> { ... }`. Consumer lands
+    /// in the next commit (target-inference from pragma presence).
+    #[allow(dead_code)]
+    pub fn has_pragma(&self, name: &str) -> bool {
+        self.pragmas.iter().any(|p| p == name)
+    }
 }
 
 /// Callee contract: program ID + per-handler shape (and optional effects).
@@ -3754,6 +3768,73 @@ handler exchange : State.A -> State.B {
         // Args carry both renderings so backends can pick the form they want.
         assert!(!c.args[0].rust_expr.is_empty());
         assert!(!c.args[0].lean_expr.is_empty());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // pragma sbpf { ... } adaptation
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn pragma_sbpf_unpacks_inner_items() {
+        let src = r#"spec Transfer
+
+pragma sbpf {
+  pubkey TOKEN_PROGRAM [6, 221, 246, 225]
+
+  instruction transfer {
+    discriminant 3
+    entry 0
+  }
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        assert_eq!(parsed.pragmas, vec!["sbpf".to_string()]);
+        assert_eq!(parsed.pubkeys.len(), 1);
+        assert_eq!(parsed.pubkeys[0].name, "TOKEN_PROGRAM");
+        assert_eq!(parsed.instructions.len(), 1);
+        assert_eq!(parsed.instructions[0].name, "transfer");
+    }
+
+    #[test]
+    fn pragma_body_adapts_into_standard_parsed_spec_fields() {
+        // Items wrapped in `pragma sbpf { ... }` must land in the same
+        // ParsedSpec fields downstream consumers already read — pubkeys,
+        // instructions, etc. The pragma is a grammatical namespace, not
+        // a new parallel tree.
+        let src = r#"spec T
+
+pragma sbpf {
+  pubkey TOKEN_PROGRAM [1, 2, 3, 4]
+
+  instruction foo {
+    discriminant 1
+    entry 0
+  }
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        assert_eq!(parsed.pragmas, vec!["sbpf".to_string()]);
+        assert!(parsed.has_pragma("sbpf"));
+        assert_eq!(parsed.pubkeys.len(), 1);
+        assert_eq!(parsed.pubkeys[0].name, "TOKEN_PROGRAM");
+        assert_eq!(parsed.instructions.len(), 1);
+        assert_eq!(parsed.instructions[0].name, "foo");
+    }
+
+    #[test]
+    fn top_level_sbpf_items_now_rejected() {
+        // Platform-specifics (pubkey, instruction, assembly) used to parse
+        // at the top level; v2.5 moves them behind `pragma sbpf { ... }`.
+        // The grammar enforces the discipline so a spec can't quietly mix
+        // them into the core surface.
+        let src = r#"spec T
+
+pubkey TOKEN_PROGRAM [1, 2, 3, 4]
+"#;
+        assert!(
+            crate::chumsky_adapter::parse_str(src).is_err(),
+            "top-level `pubkey` should no longer parse"
+        );
     }
 
     #[test]

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -3844,6 +3844,63 @@ pubkey TOKEN_PROGRAM [1, 2, 3, 4]
         );
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // ML syntax — let...in in expressions (v2.5)
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn let_in_renders_to_lean_and_rust() {
+        let src = r#"spec T
+type State | A of { balance : U64 }
+
+handler h (amount : U64) : State.A -> State.A {
+  ensures let delta = old(state.balance) - state.balance in delta == amount
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        let handler = &parsed.handlers[0];
+        assert_eq!(handler.ensures.len(), 1);
+        let e = &handler.ensures[0];
+        // Lean form uses Lean's let-binding syntax.
+        assert!(
+            e.lean_expr.contains("let delta :="),
+            "expected Lean let-binding, got: {}",
+            e.lean_expr
+        );
+        // Rust form lowers to a block expression.
+        assert!(
+            e.rust_expr.contains("let delta ="),
+            "expected Rust let-in-block, got: {}",
+            e.rust_expr
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Smoke test — items 1 (match) and 2 (ctors) already in the grammar.
+    // Confirms the claim in the v2.5 report.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ml_match_and_ctor_already_parse() {
+        let src = r#"spec T
+type State | Active of { count : U64 } | Closed
+
+handler inspect : State.Active -> State.Active {
+  ensures
+    match state with
+    | Active a => a.count >= 0
+    | Closed => true
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        assert_eq!(parsed.handlers.len(), 1);
+        assert_eq!(parsed.handlers[0].ensures.len(), 1);
+        // The rendered form should reference both variants.
+        let lean = &parsed.handlers[0].ensures[0].lean_expr;
+        assert!(lean.contains("Active"), "got: {}", lean);
+        assert!(lean.contains("Closed"), "got: {}", lean);
+    }
+
     #[test]
     fn interface_block_populates_parsed_spec() {
         let src = r#"spec Escrow

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -586,9 +586,12 @@ pub struct ParsedSpec {
     // `ParsedSpec::is_assembly_target()`. One less source of truth.
 
     // sBPF-specific fields
-    /// Assembly source path (present means sBPF mode).
-    #[allow(dead_code)]
-    pub assembly_path: Option<String>,
+    //
+    // `assembly_path` used to live here, populated by a top-level
+    // `assembly "..."` line. v2.5 drops the keyword entirely —
+    // `qedgen asm2lean --input <path>` is explicit, and other tooling
+    // uses the `src/program.s` convention next to the spec. The spec
+    // does not carry a file path.
     /// Known pubkeys as 4-chunk U64 representations.
     #[allow(dead_code)]
     pub pubkeys: Vec<ParsedPubkey>,
@@ -633,11 +636,10 @@ impl ParsedSpec {
         self.pragmas.iter().any(|p| p == name)
     }
 
-    /// Target inference: `pragma sbpf` present → assembly target.
-    /// Falls back to the legacy signal (assembly path + instructions
-    /// present) so partially-migrated specs don't silently shift mode.
+    /// Target inference: `pragma sbpf` present → assembly target, else
+    /// Quasar/Anchor (the default). Single source of truth.
     pub fn is_assembly_target(&self) -> bool {
-        self.has_pragma("sbpf") || (self.assembly_path.is_some() && !self.instructions.is_empty())
+        self.has_pragma("sbpf")
     }
 }
 

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -410,8 +410,11 @@ impl ParsedHandler {
     pub fn has_effect(&self) -> bool {
         !self.effects.is_empty()
     }
+    /// Whether this handler initiates a CPI. True if the handler has a
+    /// `transfers { }` block (legacy sugar for Token.transfer) OR any
+    /// `call Interface.handler(...)` site (v2.5 uniform CPI surface).
     pub fn has_calls(&self) -> bool {
-        !self.transfers.is_empty()
+        !self.transfers.is_empty() || !self.calls.is_empty()
     }
     pub fn has_when(&self) -> bool {
         self.pre_status.is_some()

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -587,6 +587,55 @@ pub struct ParsedSpec {
     /// Environment blocks (external state).
     #[allow(dead_code)]
     pub environments: Vec<ParsedEnvironment>,
+
+    /// Interface declarations — callee contracts for CPI. See
+    /// docs/design/spec-composition.md §2. Tier-0 interfaces have no
+    /// `requires`/`ensures` on their handlers; Tier-1/Tier-2 do.
+    pub interfaces: Vec<ParsedInterface>,
+}
+
+/// Callee contract: program ID + per-handler shape (and optional effects).
+/// Downstream consumers (lint, codegen) land in later v2.5 slices, hence
+/// `allow(dead_code)` on fields without readers yet.
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub struct ParsedInterface {
+    pub name: String,
+    pub doc: Option<String>,
+    pub program_id: Option<String>,
+    pub upstream: Option<ParsedUpstream>,
+    pub handlers: Vec<ParsedInterfaceHandler>,
+}
+
+/// Upstream version pin for a library interface — `binary_hash` is
+/// authoritative; the rest is informational. `verified_with` lists only
+/// backends that were actually run; `"lean"` appears only when the callee is
+/// genuinely proven, not axiomatized.
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub struct ParsedUpstream {
+    pub package: Option<String>,
+    pub version: Option<String>,
+    pub source: Option<String>,
+    pub binary_hash: Option<String>,
+    pub idl_hash: Option<String>,
+    pub verified_with: Vec<String>,
+    pub verified_at: Option<String>,
+}
+
+/// One handler inside an interface block. The `requires`/`ensures` vectors
+/// are empty for Tier-0 (shape-only) interfaces. Populated for Tier-1
+/// (hand-authored) and Tier-2 (imported) interfaces.
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub struct ParsedInterfaceHandler {
+    pub name: String,
+    pub doc: Option<String>,
+    pub params: Vec<(String, String)>,
+    pub discriminant: Option<String>,
+    pub accounts: Vec<ParsedHandlerAccount>,
+    pub requires: Vec<ParsedRequires>,
+    pub ensures: Vec<ParsedEnsures>,
 }
 
 /// Check spec coverage: which properties have proofs, which have sorry, which are missing.
@@ -3484,6 +3533,59 @@ handler dec (x : U64) : State.Active -> State.Active {
             err.contains("spec name mismatch"),
             "expected name-mismatch error, got: {err}"
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Interface adapter round-trip (v2.5 slice 1)
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn interface_block_populates_parsed_spec() {
+        let src = r#"spec Escrow
+
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+  upstream {
+    package      "spl-token"
+    version      "4.0.3"
+    binary_hash  "sha256:abc"
+    verified_with ["proptest", "kani"]
+    verified_at  "2026-04-18"
+  }
+
+  handler transfer (amount : U64) {
+    accounts {
+      from      : writable, type token
+      to        : writable, type token
+      authority : signer
+    }
+    requires amount > 0
+    ensures  amount > 0
+  }
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        assert_eq!(parsed.interfaces.len(), 1);
+        let i = &parsed.interfaces[0];
+        assert_eq!(i.name, "Token");
+        assert_eq!(
+            i.program_id.as_deref(),
+            Some("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+        );
+
+        let u = i.upstream.as_ref().expect("upstream present");
+        assert_eq!(u.binary_hash.as_deref(), Some("sha256:abc"));
+        // Lean absent by design — no overclaiming.
+        assert!(!u.verified_with.contains(&"lean".to_string()));
+
+        assert_eq!(i.handlers.len(), 1);
+        let h = &i.handlers[0];
+        assert_eq!(h.name, "transfer");
+        assert_eq!(h.params, vec![("amount".to_string(), "U64".to_string())]);
+        assert_eq!(h.accounts.len(), 3);
+        assert_eq!(h.requires.len(), 1);
+        assert_eq!(h.ensures.len(), 1);
     }
 
     #[test]

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -2189,8 +2189,87 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
     // Validate new-DSL constructs: Map[N] T fields, subscripted effect LHS.
     warnings.extend(check_map_and_subscript(spec));
 
+    // CPI tier lint: call sites whose target is Tier 0 (no ensures declared)
+    // get flagged so users see the gap between "my Rust compiles" and "my
+    // program is verified." See docs/design/spec-composition.md §2.
+    warnings.extend(check_shape_only_cpi(spec));
+
     // Sort by priority (ascending), then by rule name for stability
     warnings.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.rule.cmp(&b.rule)));
+
+    warnings
+}
+
+/// Emit `[shape_only_cpi]` info-level warnings for `call Interface.handler(...)`
+/// sites whose target declares no `ensures`. The call still generates a real
+/// Rust CPI builder; the lint simply makes the proof-side gap explicit so
+/// nobody mistakes a compiling CPI for a verified one.
+fn check_shape_only_cpi(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
+    let mut warnings = Vec::new();
+
+    for handler in &spec.handlers {
+        for call in &handler.calls {
+            let iface = spec
+                .interfaces
+                .iter()
+                .find(|i| i.name == call.target_interface);
+            let target_handler =
+                iface.and_then(|i| i.handlers.iter().find(|h| h.name == call.target_handler));
+
+            let (reason, fix) = match (iface, target_handler) {
+                (None, _) => (
+                    format!(
+                        "interface `{}` is not declared in this spec — the call compiles but has no contract",
+                        call.target_interface
+                    ),
+                    format!(
+                        "Declare `interface {} {{ ... }}` at the top level, or `qedgen interface --idl <path>` to scaffold one.",
+                        call.target_interface
+                    ),
+                ),
+                (Some(_), None) => (
+                    format!(
+                        "interface `{}` has no handler named `{}` — check for a typo or add the handler",
+                        call.target_interface, call.target_handler
+                    ),
+                    format!(
+                        "Add `handler {}` inside `interface {} {{ ... }}`, or update the call site to match a real handler.",
+                        call.target_handler, call.target_interface
+                    ),
+                ),
+                (Some(_), Some(h)) if h.ensures.is_empty() => (
+                    format!(
+                        "`{}.{}` declares shape only (no `ensures`) — the call has no post-state assumptions for proofs",
+                        call.target_interface, call.target_handler
+                    ),
+                    format!(
+                        "Upgrade to Tier 1 by declaring `ensures` on `{}` inside `interface {}`, or import a qedspec for full verification.",
+                        call.target_handler, call.target_interface
+                    ),
+                ),
+                // Tier 1/2 target — nothing to lint.
+                _ => continue,
+            };
+
+            warnings.push(CompletenessWarning {
+                rule: "shape_only_cpi".to_string(),
+                severity: Severity::Info,
+                priority: 3,
+                message: format!(
+                    "handler '{}' calls `{}.{}` — {}",
+                    handler.name, call.target_interface, call.target_handler, reason
+                ),
+                subject: Some(handler.name.clone()),
+                fix,
+                example: Some(format!(
+                    "  interface {} {{\n    handler {} (...) {{\n      ensures /* what the callee guarantees */\n    }}\n  }}",
+                    call.target_interface, call.target_handler
+                )),
+                counterexample: None,
+                fix_options: vec![],
+            });
+        }
+    }
 
     warnings
 }
@@ -3564,6 +3643,93 @@ handler dec (x : U64) : State.Active -> State.Active {
     // ──────────────────────────────────────────────────────────────────────
     // Interface adapter round-trip (v2.5 slice 1)
     // ──────────────────────────────────────────────────────────────────────
+
+    // ──────────────────────────────────────────────────────────────────────
+    // [shape_only_cpi] lint (v2.5 slice 4)
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn shape_only_cpi_fires_on_tier0_interface() {
+        // Interface declared with no ensures — classic Tier-0. Should lint.
+        let src = r#"spec Demo
+
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+  handler transfer (amount : U64) {
+    accounts {
+      from      : writable
+      to        : writable
+      authority : signer
+    }
+  }
+}
+
+handler pay : State.A -> State.A {
+  call Token.transfer(from = src_ta, to = dst_ta, amount = 1)
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        let ws = check_completeness(&parsed);
+        let hits: Vec<_> = ws.iter().filter(|w| w.rule == "shape_only_cpi").collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "expected one shape_only_cpi warning, got {:?}",
+            ws
+        );
+        assert!(hits[0].message.contains("shape only"));
+    }
+
+    #[test]
+    fn shape_only_cpi_fires_on_undeclared_interface() {
+        let src = r#"spec Demo
+
+handler pay : State.A -> State.A {
+  call Jupiter.swap(pool = amm, amount_in = 100, min_out = 90)
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        let ws = check_completeness(&parsed);
+        let hits: Vec<_> = ws.iter().filter(|w| w.rule == "shape_only_cpi").collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "expected one shape_only_cpi warning, got {:?}",
+            ws
+        );
+        assert!(hits[0].message.contains("not declared"));
+    }
+
+    #[test]
+    fn shape_only_cpi_silent_on_tier1_interface() {
+        // Interface declares at least one ensures — no lint should fire.
+        let src = r#"spec Demo
+
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+  handler transfer (amount : U64) {
+    accounts {
+      from      : writable
+      to        : writable
+      authority : signer
+    }
+    ensures amount > 0
+  }
+}
+
+handler pay : State.A -> State.A {
+  call Token.transfer(from = src_ta, to = dst_ta, amount = 1)
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        let ws = check_completeness(&parsed);
+        let hits: Vec<_> = ws.iter().filter(|w| w.rule == "shape_only_cpi").collect();
+        assert!(
+            hits.is_empty(),
+            "Tier 1 interfaces should not lint, got: {:?}",
+            hits
+        );
+    }
 
     #[test]
     fn call_clause_populates_handler_calls() {

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -376,6 +376,31 @@ pub struct ParsedHandler {
     pub invariants: Vec<String>,
     /// Per-handler properties (from inline property/invariant clauses).
     pub properties: Vec<String>,
+    /// `call Interface.handler(name = expr, ...)` sites — CPI invocations
+    /// resolved against a top-level `interface` block. Empty for handlers
+    /// that don't CPI. Consumed by Rust codegen (slice 5) and the
+    /// `[shape_only_cpi]` lint (slice 4).
+    #[allow(dead_code)]
+    pub calls: Vec<ParsedCall>,
+}
+
+/// A resolved `call Target.handler(...)` site inside a handler body. The
+/// target is split into interface + handler name for easier lookup; args
+/// carry both Lean and Rust renderings so backends can pick their form.
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub struct ParsedCall {
+    pub target_interface: String,
+    pub target_handler: String,
+    pub args: Vec<ParsedCallArg>,
+}
+
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub struct ParsedCallArg {
+    pub name: String,
+    pub lean_expr: String,
+    pub rust_expr: String,
 }
 
 impl ParsedHandler {
@@ -2840,6 +2865,7 @@ mod tests {
             emits: vec![],
             invariants: vec![],
             properties: vec![],
+            calls: vec![],
         }
     }
 
@@ -3538,6 +3564,28 @@ handler dec (x : U64) : State.Active -> State.Active {
     // ──────────────────────────────────────────────────────────────────────
     // Interface adapter round-trip (v2.5 slice 1)
     // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn call_clause_populates_handler_calls() {
+        let src = r#"spec Demo
+
+handler exchange : State.A -> State.B {
+  call Token.transfer(from = taker_ta, to = initializer_ta, amount = taker_amount)
+}
+"#;
+        let parsed = crate::chumsky_adapter::parse_str(src).unwrap();
+        let handler = &parsed.handlers[0];
+        assert_eq!(handler.calls.len(), 1);
+        let c = &handler.calls[0];
+        assert_eq!(c.target_interface, "Token");
+        assert_eq!(c.target_handler, "transfer");
+        assert_eq!(c.args.len(), 3);
+        assert_eq!(c.args[0].name, "from");
+        assert_eq!(c.args[2].name, "amount");
+        // Args carry both renderings so backends can pick the form they want.
+        assert!(!c.args[0].rust_expr.is_empty());
+        assert!(!c.args[0].lean_expr.is_empty());
+    }
 
     #[test]
     fn interface_block_populates_parsed_spec() {

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -1398,9 +1398,6 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
             TopItem::ProgramId(pid) => {
                 out.program_id = Some(pid.clone());
             }
-            TopItem::Assembly(path) => {
-                out.assembly_path = Some(path.clone());
-            }
             TopItem::Pubkey(p) => {
                 out.pubkeys.push(ParsedPubkey {
                     name: p.name.clone(),
@@ -1472,9 +1469,6 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
                                 name: pk.name.clone(),
                                 chunks: pk.chunks.iter().map(|c| c.to_string()).collect(),
                             });
-                        }
-                        TopItem::Assembly(path) => {
-                            out.assembly_path = Some(path.clone());
                         }
                         TopItem::Instruction(instr) => {
                             out.instructions.push(adapt_instruction(instr, consts));

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -1395,9 +1395,6 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
                 out.type_aliases
                     .push((ta.name.clone(), type_ref_to_string(&ta.target)));
             }
-            TopItem::Target(t) => {
-                out.target = Some(t.clone());
-            }
             TopItem::ProgramId(pid) => {
                 out.program_id = Some(pid.clone());
             }

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -12,11 +12,12 @@
 
 use crate::ast::{self as a, Expr, Node, TopItem};
 use crate::check::{
-    FlowKind, ParsedAccountType, ParsedCover, ParsedEnsures, ParsedEnvironment, ParsedErrorCode,
-    ParsedEvent, ParsedGuard, ParsedHandler, ParsedHandlerAccount, ParsedInstruction,
-    ParsedInterface, ParsedInterfaceHandler, ParsedLayoutField, ParsedLiveness, ParsedPda,
-    ParsedProperty, ParsedPubkey, ParsedRecordType, ParsedRequires, ParsedSbpfProperty, ParsedSpec,
-    ParsedSumType, ParsedUpstream, ParsedVariant, SbpfPropertyKind,
+    FlowKind, ParsedAccountType, ParsedCall, ParsedCallArg, ParsedCover, ParsedEnsures,
+    ParsedEnvironment, ParsedErrorCode, ParsedEvent, ParsedGuard, ParsedHandler,
+    ParsedHandlerAccount, ParsedInstruction, ParsedInterface, ParsedInterfaceHandler,
+    ParsedLayoutField, ParsedLiveness, ParsedPda, ParsedProperty, ParsedPubkey, ParsedRecordType,
+    ParsedRequires, ParsedSbpfProperty, ParsedSpec, ParsedSumType, ParsedUpstream, ParsedVariant,
+    SbpfPropertyKind,
 };
 
 // ============================================================================
@@ -1614,6 +1615,7 @@ fn adapt_handler(h: &a::HandlerDecl, consts: ConstTable, env: &TypeEnv) -> Parse
         emits: Vec::new(),
         invariants: Vec::new(),
         properties: Vec::new(),
+        calls: Vec::new(),
     };
 
     for Node { node: clause, .. } in &h.clauses {
@@ -1724,6 +1726,32 @@ fn adapt_handler(h: &a::HandlerDecl, consts: ConstTable, env: &TypeEnv) -> Parse
                 // Branches are expanded into synthetic handlers by
                 // `expand_handler`; this function only builds the shared
                 // base and must ignore the branch clause itself.
+            }
+            a::HandlerClause::Call(c) => {
+                // Split `Interface.handler` from the qualified path. Longer
+                // paths (unusual — e.g. nested namespacing) flatten with '.'
+                // into the handler name so the call still records, and the
+                // resolver (slice 4+) can decide what to do.
+                let segs = &c.target.0;
+                let (iface, handler_name) = match segs.as_slice() {
+                    [] => (String::new(), String::new()),
+                    [only] => (String::new(), only.clone()),
+                    [head, tail @ ..] => (head.clone(), tail.join(".")),
+                };
+                let args = c
+                    .args
+                    .iter()
+                    .map(|arg| ParsedCallArg {
+                        name: arg.name.clone(),
+                        lean_expr: expr_to_lean(&arg.value.node, Ctx::Guard, consts, env),
+                        rust_expr: expr_to_rust(&arg.value.node, Ctx::Guard, consts),
+                    })
+                    .collect();
+                handler.calls.push(ParsedCall {
+                    target_interface: iface,
+                    target_handler: handler_name,
+                    args,
+                });
             }
         }
     }

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -1456,6 +1456,51 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
             TopItem::Interface(iface) => {
                 out.interfaces.push(adapt_interface(iface, consts, &env));
             }
+            TopItem::Pragma(p) => {
+                // Record the pragma name for target inference. Any given
+                // pragma may appear at most once per spec; duplicates are
+                // flagged at lint time, not here.
+                out.pragmas.push(p.name.clone());
+
+                // Inline-adapt each nested item. The parser restricts pragma
+                // bodies to a whitelist (const/pubkey/assembly/instruction/
+                // errors), so only those cases matter.
+                for Node { node: inner, .. } in &p.items {
+                    match inner {
+                        TopItem::Const { name, value } => {
+                            constants.push((name.clone(), value.to_string()));
+                        }
+                        TopItem::Pubkey(pk) => {
+                            out.pubkeys.push(ParsedPubkey {
+                                name: pk.name.clone(),
+                                chunks: pk.chunks.iter().map(|c| c.to_string()).collect(),
+                            });
+                        }
+                        TopItem::Assembly(path) => {
+                            out.assembly_path = Some(path.clone());
+                        }
+                        TopItem::Instruction(instr) => {
+                            out.instructions.push(adapt_instruction(instr, consts));
+                        }
+                        TopItem::Errors(entries) => {
+                            for e in entries {
+                                out.error_codes.push(e.name.clone());
+                                if e.code.is_some() || e.description.is_some() {
+                                    out.valued_errors.push(ParsedErrorCode {
+                                        name: e.name.clone(),
+                                        value: e.code,
+                                        description: e.description.clone(),
+                                    });
+                                }
+                            }
+                        }
+                        // Grammar already rejects non-whitelisted items; this
+                        // arm is defensive and silently ignores anything that
+                        // slipped through (would indicate a grammar bug).
+                        _ => {}
+                    }
+                }
+            }
         }
     }
 

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -263,6 +263,9 @@ impl<'a> TypeEnv<'a> {
             Expr::App { .. } => Kind::Other,
             // Postfix field access — abstract, treat as Other.
             Expr::Field { .. } => Kind::Other,
+            // `let x = v in body` — kind follows the body (the let is
+            // transparent from the caller's perspective).
+            Expr::Let { body, .. } => self.infer(&body.node),
         }
     }
 }
@@ -458,6 +461,16 @@ fn expr_to_lean(e: &Expr, ctx: Ctx, consts: ConstTable, env: &TypeEnv) -> String
         Expr::Field { base, field } => {
             let base_str = expr_to_lean(&base.node, ctx, consts, env);
             format!("({}).{}", base_str, field)
+        }
+        Expr::Let { name, value, body } => {
+            // Lean's `let x := v; body` is semicolon-separated inside a
+            // tactic-free term position, which is what ensures/requires give us.
+            format!(
+                "(let {} := {}; {})",
+                name,
+                expr_to_lean(&value.node, ctx, consts, env),
+                expr_to_lean(&body.node, ctx, consts, env)
+            )
         }
     }
 }
@@ -743,6 +756,16 @@ fn expr_to_rust(e: &Expr, ctx: Ctx, consts: ConstTable) -> String {
         Expr::Field { base, field } => {
             let base_str = expr_to_rust(&base.node, ctx, consts);
             format!("{}.{}", base_str, field)
+        }
+        Expr::Let { name, value, body } => {
+            // Rust lowers a let-in expression to a block. Parentheses are
+            // safe around the block for embedding in larger expressions.
+            format!(
+                "({{ let {} = {}; {} }})",
+                name,
+                expr_to_rust(&value.node, ctx, consts),
+                expr_to_rust(&body.node, ctx, consts)
+            )
         }
     }
 }

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -14,8 +14,9 @@ use crate::ast::{self as a, Expr, Node, TopItem};
 use crate::check::{
     FlowKind, ParsedAccountType, ParsedCover, ParsedEnsures, ParsedEnvironment, ParsedErrorCode,
     ParsedEvent, ParsedGuard, ParsedHandler, ParsedHandlerAccount, ParsedInstruction,
-    ParsedLayoutField, ParsedLiveness, ParsedPda, ParsedProperty, ParsedPubkey, ParsedRecordType,
-    ParsedRequires, ParsedSbpfProperty, ParsedSpec, ParsedSumType, ParsedVariant, SbpfPropertyKind,
+    ParsedInterface, ParsedInterfaceHandler, ParsedLayoutField, ParsedLiveness, ParsedPda,
+    ParsedProperty, ParsedPubkey, ParsedRecordType, ParsedRequires, ParsedSbpfProperty, ParsedSpec,
+    ParsedSumType, ParsedUpstream, ParsedVariant, SbpfPropertyKind,
 };
 
 // ============================================================================
@@ -1451,6 +1452,9 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
                     constraints_rust,
                 });
             }
+            TopItem::Interface(iface) => {
+                out.interfaces.push(adapt_interface(iface, consts, &env));
+            }
         }
     }
 
@@ -1725,6 +1729,108 @@ fn adapt_handler(h: &a::HandlerDecl, consts: ConstTable, env: &TypeEnv) -> Parse
     }
 
     handler
+}
+
+// ----------------------------------------------------------------------------
+// Interface adaptation
+// ----------------------------------------------------------------------------
+
+fn adapt_interface<'a>(
+    iface: &'a a::InterfaceDecl,
+    consts: ConstTable<'a>,
+    env: &TypeEnv<'a>,
+) -> ParsedInterface {
+    let handlers = iface
+        .handlers
+        .iter()
+        .map(|h| adapt_interface_handler(h, consts, env))
+        .collect();
+    ParsedInterface {
+        name: iface.name.clone(),
+        doc: iface.doc.clone(),
+        program_id: iface.program_id.clone(),
+        upstream: iface.upstream.as_ref().map(|u| ParsedUpstream {
+            package: u.package.clone(),
+            version: u.version.clone(),
+            source: u.source.clone(),
+            binary_hash: u.binary_hash.clone(),
+            idl_hash: u.idl_hash.clone(),
+            verified_with: u.verified_with.clone(),
+            verified_at: u.verified_at.clone(),
+        }),
+        handlers,
+    }
+}
+
+fn adapt_interface_handler<'a>(
+    h: &'a a::InterfaceHandlerDecl,
+    consts: ConstTable<'a>,
+    env: &TypeEnv<'a>,
+) -> ParsedInterfaceHandler {
+    let mut out = ParsedInterfaceHandler {
+        name: h.name.clone(),
+        doc: h.doc.clone(),
+        params: h
+            .params
+            .iter()
+            .map(|p| (p.name.clone(), type_ref_to_string(&p.ty)))
+            .collect(),
+        discriminant: None,
+        accounts: Vec::new(),
+        requires: Vec::new(),
+        ensures: Vec::new(),
+    };
+
+    for Node { node: clause, .. } in &h.clauses {
+        match clause {
+            a::InterfaceHandlerClause::Discriminant(s) => {
+                out.discriminant = Some(s.clone());
+            }
+            a::InterfaceHandlerClause::Accounts(descs) => {
+                for d in descs {
+                    let mut acc = ParsedHandlerAccount {
+                        name: d.name.clone(),
+                        is_signer: false,
+                        is_writable: false,
+                        is_program: false,
+                        pda_seeds: None,
+                        account_type: None,
+                        authority: None,
+                    };
+                    for attr in &d.attrs {
+                        match attr {
+                            a::AccountAttr::Simple(s) => match s.as_str() {
+                                "signer" => acc.is_signer = true,
+                                "writable" => acc.is_writable = true,
+                                "readonly" => acc.is_writable = false,
+                                "program" => acc.is_program = true,
+                                _ => acc.account_type = Some(s.clone()),
+                            },
+                            a::AccountAttr::Type(t) => acc.account_type = Some(t.clone()),
+                            a::AccountAttr::Authority(x) => acc.authority = Some(x.clone()),
+                            a::AccountAttr::Pda(seeds) => acc.pda_seeds = Some(seeds.clone()),
+                        }
+                    }
+                    out.accounts.push(acc);
+                }
+            }
+            a::InterfaceHandlerClause::Requires { guard, on_fail } => {
+                out.requires.push(ParsedRequires {
+                    lean_expr: expr_to_lean(&guard.node, Ctx::Guard, consts, env),
+                    rust_expr: expr_to_rust(&guard.node, Ctx::Guard, consts),
+                    error_name: on_fail.clone(),
+                });
+            }
+            a::InterfaceHandlerClause::Ensures(e) => {
+                out.ensures.push(ParsedEnsures {
+                    lean_expr: expr_to_lean(&e.node, Ctx::Ensures, consts, env),
+                    rust_expr: expr_to_rust(&e.node, Ctx::Ensures, consts),
+                });
+            }
+        }
+    }
+
+    out
 }
 
 // ============================================================================

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -110,6 +110,7 @@ const KEYWORDS: &[&str] = &[
     "is",
     "mul_div_floor",
     "mul_div_ceil",
+    "interface",
 ];
 
 fn non_keyword_ident<'a>() -> impl Parser<'a, &'a str, String, Err<'a>> + Clone {
@@ -1114,10 +1115,35 @@ fn handler_clause<'a>() -> impl Parser<'a, &'a str, HandlerClause, Err<'a>> + Cl
         .ignore_then(non_keyword_ident())
         .map(HandlerClause::Include);
 
+    // call Target.handler(name = expr, name = expr, ...)
+    let call_kw_arg = non_keyword_ident()
+        .then_ignore(wsc())
+        .then_ignore(just('='))
+        .then_ignore(wsc())
+        .then(expr())
+        .map(|(name, value)| CallArg { name, value });
+
+    let call_c = just("call")
+        .then_ignore(wsc())
+        .ignore_then(qualified_path())
+        .then_ignore(wsc())
+        .then_ignore(just('('))
+        .then_ignore(wsc())
+        .then(
+            call_kw_arg
+                .then_ignore(wsc())
+                .separated_by(just(',').then_ignore(wsc()))
+                .allow_trailing()
+                .collect::<Vec<CallArg>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just(')'))
+        .map(|(target, args)| HandlerClause::Call(CallExpr { target, args }));
+
     // `choice()` has an arity limit; split into groups.
     let grp_a = choice((auth, accounts, requires, ensures, modifies, let_c, effect));
     let grp_b = choice((transfers, takes, emits, aborts_total, invariant, include));
-    let grp_c = choice((match_c,));
+    let grp_c = choice((match_c, call_c));
     choice((grp_a, grp_b, grp_c))
 }
 
@@ -2791,5 +2817,78 @@ interface Token {
             }
             o => panic!("expected Interface, got {:?}", o),
         }
+    }
+
+    // ------------------------------------------------------------------
+    // call clause (v2.5 slice 2)
+    // ------------------------------------------------------------------
+
+    fn first_handler_clauses(spec: &Spec) -> &Vec<Node<HandlerClause>> {
+        match spec.items.iter().find_map(|n| match &n.node {
+            TopItem::Handler(h) => Some(h),
+            _ => None,
+        }) {
+            Some(h) => &h.clauses,
+            None => panic!("no handler in spec"),
+        }
+    }
+
+    #[test]
+    fn parses_call_clause_with_kw_args() {
+        let src = r#"spec T
+handler exchange : State.A -> State.B {
+  call Token.transfer(from = taker_ta, to = initializer_ta, amount = taker_amount, authority = taker)
+}
+"#;
+        let s = parse_ok(src);
+        let clauses = first_handler_clauses(&s);
+        let call = clauses.iter().find_map(|c| match &c.node {
+            HandlerClause::Call(e) => Some(e),
+            _ => None,
+        });
+        let call = call.expect("expected a Call clause");
+        assert_eq!(
+            call.target.0,
+            vec!["Token".to_string(), "transfer".to_string()]
+        );
+        assert_eq!(call.args.len(), 4);
+        assert_eq!(call.args[0].name, "from");
+        assert_eq!(call.args[3].name, "authority");
+    }
+
+    #[test]
+    fn parses_call_with_trailing_comma() {
+        let src = r#"spec T
+handler h : State.A -> State.A {
+  call Token.transfer(
+    from   = a,
+    to     = b,
+    amount = 100,
+  )
+}
+"#;
+        let s = parse_ok(src);
+        let clauses = first_handler_clauses(&s);
+        let has_call = clauses
+            .iter()
+            .any(|c| matches!(c.node, HandlerClause::Call(_)));
+        assert!(has_call);
+    }
+
+    #[test]
+    fn parses_call_with_no_args() {
+        let src = r#"spec T
+handler h : State.A -> State.A {
+  call Clock.current()
+}
+"#;
+        let s = parse_ok(src);
+        let clauses = first_handler_clauses(&s);
+        let call = clauses.iter().find_map(|c| match &c.node {
+            HandlerClause::Call(e) => Some(e),
+            _ => None,
+        });
+        let call = call.expect("expected a Call");
+        assert!(call.args.is_empty());
     }
 }

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -1834,6 +1834,216 @@ fn instruction_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone 
         .map(|((doc, name), items)| TopItem::Instruction(InstructionDecl { name, doc, items }))
 }
 
+// ----------------------------------------------------------------------------
+// interface Name { program_id "...", upstream { ... }, handler h(args) { ... } }
+// ----------------------------------------------------------------------------
+
+/// Internal: items that appear at the top of an `interface` block.
+/// Folded into `InterfaceDecl` by the decl combinator.
+enum InterfaceItem {
+    ProgramId(String),
+    Upstream(UpstreamDecl),
+    Handler(InterfaceHandlerDecl),
+}
+
+/// Internal: items that appear inside an `upstream { ... }` block.
+enum UpstreamItem {
+    Package(String),
+    Version(String),
+    Source(String),
+    BinaryHash(String),
+    IdlHash(String),
+    VerifiedWith(Vec<String>),
+    VerifiedAt(String),
+}
+
+// upstream { package "...", version "...", binary_hash "...", ... }
+fn upstream_block<'a>() -> impl Parser<'a, &'a str, UpstreamDecl, Err<'a>> + Clone {
+    let package = kw("package")
+        .ignore_then(string_lit())
+        .map(UpstreamItem::Package);
+    let version = kw("version")
+        .ignore_then(string_lit())
+        .map(UpstreamItem::Version);
+    let source = kw("source")
+        .ignore_then(string_lit())
+        .map(UpstreamItem::Source);
+    let binary_hash = kw("binary_hash")
+        .ignore_then(string_lit())
+        .map(UpstreamItem::BinaryHash);
+    let idl_hash = kw("idl_hash")
+        .ignore_then(string_lit())
+        .map(UpstreamItem::IdlHash);
+    let verified_with = kw("verified_with")
+        .ignore_then(just('['))
+        .then_ignore(wsc())
+        .ignore_then(
+            string_lit()
+                .then_ignore(wsc())
+                .separated_by(just(',').then_ignore(wsc()))
+                .allow_trailing()
+                .collect::<Vec<String>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just(']'))
+        .map(UpstreamItem::VerifiedWith);
+    let verified_at = kw("verified_at")
+        .ignore_then(string_lit())
+        .map(UpstreamItem::VerifiedAt);
+
+    let item = choice((
+        package,
+        version,
+        source,
+        binary_hash,
+        idl_hash,
+        verified_with,
+        verified_at,
+    ));
+
+    kw("upstream")
+        .ignore_then(just('{'))
+        .then_ignore(wsc())
+        .ignore_then(
+            item.then_ignore(wsc())
+                .repeated()
+                .collect::<Vec<UpstreamItem>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(|items| {
+            let mut u = UpstreamDecl::default();
+            for it in items {
+                match it {
+                    UpstreamItem::Package(s) => u.package = Some(s),
+                    UpstreamItem::Version(s) => u.version = Some(s),
+                    UpstreamItem::Source(s) => u.source = Some(s),
+                    UpstreamItem::BinaryHash(s) => u.binary_hash = Some(s),
+                    UpstreamItem::IdlHash(s) => u.idl_hash = Some(s),
+                    UpstreamItem::VerifiedWith(v) => u.verified_with = v,
+                    UpstreamItem::VerifiedAt(s) => u.verified_at = Some(s),
+                }
+            }
+            u
+        })
+}
+
+// Clauses inside an interface-handler body: discriminant, accounts, requires, ensures.
+fn interface_handler_clause<'a>(
+) -> impl Parser<'a, &'a str, InterfaceHandlerClause, Err<'a>> + Clone {
+    let discriminant = kw("discriminant")
+        .ignore_then(choice((string_lit(), non_keyword_ident())))
+        .map(InterfaceHandlerClause::Discriminant);
+
+    let accounts = just("accounts")
+        .then_ignore(wsc())
+        .ignore_then(just('{'))
+        .then_ignore(wsc())
+        .ignore_then(
+            account_descriptor()
+                .then_ignore(wsc())
+                .repeated()
+                .collect::<Vec<AccountDescriptor>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(InterfaceHandlerClause::Accounts);
+
+    let requires = just("requires")
+        .then_ignore(wsc())
+        .ignore_then(expr())
+        .then_ignore(wsc())
+        .then(
+            just("else")
+                .then_ignore(wsc())
+                .ignore_then(non_keyword_ident())
+                .or_not(),
+        )
+        .map(|(guard, on_fail)| InterfaceHandlerClause::Requires { guard, on_fail });
+
+    let ensures = just("ensures")
+        .then_ignore(wsc())
+        .ignore_then(expr())
+        .map(InterfaceHandlerClause::Ensures);
+
+    choice((discriminant, accounts, requires, ensures))
+}
+
+// handler h(params)* { discriminant, accounts, requires, ensures }  — inside an interface block.
+fn interface_handler_decl<'a>() -> impl Parser<'a, &'a str, InterfaceHandlerDecl, Err<'a>> + Clone {
+    doc_comments()
+        .then_ignore(kw("handler"))
+        .then(non_keyword_ident())
+        .then_ignore(wsc())
+        .then(
+            handler_param()
+                .then_ignore(wsc())
+                .repeated()
+                .collect::<Vec<TypedField>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just('{'))
+        .then_ignore(wsc())
+        .then(
+            interface_handler_clause()
+                .map_with(|c, e| Node::new(c, e.span().into_range()))
+                .then_ignore(wsc())
+                .repeated()
+                .collect::<Vec<Node<InterfaceHandlerClause>>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(|(((doc, name), params), clauses)| InterfaceHandlerDecl {
+            name,
+            doc,
+            params,
+            clauses,
+        })
+}
+
+fn interface_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
+    let program_id = kw("program_id")
+        .ignore_then(string_lit())
+        .map(InterfaceItem::ProgramId);
+    let upstream = upstream_block().map(InterfaceItem::Upstream);
+    let handler = interface_handler_decl().map(InterfaceItem::Handler);
+
+    let item = choice((program_id, upstream, handler));
+
+    doc_comments()
+        .then_ignore(kw("interface"))
+        .then(non_keyword_ident())
+        .then_ignore(wsc())
+        .then_ignore(just('{'))
+        .then_ignore(wsc())
+        .then(
+            item.then_ignore(wsc())
+                .repeated()
+                .collect::<Vec<InterfaceItem>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(|((doc, name), items)| {
+            let mut program_id = None;
+            let mut upstream = None;
+            let mut handlers = Vec::new();
+            for it in items {
+                match it {
+                    InterfaceItem::ProgramId(s) => program_id = Some(s),
+                    InterfaceItem::Upstream(u) => upstream = Some(u),
+                    InterfaceItem::Handler(h) => handlers.push(h),
+                }
+            }
+            TopItem::Interface(InterfaceDecl {
+                name,
+                doc,
+                program_id,
+                upstream,
+                handlers,
+            })
+        })
+}
+
 // Top-level item: priority-ordered choice.
 // record_decl must precede adt_decl (PEG-style backtracking via .or).
 fn top_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
@@ -1859,7 +2069,12 @@ fn top_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
         program_id_decl(),
         assembly_decl(),
     ));
-    let group_c = choice((pubkey_decl(), errors_decl(), instruction_decl()));
+    let group_c = choice((
+        pubkey_decl(),
+        errors_decl(),
+        instruction_decl(),
+        interface_decl(),
+    ));
     choice((group_a, group_b, group_c)).map_with(|item, e| Node::new(item, e.span().into_range()))
 }
 
@@ -2101,6 +2316,7 @@ property conservation :
                 TopItem::Pubkey(_) => "pubkey",
                 TopItem::Errors(_) => "errors",
                 TopItem::Instruction(_) => "instruction",
+                TopItem::Interface(_) => "interface",
             })
             .fold(
                 std::collections::BTreeMap::<&str, usize>::new(),
@@ -2457,6 +2673,123 @@ liveness drain : State.Draining ~> State.Active via [a, b] within 2"#;
                 assert_eq!(l.within, 2);
             }
             o => panic!("expected Liveness, got {:?}", o),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // interface block (v2.5 slice 1)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parses_tier0_interface_shape_only() {
+        let src = r#"spec Demo
+interface Jupiter {
+  program_id "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"
+
+  handler swap (amount_in : U64) (min_amount_out : U64) {
+    discriminant "0xE445A52E51CB9A1D"
+    accounts {
+      user_input_ta  : writable, type token
+      user_output_ta : writable, type token
+      user           : signer
+    }
+  }
+}
+"#;
+        let s = parse_ok(src);
+        let i = match &s.items[0].node {
+            TopItem::Interface(i) => i,
+            o => panic!("expected Interface, got {:?}", o),
+        };
+        assert_eq!(i.name, "Jupiter");
+        assert_eq!(
+            i.program_id.as_deref(),
+            Some("JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4")
+        );
+        assert!(i.upstream.is_none());
+        assert_eq!(i.handlers.len(), 1);
+        let h = &i.handlers[0];
+        assert_eq!(h.name, "swap");
+        assert_eq!(h.params.len(), 2);
+        // Tier-0: no requires/ensures.
+        let has_requires = h
+            .clauses
+            .iter()
+            .any(|c| matches!(c.node, InterfaceHandlerClause::Requires { .. }));
+        let has_ensures = h
+            .clauses
+            .iter()
+            .any(|c| matches!(c.node, InterfaceHandlerClause::Ensures(_)));
+        assert!(!has_requires, "Tier-0 interface should have no requires");
+        assert!(!has_ensures, "Tier-0 interface should have no ensures");
+    }
+
+    #[test]
+    fn parses_tier1_interface_with_upstream_and_ensures() {
+        let src = r#"spec Demo
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+  upstream {
+    package      "spl-token"
+    version      "4.0.3"
+    binary_hash  "sha256:abcdef1234567890"
+    verified_with ["proptest", "kani"]
+    verified_at  "2026-04-18"
+  }
+
+  handler transfer (amount : U64) {
+    accounts {
+      from      : writable, type token
+      to        : writable, type token
+      authority : signer
+    }
+    requires amount > 0
+    ensures  amount > 0
+  }
+}
+"#;
+        let s = parse_ok(src);
+        let i = match &s.items[0].node {
+            TopItem::Interface(i) => i,
+            o => panic!("expected Interface, got {:?}", o),
+        };
+        let u = i.upstream.as_ref().expect("upstream present");
+        assert_eq!(u.package.as_deref(), Some("spl-token"));
+        assert_eq!(u.version.as_deref(), Some("4.0.3"));
+        assert_eq!(u.binary_hash.as_deref(), Some("sha256:abcdef1234567890"));
+        assert_eq!(
+            u.verified_with,
+            vec!["proptest".to_string(), "kani".to_string()]
+        );
+        // Lean deliberately absent — no overclaiming.
+        assert!(!u.verified_with.contains(&"lean".to_string()));
+
+        let h = &i.handlers[0];
+        let has_requires = h
+            .clauses
+            .iter()
+            .any(|c| matches!(c.node, InterfaceHandlerClause::Requires { .. }));
+        let has_ensures = h
+            .clauses
+            .iter()
+            .any(|c| matches!(c.node, InterfaceHandlerClause::Ensures(_)));
+        assert!(has_requires);
+        assert!(has_ensures);
+    }
+
+    #[test]
+    fn parses_empty_interface() {
+        // An interface with no handlers is valid (e.g. a stub pre-codegen).
+        let src =
+            "spec T\ninterface Empty {\n  program_id \"11111111111111111111111111111111\"\n}\n";
+        let s = parse_ok(src);
+        match &s.items[0].node {
+            TopItem::Interface(i) => {
+                assert_eq!(i.name, "Empty");
+                assert!(i.handlers.is_empty());
+            }
+            o => panic!("expected Interface, got {:?}", o),
         }
     }
 }

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -1312,16 +1312,6 @@ fn invariant_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
         .map(|(name, body)| TopItem::Invariant(InvariantDecl { name, body }))
 }
 
-// target assembly | target quasar
-fn target_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
-    kw("target")
-        .ignore_then(choice((
-            kw("assembly").to("assembly".to_string()),
-            kw("quasar").to("quasar".to_string()),
-        )))
-        .map(TopItem::Target)
-}
-
 // program_id "base58..."
 fn program_id_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
     kw("program_id")
@@ -2128,7 +2118,6 @@ fn top_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
         pda_decl(),
         event_decl(),
         environment_decl(),
-        target_decl(),
         program_id_decl(),
     ));
     // Note: `pubkey`, `instruction`, `assembly`, and the `errors [...]`
@@ -2370,7 +2359,6 @@ property conservation :
                 TopItem::Pda(_) => "pda",
                 TopItem::Event(_) => "event",
                 TopItem::Environment(_) => "environment",
-                TopItem::Target(_) => "target",
                 TopItem::ProgramId(_) => "program_id",
                 TopItem::Assembly(_) => "assembly",
                 TopItem::TypeAlias(_) => "type_alias",

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -1319,13 +1319,6 @@ fn program_id_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
         .map(TopItem::ProgramId)
 }
 
-// assembly "path/to/file.s"
-fn assembly_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
-    kw("assembly")
-        .ignore_then(string_lit())
-        .map(TopItem::Assembly)
-}
-
 // pda name [seed1, seed2, ...]
 fn pda_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
     let seed = choice((
@@ -2072,7 +2065,6 @@ fn pragma_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone
     choice((
         const_decl(),
         pubkey_decl(),
-        assembly_decl(),
         instruction_decl(),
         errors_decl(),
     ))
@@ -2360,7 +2352,6 @@ property conservation :
                 TopItem::Event(_) => "event",
                 TopItem::Environment(_) => "environment",
                 TopItem::ProgramId(_) => "program_id",
-                TopItem::Assembly(_) => "assembly",
                 TopItem::TypeAlias(_) => "type_alias",
                 TopItem::Pubkey(_) => "pubkey",
                 TopItem::Errors(_) => "errors",

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -112,6 +112,8 @@ const KEYWORDS: &[&str] = &[
     "mul_div_ceil",
     "interface",
     "pragma",
+    "let",
+    "in",
 ];
 
 fn non_keyword_ident<'a>() -> impl Parser<'a, &'a str, String, Err<'a>> + Clone {
@@ -527,10 +529,34 @@ fn expr<'a>() -> impl Parser<'a, &'a str, Node<Expr>, Err<'a>> + Clone {
             })
             .boxed();
 
+        // `let NAME = value in body` — ML-style expression binding.
+        // Inside ensures/requires/effect-rhs, lets you derive a value once
+        // and reference it by name. Lowers to Lean's `let NAME := value; body`.
+        let let_in = kw("let")
+            .ignore_then(non_keyword_ident())
+            .then_ignore(wsc())
+            .then_ignore(just('='))
+            .then_ignore(wsc())
+            .then(expr.clone())
+            .then_ignore(wsc())
+            .then_ignore(kw("in"))
+            .then(expr.clone())
+            .map_with(|((name, value), body), e| {
+                Node::new(
+                    Expr::Let {
+                        name,
+                        value: Box::new(value),
+                        body: Box::new(body),
+                    },
+                    e.span().into_range(),
+                )
+            })
+            .boxed();
+
         // atom — must stay under chumsky's `choice` arity limit; split.
         // `.boxed()` tames the type complexity that otherwise trips Apple's
         // linker on overlong symbol names.
-        let group_a = choice((int, bool_lit, old, sum, quant)).boxed();
+        let group_a = choice((int, bool_lit, old, let_in, sum, quant)).boxed();
         let group_b = choice((mul_div_floor_atom, mul_div_ceil_atom, match_expr)).boxed();
         // `record_update` must precede `ctor` (leading `.` distinguishes
         // them, but this ordering is clearer). `app_expr` must precede
@@ -2962,5 +2988,71 @@ pragma sbpf {
             }
             o => panic!("expected Pragma, got {:?}", o),
         }
+    }
+
+    // ------------------------------------------------------------------
+    // ML-style `let x = v in body` in expressions (v2.5)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parses_let_in_inside_ensures() {
+        let src = r#"spec T
+type State | A of { balance : U64 }
+
+handler withdraw (amount : U64) : State.A -> State.A {
+  effect { balance = balance - amount }
+  ensures let delta = old(state.balance) - state.balance in delta == amount
+}
+"#;
+        let s = parse_ok(src);
+        let clauses = first_handler_clauses(&s);
+        let ensures = clauses
+            .iter()
+            .find_map(|c| match &c.node {
+                HandlerClause::Ensures(e) => Some(e),
+                _ => None,
+            })
+            .expect("expected an Ensures clause");
+        // Top of the ensures expression is the Let binding; its body is a Cmp.
+        match &ensures.node {
+            Expr::Let { name, body, .. } => {
+                assert_eq!(name, "delta");
+                assert!(
+                    matches!(body.node, Expr::Cmp { .. }),
+                    "expected Cmp in let body, got {:?}",
+                    body.node
+                );
+            }
+            other => panic!("expected Let at top of ensures, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_nested_let_in() {
+        let src = r#"spec T
+type State | A of { x : U64, y : U64 }
+
+handler h : State.A -> State.A {
+  ensures
+    let a = state.x in
+    let b = state.y in
+    a + b == a + b
+}
+"#;
+        parse_ok(src);
+    }
+
+    #[test]
+    fn let_keyword_still_works_as_handler_clause() {
+        // Keyword-ifying `let` must not break the statement-level clause.
+        let src = r#"spec T
+type State | A of { count : U64 }
+
+handler h (amount : U64) : State.A -> State.A {
+  let doubled = amount + amount
+  effect { count = count + doubled }
+}
+"#;
+        parse_ok(src);
     }
 }

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -111,6 +111,7 @@ const KEYWORDS: &[&str] = &[
     "mul_div_floor",
     "mul_div_ceil",
     "interface",
+    "pragma",
 ];
 
 fn non_keyword_ident<'a>() -> impl Parser<'a, &'a str, String, Err<'a>> + Clone {
@@ -2070,6 +2071,42 @@ fn interface_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
         })
 }
 
+// ----------------------------------------------------------------------------
+// pragma <name> { <platform_item>* } — platform-specific namespace.
+// ----------------------------------------------------------------------------
+
+/// Items allowed inside a pragma body. Restricted whitelist — keeps the
+/// grammar tight and emits clearer errors on misplaced constructs. Extend
+/// as new platforms or pragma content arrives.
+fn pragma_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
+    choice((
+        const_decl(),
+        pubkey_decl(),
+        assembly_decl(),
+        instruction_decl(),
+        errors_decl(),
+    ))
+    .map_with(|item, e| Node::new(item, e.span().into_range()))
+}
+
+fn pragma_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
+    doc_comments()
+        .then_ignore(kw("pragma"))
+        .then(non_keyword_ident())
+        .then_ignore(wsc())
+        .then_ignore(just('{'))
+        .then_ignore(wsc())
+        .then(
+            pragma_item()
+                .then_ignore(wsc())
+                .repeated()
+                .collect::<Vec<Node<TopItem>>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(|((doc, name), items)| TopItem::Pragma(PragmaDecl { name, doc, items }))
+}
+
 // Top-level item: priority-ordered choice.
 // record_decl must precede adt_decl (PEG-style backtracking via .or).
 fn top_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
@@ -2093,14 +2130,12 @@ fn top_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
         environment_decl(),
         target_decl(),
         program_id_decl(),
-        assembly_decl(),
     ));
-    let group_c = choice((
-        pubkey_decl(),
-        errors_decl(),
-        instruction_decl(),
-        interface_decl(),
-    ));
+    // Note: `pubkey`, `instruction`, `assembly`, and the `errors [...]`
+    // sugar are platform-specific and only parse inside
+    // `pragma sbpf { ... }`. Use `type Error | A | B | ...` for errors at
+    // the core-DSL level. The platform-agnostic top level is the point.
+    let group_c = choice((interface_decl(), pragma_decl()));
     choice((group_a, group_b, group_c)).map_with(|item, e| Node::new(item, e.span().into_range()))
 }
 
@@ -2343,6 +2378,7 @@ property conservation :
                 TopItem::Errors(_) => "errors",
                 TopItem::Instruction(_) => "instruction",
                 TopItem::Interface(_) => "interface",
+                TopItem::Pragma(_) => "pragma",
             })
             .fold(
                 std::collections::BTreeMap::<&str, usize>::new(),
@@ -2890,5 +2926,62 @@ handler h : State.A -> State.A {
         });
         let call = call.expect("expected a Call");
         assert!(call.args.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // pragma sbpf { ... } (v2.5 slice — platform-specific namespace)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parses_pragma_sbpf_with_instruction() {
+        let src = r#"spec Transfer
+pragma sbpf {
+  pubkey TOKEN_PROGRAM [1, 2, 3, 4]
+
+  instruction transfer {
+    discriminant 3
+    entry 0
+  }
+}
+"#;
+        let s = parse_ok(src);
+        let p = match &s.items[0].node {
+            TopItem::Pragma(p) => p,
+            o => panic!("expected Pragma, got {:?}", o),
+        };
+        assert_eq!(p.name, "sbpf");
+        assert_eq!(p.items.len(), 2);
+        // Order is preserved: pubkey first, instruction second.
+        assert!(matches!(p.items[0].node, TopItem::Pubkey(_)));
+        assert!(matches!(p.items[1].node, TopItem::Instruction(_)));
+    }
+
+    #[test]
+    fn pragma_body_rejects_non_whitelisted_items() {
+        // A `handler` at the top level of a pragma is not in the whitelist
+        // — it belongs to the core DSL. The parser fails on the closing
+        // brace because the handler doesn't consume.
+        let src = r#"spec T
+pragma sbpf {
+  handler nope : State.A -> State.A { effect {} }
+}
+"#;
+        assert!(
+            parse(src).is_err(),
+            "pragma body should reject `handler`; core DSL items belong at top level"
+        );
+    }
+
+    #[test]
+    fn empty_pragma_parses() {
+        let src = "spec T\npragma sbpf {}\n";
+        let s = parse_ok(src);
+        match &s.items[0].node {
+            TopItem::Pragma(p) => {
+                assert_eq!(p.name, "sbpf");
+                assert!(p.items.is_empty());
+            }
+            o => panic!("expected Pragma, got {:?}", o),
+        }
     }
 }

--- a/crates/qedgen/src/codegen.rs
+++ b/crates/qedgen/src/codegen.rs
@@ -628,9 +628,29 @@ fn render_handler_scaffold(
         ));
     }
 
-    let needs_fill = any_unmechanized || has_events || has_transfers;
+    // `call Interface.handler(name = expr, ...)` sites — the uniform CPI
+    // surface introduced in v2.5 (slice 2). For MVP this follows the same
+    // agent-fill shape as `transfers { }`: emit a structured comment so the
+    // prompt in fill.rs has everything it needs to generate a correct CPI
+    // envelope. Real codegen from a resolved interface lands in v2.6 once
+    // `import` is in play (see docs/design/spec-composition.md §2).
+    let has_calls = !handler.calls.is_empty();
+    for c in &handler.calls {
+        let args = c
+            .args
+            .iter()
+            .map(|a| format!("{}={}", a.name, a.rust_expr))
+            .collect::<Vec<_>>()
+            .join(", ");
+        out.push_str(&format!(
+            "        // Spec call: {}.{}({})\n",
+            c.target_interface, c.target_handler, args
+        ));
+    }
+
+    let needs_fill = any_unmechanized || has_events || has_transfers || has_calls;
     if needs_fill {
-        out.push_str("        todo!(\"fill non-mechanical effects, events, transfers\")\n");
+        out.push_str("        todo!(\"fill non-mechanical effects, events, transfers, calls\")\n");
     } else {
         out.push_str("        Ok(())\n");
     }

--- a/crates/qedgen/src/codegen.rs
+++ b/crates/qedgen/src/codegen.rs
@@ -388,7 +388,9 @@ fn generate_instructions(
     std::fs::write(instr_dir.join("mod.rs"), &mod_out)?;
 
     // Read spec source once — used for spec_hash attributes.
-    let spec_src = std::fs::read_to_string(spec_path).unwrap_or_default();
+    // `read_spec_source` handles both single-file and multi-file (directory)
+    // specs, concatenating fragments in the same order the loader merges them.
+    let spec_src = crate::check::read_spec_source(spec_path).unwrap_or_default();
     let spec_attr = relative_spec_path(spec_path, output_dir);
 
     // Per-handler instruction files — skip if existing (user-owned).

--- a/crates/qedgen/src/fill.rs
+++ b/crates/qedgen/src/fill.rs
@@ -413,6 +413,30 @@ fn build_prompt(
     }
     out.push('\n');
 
+    // -- CPI calls (v2.5 slice 2+5) -----------------------------------
+    // Each `call Interface.handler(name = expr, ...)` is a CPI obligation
+    // the agent must turn into the appropriate CPI envelope. The target
+    // interface's `program_id`, `discriminant`, and account shape carry
+    // everything else needed (when the interface is declared in-spec).
+    out.push_str("  calls (NEEDS FILL):\n");
+    if handler.calls.is_empty() {
+        out.push_str("           — none —\n");
+    } else {
+        for c in &handler.calls {
+            let args = c
+                .args
+                .iter()
+                .map(|a| format!("{}={}", a.name, a.rust_expr))
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push_str(&format!(
+                "           call {}.{}({})\n",
+                c.target_interface, c.target_handler, args
+            ));
+        }
+    }
+    out.push('\n');
+
     // -- Available accounts -------------------------------------------
     out.push_str("Available accounts in `&mut self`:\n");
     for acct in &handler.accounts {
@@ -439,7 +463,7 @@ fn build_prompt(
     out.push_str(&handler.name);
     out.push_str("(self, ...)?;` call as the first statement.\n");
     out.push_str("  - Keep mechanically-expanded effect lines exactly as written.\n");
-    out.push_str("  - Replace the `todo!(...)` line with the remaining effects + events + transfers, then `Ok(())`.\n");
+    out.push_str("  - Replace the `todo!(...)` line with the remaining effects + events + transfers + calls, then `Ok(())`.\n");
     out.push_str("  - Do not modify the `#[qed(verified, ...)]` attribute (drift detection).\n");
     out.push_str("  - Use the existing `crate::events::*` and `crate::guards::*` imports.\n");
 

--- a/crates/qedgen/src/idl2spec.rs
+++ b/crates/qedgen/src/idl2spec.rs
@@ -249,9 +249,11 @@ pub(crate) fn render(idl: &Idl, analyses: &[InstructionAnalysis]) -> String {
     writeln!(s).unwrap();
 
     // ── spec header ──────────────────────────────────────────────────────
+    //
+    // No `target quasar` — Anchor/Quasar is the default; the sBPF target is
+    // opted into with `pragma sbpf { ... }`. See v2.5 spec-composition.
     writeln!(s, "spec {}", program_name).unwrap();
     writeln!(s).unwrap();
-    writeln!(s, "target quasar").unwrap();
     writeln!(s, "// TODO: Replace with deployed program ID").unwrap();
     writeln!(s, "program_id \"11111111111111111111111111111111\"").unwrap();
     writeln!(s).unwrap();
@@ -677,7 +679,10 @@ mod tests {
         });
 
         assert_eq!(spec.program_name, "Escrow");
-        assert_eq!(spec.target.as_deref(), Some("quasar"));
+        assert!(
+            !spec.is_assembly_target(),
+            "IDL-generated specs default to Quasar (no `pragma sbpf`)"
+        );
         assert_eq!(spec.handlers.len(), 3);
         assert_eq!(spec.handlers[0].name, "initialize");
         assert_eq!(spec.handlers[1].name, "exchange");

--- a/crates/qedgen/src/init.rs
+++ b/crates/qedgen/src/init.rs
@@ -7,11 +7,75 @@ const GITIGNORE: &str = ".lake/\nbuild/\nlake-packages/\nlean_solana/.lake/\nlea
 const QED_DIR: &str = ".qed";
 
 /// Persistent project metadata stored in `.qed/config.json`.
+///
+/// `.qed/` pins the project layout: CLI commands resolve the spec path by
+/// walking up from the current directory, finding the nearest `.qed/`, and
+/// reading this file. Users can still pass `--spec <path>` explicitly;
+/// the config is the fallback.
 #[derive(Serialize, Deserialize)]
 pub struct QedConfig {
     pub name: String,
+    /// Path to the authored `.qedspec` (file or directory). Relative to
+    /// the directory containing `.qed/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spec: Option<String>,
+    /// Directory for vendored library interfaces (e.g. SPL Token).
+    /// Relative to the directory containing `.qed/`. Defaults to
+    /// `.qed/interfaces` when written by `qedgen init`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interfaces_dir: Option<String>,
     pub created_at: String,
+}
+
+/// Walk upward from `start` looking for a `.qed/config.json`. Returns the
+/// discovered `.qed/` directory and the loaded config, or `None` if no
+/// ancestor has one.
+pub fn discover_qed_config(start: &Path) -> Option<(std::path::PathBuf, QedConfig)> {
+    let mut current: Option<&Path> = Some(start);
+    while let Some(dir) = current {
+        let candidate = dir.join(QED_DIR);
+        let config_path = candidate.join("config.json");
+        if config_path.is_file() {
+            if let Ok(raw) = std::fs::read_to_string(&config_path) {
+                if let Ok(config) = serde_json::from_str::<QedConfig>(&raw) {
+                    return Some((candidate, config));
+                }
+            }
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+/// Resolve the spec path a CLI command should operate on.
+///
+/// Precedence:
+/// 1. `--spec <path>` passed explicitly — returned as-is.
+/// 2. `.qed/config.json spec` field discovered by walking up from `cwd`
+///    (the config's spec is resolved relative to the directory containing
+///    `.qed/`).
+/// 3. Neither — a helpful error pointing at the two options.
+pub fn resolve_spec_path(explicit: Option<&Path>, cwd: &Path) -> Result<std::path::PathBuf> {
+    if let Some(p) = explicit {
+        return Ok(p.to_path_buf());
+    }
+    let (qed_dir, config) = discover_qed_config(cwd).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no --spec given and no .qed/config.json found in {} or any parent — \
+             run `qedgen init` or pass `--spec <path>`",
+            cwd.display()
+        )
+    })?;
+    let spec_rel = config.spec.ok_or_else(|| {
+        anyhow::anyhow!(
+            "found {} but it has no `spec` field — \
+             edit the config or pass `--spec <path>`",
+            qed_dir.join("config.json").display()
+        )
+    })?;
+    // `.qed/` lives inside the project root; spec is relative to that root.
+    let project_root = qed_dir.parent().unwrap_or(Path::new("."));
+    Ok(project_root.join(spec_rel))
 }
 
 /// Check whether `.qed/` exists in the same directory as `spec_path`.
@@ -32,7 +96,12 @@ pub fn find_qed_dir(spec_path: &Path) -> Option<std::path::PathBuf> {
 
 /// Initialize `.qed/` in the given directory. Returns error if already initialized.
 /// `dir` should be the program root — the directory where the `.qedspec` lives.
-pub fn init_qed_dir(dir: &Path, name: &str) -> Result<()> {
+///
+/// `spec_rel` is the spec path *relative to `dir`* — the pointer written into
+/// `config.json` so `qedgen check`/`codegen` can resolve it without `--spec`.
+/// Pass `None` to leave the field empty (users will need to pass `--spec`
+/// explicitly until they edit the config).
+pub fn init_qed_dir(dir: &Path, name: &str, spec_rel: Option<&str>) -> Result<()> {
     let qed_path = dir.join(QED_DIR);
     if qed_path.exists() {
         anyhow::bail!(
@@ -46,7 +115,10 @@ pub fn init_qed_dir(dir: &Path, name: &str) -> Result<()> {
 
     let config = QedConfig {
         name: name.to_string(),
-        spec: None,
+        spec: spec_rel.map(|s| s.to_string()),
+        // Vendored library interfaces (e.g. SPL Token) land here when the
+        // user runs `qedgen interface --idl <path> --vendor`.
+        interfaces_dir: Some(".qed/interfaces".to_string()),
         created_at: chrono_now(),
     };
     let json = serde_json::to_string_pretty(&config)?;
@@ -263,5 +335,66 @@ fn capitalize(s: &str) -> String {
     match chars.next() {
         None => String::new(),
         Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_walks_up_from_nested_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        init_qed_dir(root, "demo", Some("demo.qedspec")).unwrap();
+        let nested = root.join("src/deep/nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let (qed_dir, config) = discover_qed_config(&nested).expect("discovery succeeds");
+        assert_eq!(qed_dir, root.join(QED_DIR));
+        assert_eq!(config.spec.as_deref(), Some("demo.qedspec"));
+    }
+
+    #[test]
+    fn discover_returns_none_with_no_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Don't init — no .qed/ anywhere.
+        assert!(discover_qed_config(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn resolve_spec_prefers_explicit_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        init_qed_dir(root, "demo", Some("from_config.qedspec")).unwrap();
+        // Explicit --spec should win over discovery.
+        let explicit = root.join("from_flag.qedspec");
+        let resolved = resolve_spec_path(Some(&explicit), root).unwrap();
+        assert_eq!(resolved, explicit);
+    }
+
+    #[test]
+    fn resolve_spec_falls_back_to_config_pointer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        init_qed_dir(root, "demo", Some("demo.qedspec")).unwrap();
+        // No explicit --spec → discovery resolves via config, relative to
+        // the directory containing .qed/.
+        let nested = root.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        let resolved = resolve_spec_path(None, &nested).unwrap();
+        assert_eq!(resolved, root.join("demo.qedspec"));
+    }
+
+    #[test]
+    fn resolve_spec_errors_when_config_lacks_spec_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // spec_rel = None → config has no spec pointer.
+        init_qed_dir(root, "demo", None).unwrap();
+        let err = resolve_spec_path(None, root).unwrap_err().to_string();
+        assert!(
+            err.contains("no `spec` field"),
+            "expected 'no spec field' error, got: {err}"
+        );
     }
 }

--- a/crates/qedgen/src/integration_test.rs
+++ b/crates/qedgen/src/integration_test.rs
@@ -647,7 +647,7 @@ mod tests {
         // to the Quasar (Rust) target.
         std::fs::write(
             &spec_path,
-            "spec Test\ntarget assembly\nassembly \"a.s\"\n\ntype State | Idle\n\nhandler noop : State.Idle -> State.Idle { }\n",
+            "spec Test\ntarget assembly\n\npragma sbpf {\n  assembly \"a.s\"\n}\n\ntype State | Idle\n\nhandler noop : State.Idle -> State.Idle { }\n",
         )
         .unwrap();
         let result = generate(&spec_path, &out_path);

--- a/crates/qedgen/src/integration_test.rs
+++ b/crates/qedgen/src/integration_test.rs
@@ -647,7 +647,7 @@ mod tests {
         // to the Quasar (Rust) target.
         std::fs::write(
             &spec_path,
-            "spec Test\n\npragma sbpf {\n  assembly \"a.s\"\n}\n\ntype State | Idle\n\nhandler noop : State.Idle -> State.Idle { }\n",
+            "spec Test\n\npragma sbpf {}\n\ntype State | Idle\n\nhandler noop : State.Idle -> State.Idle { }\n",
         )
         .unwrap();
         let result = generate(&spec_path, &out_path);

--- a/crates/qedgen/src/integration_test.rs
+++ b/crates/qedgen/src/integration_test.rs
@@ -14,7 +14,7 @@ pub fn generate(spec_path: &Path, output_path: &Path) -> Result<()> {
     let spec = check::parse_spec_file(spec_path)?;
 
     // Only Quasar targets make sense for integration tests
-    if spec.target.as_deref() == Some("assembly") || spec.assembly_path.is_some() {
+    if spec.is_assembly_target() {
         anyhow::bail!("Integration tests are only supported for Quasar targets, not assembly/sBPF");
     }
 
@@ -647,7 +647,7 @@ mod tests {
         // to the Quasar (Rust) target.
         std::fs::write(
             &spec_path,
-            "spec Test\ntarget assembly\n\npragma sbpf {\n  assembly \"a.s\"\n}\n\ntype State | Idle\n\nhandler noop : State.Idle -> State.Idle { }\n",
+            "spec Test\n\npragma sbpf {\n  assembly \"a.s\"\n}\n\ntype State | Idle\n\nhandler noop : State.Idle -> State.Idle { }\n",
         )
         .unwrap();
         let result = generate(&spec_path, &out_path);

--- a/crates/qedgen/src/interface_gen.rs
+++ b/crates/qedgen/src/interface_gen.rs
@@ -1,0 +1,245 @@
+//! Tier-0 interface generator — Anchor IDL → `.qedspec` interface block.
+//!
+//! Emits a shape-only `interface Name { ... }` block: program ID, per-handler
+//! discriminators, account roles (signer/writable), and argument types. No
+//! `requires`/`ensures`/`effect` — those require semantic understanding that
+//! an IDL alone cannot give. The upstream block is left as a TODO for humans
+//! to fill in after they've verified the deployed program.
+//!
+//! See docs/design/spec-composition.md §2 "Tier 0 — shape from IDL."
+
+use anyhow::{Context, Result};
+use std::fmt::Write as _;
+use std::path::Path;
+
+use crate::spec::{self, Idl, IdlAccount, IdlInstruction};
+
+/// Generate an interface `.qedspec` from an Anchor IDL. Returns the rendered
+/// source; the caller writes it to disk.
+pub fn generate(idl_path: &Path) -> Result<String> {
+    let (idl, _analyses) = spec::parse_idl(idl_path)?;
+    Ok(render(&idl))
+}
+
+/// Convenience: generate + write in one step.
+pub fn generate_to_file(idl_path: &Path, out_path: &Path) -> Result<()> {
+    let src = generate(idl_path)?;
+    if let Some(parent) = out_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+    }
+    std::fs::write(out_path, &src).with_context(|| format!("writing {}", out_path.display()))?;
+    Ok(())
+}
+
+fn render(idl: &Idl) -> String {
+    let program_name = &idl.metadata.name;
+    let interface_name = snake_to_pascal(program_name);
+    let spec_name = format!("{}Interface", interface_name);
+
+    let mut out = String::new();
+    writeln!(out, "// Tier-0 interface generated from Anchor IDL.").unwrap();
+    writeln!(
+        out,
+        "// Shape only — no requires/ensures. Upgrade to Tier 1 by declaring"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "// what each handler does to caller-observable state. See"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "// docs/design/spec-composition.md §2 for the tier model."
+    )
+    .unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "spec {}", spec_name).unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "interface {} {{", interface_name).unwrap();
+
+    if let Some(addr) = idl.address.as_deref() {
+        writeln!(out, "  program_id \"{}\"", addr).unwrap();
+        writeln!(out).unwrap();
+    } else {
+        writeln!(
+            out,
+            "  // TODO program_id — not present in IDL. Fill in the deployed address."
+        )
+        .unwrap();
+        writeln!(out).unwrap();
+    }
+
+    writeln!(out, "  upstream {{").unwrap();
+    writeln!(
+        out,
+        "    // TODO fill in after you've run QEDGen harnesses against the"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "    // deployed program. `binary_hash` is authoritative — it pins"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "    // callers to the exact bytes on chain. `verified_with` lists"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "    // only backends that were actually run; omit \"lean\" unless you"
+    )
+    .unwrap();
+    writeln!(out, "    // have a real proof (not just axiomatization).").unwrap();
+    writeln!(out, "    //").unwrap();
+    writeln!(out, "    // package      \"{}\"", program_name).unwrap();
+    writeln!(out, "    // version      \"TODO\"").unwrap();
+    writeln!(out, "    // binary_hash  \"sha256:TODO\"").unwrap();
+    writeln!(out, "    // verified_with [\"proptest\"]").unwrap();
+    writeln!(out, "    // verified_at  \"TODO\"").unwrap();
+    writeln!(out, "  }}").unwrap();
+
+    for ix in &idl.instructions {
+        writeln!(out).unwrap();
+        render_handler(&mut out, ix);
+    }
+
+    writeln!(out, "}}").unwrap();
+    out
+}
+
+fn render_handler(out: &mut String, ix: &IdlInstruction) {
+    let name = &ix.name;
+
+    // Doc comment — each line becomes `/// ...`.
+    for line in &ix.docs {
+        writeln!(out, "  /// {}", line.trim()).unwrap();
+    }
+
+    // handler signature: `handler name (p : T) (q : U)` — params, no transition.
+    write!(out, "  handler {}", name).unwrap();
+    for arg in &ix.args {
+        let ty = spec::type_label(&arg.ty);
+        write!(out, " ({} : {})", arg.name, ty).unwrap();
+    }
+    writeln!(out, " {{").unwrap();
+
+    // discriminant: 8-byte Anchor discriminators render as a hex literal
+    // (0x + 16 hex chars) so they match the format used in hand-authored
+    // interfaces.
+    if !ix.discriminator.is_empty() {
+        let mut hex = String::from("0x");
+        for b in &ix.discriminator {
+            write!(hex, "{:02X}", b).unwrap();
+        }
+        writeln!(out, "    discriminant \"{}\"", hex).unwrap();
+    } else {
+        writeln!(
+            out,
+            "    // TODO discriminant — IDL did not carry one (pre-Anchor 0.30?)."
+        )
+        .unwrap();
+    }
+
+    // accounts { ... }
+    if !ix.accounts.is_empty() {
+        writeln!(out, "    accounts {{").unwrap();
+        for acc in &ix.accounts {
+            render_account(out, acc);
+        }
+        writeln!(out, "    }}").unwrap();
+    }
+
+    writeln!(out, "  }}").unwrap();
+}
+
+fn render_account(out: &mut String, acc: &IdlAccount) {
+    let mut attrs: Vec<&str> = Vec::new();
+    if acc.signer {
+        attrs.push("signer");
+    }
+    if acc.writable {
+        attrs.push("writable");
+    } else {
+        attrs.push("readonly");
+    }
+    // PDA seeds aren't rendered declaratively yet — keep the shape honest
+    // and emit a comment pointing at them so humans can lift them if they
+    // want the caller to check derivation.
+    write!(out, "      {:<24} : {}", acc.name, attrs.join(", ")).unwrap();
+    writeln!(out).unwrap();
+    if acc.pda.is_some() {
+        writeln!(
+            out,
+            "      // ^ IDL declares PDA seeds for {}; add `pda [...]` if callers should verify.",
+            acc.name
+        )
+        .unwrap();
+    }
+}
+
+fn snake_to_pascal(s: &str) -> String {
+    let mut out = String::new();
+    let mut upper_next = true;
+    for ch in s.chars() {
+        if ch == '_' || ch == '-' {
+            upper_next = true;
+        } else if upper_next {
+            out.push(ch.to_ascii_uppercase());
+            upper_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendered_interface_parses_back() {
+        // Use the escrow IDL shipped under examples/ as the fixture. If the
+        // generator ever emits invalid .qedspec, this round-trip fails loud.
+        let idl_path = Path::new("../../examples/rust/escrow/target/idl/escrow.json");
+        if !idl_path.exists() {
+            // Escrow IDL is a build artifact; skip when it hasn't been built.
+            eprintln!("skipping: {} not present", idl_path.display());
+            return;
+        }
+        let rendered = generate(idl_path).expect("IDL generator produced output");
+
+        // Round-trip through the parser — any grammar slip shows up here.
+        let parsed = crate::chumsky_adapter::parse_str(&rendered)
+            .expect("generated interface re-parses cleanly");
+        assert_eq!(
+            parsed.interfaces.len(),
+            1,
+            "expected exactly one interface block"
+        );
+        let iface = &parsed.interfaces[0];
+        assert_eq!(iface.name, "Escrow");
+        assert_eq!(
+            iface.program_id.as_deref(),
+            Some("FyeRokiKoSz9VxRdgDEuKVKwWuGsZLEbMkywgJQDXeFK")
+        );
+        // Tier 0: all handlers have empty requires/ensures.
+        for h in &iface.handlers {
+            assert!(h.requires.is_empty(), "{} leaked a requires", h.name);
+            assert!(h.ensures.is_empty(), "{} leaked an ensures", h.name);
+            assert!(h.discriminant.is_some(), "{} missing discriminant", h.name);
+        }
+    }
+
+    #[test]
+    fn snake_to_pascal_basic() {
+        assert_eq!(snake_to_pascal("spl_token"), "SplToken");
+        assert_eq!(snake_to_pascal("escrow"), "Escrow");
+        assert_eq!(snake_to_pascal("my_program"), "MyProgram");
+    }
+}

--- a/crates/qedgen/src/lean_gen.rs
+++ b/crates/qedgen/src/lean_gen.rs
@@ -3559,41 +3559,43 @@ mod tests {
 spec Dropset
 
 target assembly
-assembly "src/dropset.s"
 
-const DISC_REGISTER_MARKET     = 0
-const ACCT_NON_DUP_MARKER      = 255
-const DATA_LEN_ZERO             = 0
-const SIZE_OF_EMPTY_ACCOUNT     = 10_336
-const SIZE_OF_MARKET_HEADER     = 40
-const SIZE_OF_ADDRESS           = 32
-const SIZE_OF_CREATE_ACCOUNT    = 56
+pragma sbpf {
+  assembly "src/dropset.s"
 
-pubkey RENT [
-  5_862_609_301_215_225_606,
-  9_219_231_539_345_853_473,
-  4_971_307_250_928_769_624,
-  2_329_533_411
-]
+  const DISC_REGISTER_MARKET     = 0
+  const ACCT_NON_DUP_MARKER      = 255
+  const DATA_LEN_ZERO             = 0
+  const SIZE_OF_EMPTY_ACCOUNT     = 10_336
+  const SIZE_OF_MARKET_HEADER     = 40
+  const SIZE_OF_ADDRESS           = 32
+  const SIZE_OF_CREATE_ACCOUNT    = 56
 
-errors [
-  InvalidDiscriminant         = 1   "Discriminant is not REGISTER_MARKET",
-  InvalidInstructionLength    = 2   "Instruction data is not 1 byte",
-  InvalidNumberOfAccounts     = 3   "Fewer than 10 accounts provided",
-  UserHasData                 = 4   "User account already has data",
-  MarketAccountIsDuplicate    = 5   "Market account is a duplicate",
-  MarketHasData               = 6   "Market account already has data",
-  BaseMintIsDuplicate         = 7   "Base mint account is a duplicate",
-  QuoteMintIsDuplicate        = 8   "Quote mint account is a duplicate",
-  InvalidMarketPubkey         = 9   "Market pubkey does not match derived PDA",
-  SystemProgramIsDuplicate    = 10  "System Program account is a duplicate",
-  InvalidSystemProgramPubkey  = 11  "System Program pubkey is wrong",
-  RentSysvarIsDuplicate       = 12  "Rent sysvar account is a duplicate",
-  InvalidRentSysvarPubkey     = 13  "Rent sysvar pubkey is wrong"
-]
+  pubkey RENT [
+    5_862_609_301_215_225_606,
+    9_219_231_539_345_853_473,
+    4_971_307_250_928_769_624,
+    2_329_533_411
+  ]
 
-/// Validates accounts, derives market PDA, creates market account via CPI
-instruction RegisterMarket {
+  errors [
+    InvalidDiscriminant         = 1   "Discriminant is not REGISTER_MARKET",
+    InvalidInstructionLength    = 2   "Instruction data is not 1 byte",
+    InvalidNumberOfAccounts     = 3   "Fewer than 10 accounts provided",
+    UserHasData                 = 4   "User account already has data",
+    MarketAccountIsDuplicate    = 5   "Market account is a duplicate",
+    MarketHasData               = 6   "Market account already has data",
+    BaseMintIsDuplicate         = 7   "Base mint account is a duplicate",
+    QuoteMintIsDuplicate        = 8   "Quote mint account is a duplicate",
+    InvalidMarketPubkey         = 9   "Market pubkey does not match derived PDA",
+    SystemProgramIsDuplicate    = 10  "System Program account is a duplicate",
+    InvalidSystemProgramPubkey  = 11  "System Program pubkey is wrong",
+    RentSysvarIsDuplicate       = 12  "Rent sysvar account is a duplicate",
+    InvalidRentSysvarPubkey     = 13  "Rent sysvar pubkey is wrong"
+  ]
+
+  /// Validates accounts, derives market PDA, creates market account via CPI
+  instruction RegisterMarket {
   discriminant DISC_REGISTER_MARKET
   entry 24
 
@@ -3699,6 +3701,7 @@ instruction RegisterMarket {
     after all guards
     exit 0
   }
+}
 }
 "#;
 

--- a/crates/qedgen/src/lean_gen.rs
+++ b/crates/qedgen/src/lean_gen.rs
@@ -70,10 +70,9 @@ pub fn generate(spec: &ParsedSpec, output_path: &Path) -> Result<()> {
 
 /// Render a `ParsedSpec` into a complete Lean 4 source string.
 pub fn render(spec: &ParsedSpec) -> String {
-    // sBPF mode: target is "assembly", or assembly_path is set with instructions
-    if spec.target.as_deref() == Some("assembly")
-        || (spec.assembly_path.is_some() && !spec.instructions.is_empty())
-    {
+    // sBPF mode: inferred from `pragma sbpf { ... }` presence (or the
+    // legacy fallback signal — see ParsedSpec::is_assembly_target).
+    if spec.is_assembly_target() {
         return render_sbpf(spec);
     }
 
@@ -3557,8 +3556,6 @@ mod tests {
 
     const DROPSET_SPEC: &str = r#"
 spec Dropset
-
-target assembly
 
 pragma sbpf {
   assembly "src/dropset.s"

--- a/crates/qedgen/src/lean_gen.rs
+++ b/crates/qedgen/src/lean_gen.rs
@@ -3558,8 +3558,6 @@ mod tests {
 spec Dropset
 
 pragma sbpf {
-  assembly "src/dropset.s"
-
   const DISC_REGISTER_MARKET     = 0
   const ACCT_NON_DUP_MARKER      = 255
   const DATA_LEN_ZERO             = 0

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -15,6 +15,7 @@ mod fingerprint;
 mod idl2spec;
 mod init;
 mod integration_test;
+mod interface_gen;
 mod kani;
 mod lean_gen;
 mod project;
@@ -104,6 +105,23 @@ enum Commands {
         /// Auto-escalate to Aristotle if sorry markers remain after Leanstral
         #[arg(long)]
         escalate: bool,
+    },
+
+    /// Generate a Tier-0 .qedspec interface block from an Anchor IDL.
+    ///
+    /// Shape only — program ID, discriminators, accounts, argument types.
+    /// No requires/ensures (effects need semantic understanding the IDL does
+    /// not carry). Upgrade to Tier 1 by declaring what the callee does; see
+    /// docs/design/spec-composition.md §2.
+    Interface {
+        /// Path to the Anchor IDL JSON file.
+        #[arg(long)]
+        idl: PathBuf,
+
+        /// Path to write the generated .qedspec. If omitted, the rendered
+        /// source is printed to stdout so the caller can redirect.
+        #[arg(long)]
+        out: Option<PathBuf>,
     },
 
     /// Generate SPEC.md or .qedspec from an Anchor IDL or a .qedspec file
@@ -663,6 +681,17 @@ async fn main() -> Result<()> {
                 }
             }
         }
+
+        Commands::Interface { idl, out } => match out {
+            Some(path) => {
+                interface_gen::generate_to_file(&idl, &path)?;
+                eprintln!("Wrote Tier-0 interface to {}", path.display());
+            }
+            None => {
+                let rendered = interface_gen::generate(&idl)?;
+                print!("{}", rendered);
+            }
+        },
 
         Commands::Spec {
             idl,

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -120,8 +120,14 @@ enum Commands {
 
         /// Path to write the generated .qedspec. If omitted, the rendered
         /// source is printed to stdout so the caller can redirect.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "vendor")]
         out: Option<PathBuf>,
+
+        /// Drop the interface into `.qed/interfaces/<program>.qedspec` (the
+        /// vendored-library convention). Resolved via the nearest `.qed/`.
+        /// Overrides `--out`; errors if no `.qed/` ancestor is found.
+        #[arg(long)]
+        vendor: bool,
     },
 
     /// Generate SPEC.md or .qedspec from an Anchor IDL or a .qedspec file
@@ -191,6 +197,12 @@ enum Commands {
         #[arg(long)]
         name: String,
 
+        /// Path to the authored `.qedspec` (file or directory). Written
+        /// into `.qed/config.json` so `qedgen check`/`codegen` can resolve
+        /// it without an explicit `--spec`. Relative to the program root.
+        #[arg(long)]
+        spec: Option<PathBuf>,
+
         /// sBPF assembly source file (runs asm2lean automatically)
         #[arg(long)]
         asm: Option<PathBuf>,
@@ -214,9 +226,11 @@ enum Commands {
     /// With --explain: generates a Markdown verification report.
     /// With --drift: detects code drift in #[qed(verified)] functions.
     Check {
-        /// Path to the spec file (.qedspec)
+        /// Path to the spec file (.qedspec or a directory of fragments).
+        /// Optional — falls back to the `spec` field in the nearest
+        /// `.qed/config.json` discovered by walking up from cwd.
         #[arg(long)]
-        spec: PathBuf,
+        spec: Option<PathBuf>,
 
         /// Path to the proofs directory
         #[arg(long, default_value = "./formal_verification")]
@@ -311,9 +325,11 @@ enum Commands {
     /// Default (no flags): generates Quasar Rust skeleton only.
     /// Use flags to generate additional artifacts, or --all for everything.
     Codegen {
-        /// Path to the spec file (.qedspec)
+        /// Path to the spec file (.qedspec or a directory of fragments).
+        /// Optional — falls back to the `spec` field in the nearest
+        /// `.qed/config.json` discovered by walking up from cwd.
         #[arg(long)]
-        spec: PathBuf,
+        spec: Option<PathBuf>,
 
         /// Output directory for the generated Quasar project
         #[arg(long, default_value = "./programs")]
@@ -682,16 +698,40 @@ async fn main() -> Result<()> {
             }
         }
 
-        Commands::Interface { idl, out } => match out {
-            Some(path) => {
+        Commands::Interface { idl, out, vendor } => {
+            if vendor {
+                // Drop into `.qed/interfaces/<program>.qedspec`. The program
+                // name is derived from the IDL metadata; the directory is
+                // resolved via the nearest `.qed/` ancestor of cwd.
+                let cwd = std::env::current_dir()?;
+                let (qed_dir, config) = init::discover_qed_config(&cwd).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--vendor requires a `.qed/` ancestor of {} — run `qedgen init` first or pass `--out`",
+                        cwd.display()
+                    )
+                })?;
+                let project_root = qed_dir.parent().unwrap_or(std::path::Path::new("."));
+                let interfaces_dir = project_root.join(
+                    config
+                        .interfaces_dir
+                        .as_deref()
+                        .unwrap_or(".qed/interfaces"),
+                );
+                let stem = idl
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("interface");
+                let target = interfaces_dir.join(format!("{}.qedspec", stem));
+                interface_gen::generate_to_file(&idl, &target)?;
+                eprintln!("Vendored interface to {}", target.display());
+            } else if let Some(path) = out {
                 interface_gen::generate_to_file(&idl, &path)?;
                 eprintln!("Wrote Tier-0 interface to {}", path.display());
-            }
-            None => {
+            } else {
                 let rendered = interface_gen::generate(&idl)?;
                 print!("{}", rendered);
             }
-        },
+        }
 
         Commands::Spec {
             idl,
@@ -741,6 +781,7 @@ async fn main() -> Result<()> {
 
         Commands::Init {
             name,
+            spec,
             asm,
             mathlib,
             quasar,
@@ -748,7 +789,16 @@ async fn main() -> Result<()> {
         } => {
             // .qed/ lives at the program root (parent of formal_verification/)
             let program_root = output_dir.parent().unwrap_or(std::path::Path::new("."));
-            init::init_qed_dir(program_root, &name)?;
+            // The spec pointer is stored relative to program_root so
+            // `qedgen check` from anywhere under the project resolves it
+            // via .qed/config.json → project_root / <spec>.
+            let spec_rel = spec.as_ref().map(|p| {
+                p.strip_prefix(program_root)
+                    .unwrap_or(p.as_path())
+                    .to_string_lossy()
+                    .to_string()
+            });
+            init::init_qed_dir(program_root, &name, spec_rel.as_deref())?;
 
             init::init(&name, &output_dir, asm.as_deref(), mathlib, quasar)?;
 
@@ -787,6 +837,8 @@ async fn main() -> Result<()> {
             json,
         } => {
             require_git_repo()?;
+            let cwd = std::env::current_dir()?;
+            let spec = init::resolve_spec_path(spec.as_deref(), &cwd)?;
             let spec_name = spec
                 .file_stem()
                 .map(|s| s.to_string_lossy().to_string())
@@ -1039,6 +1091,8 @@ async fn main() -> Result<()> {
             fill_tests,
         } => {
             require_git_repo()?;
+            let cwd = std::env::current_dir()?;
+            let spec = init::resolve_spec_path(spec.as_deref(), &cwd)?;
             // Rust skeleton (always)
             codegen::generate(&spec, &output_dir)?;
 

--- a/crates/qedgen/src/spec.rs
+++ b/crates/qedgen/src/spec.rs
@@ -17,6 +17,10 @@ use std::path::Path;
 #[derive(Debug, Deserialize)]
 pub(crate) struct Idl {
     pub metadata: IdlMetadata,
+    /// Anchor 0.30+ emits `address` at the IDL root for the deployed program
+    /// ID. Older IDLs put it under metadata; we fall back on both.
+    #[serde(default)]
+    pub address: Option<String>,
     #[serde(default)]
     pub instructions: Vec<IdlInstruction>,
     #[serde(default)]
@@ -39,6 +43,11 @@ pub(crate) struct IdlInstruction {
     pub accounts: Vec<IdlAccount>,
     #[serde(default)]
     pub args: Vec<IdlArg>,
+    /// Anchor 0.30+ emits an 8-byte discriminator. Older IDLs omit it; the
+    /// interface-from-IDL generator leaves the `discriminant` line as a
+    /// TODO in that case.
+    #[serde(default)]
+    pub discriminator: Vec<u8>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/docs/design/spec-composition.md
+++ b/docs/design/spec-composition.md
@@ -226,6 +226,86 @@ against mistaking "my Rust compiles" for "my program is verified."
 If any of those come up, the answer is "declare it as a separate handler in
 your own spec" — not "extend interface."
 
+### Library interface pinning (upstream version binding)
+
+Tier-1 interfaces QEDGen ships for SPL Token, System Program, etc. are
+trusted transitively by every consumer. A silent runtime or program upgrade
+that changes upstream behavior would invalidate every consumer's proof with
+no diagnostic. Every library interface therefore carries an **`upstream`
+block** declaring the exact version it was verified against:
+
+```qedspec
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+  upstream {
+    package      "spl-token"
+    version      "4.0.3"
+    source       "https://github.com/solana-program/token/tree/v4.0.3"
+    binary_hash  "sha256:a1b2c3…"      # of the deployed .so on mainnet
+    idl_hash     "sha256:d4e5f6…"      # of the Anchor IDL we codegen'd from
+    verified_with ["proptest", "kani"]  # what QEDGen ran; "lean" only when proven, not axiomatized
+    verified_at  "2026-04-18"
+  }
+
+  handler transfer (amount : U64) { ... }
+  ...
+}
+```
+
+Semantics:
+
+- **`binary_hash` is authoritative.** It's the SHA-256 of the deployed
+  program's `.so` bytes (what `solana program dump <program_id>` returns).
+  Version strings and commit hashes are informational; the binary hash is
+  what a caller's attestation chains to.
+- **`verified_with`** is honest. `"proptest"` means we ran property tests
+  against the real program. `"kani"` means we BMC-checked the CPI envelope.
+  `"lean"` only appears when we actually have a proof of the program's Rust
+  source — which we generally do **not** have for external programs. For
+  SPL Token today, the Lean side remains axiomatized and `verified_with`
+  omits `"lean"`. No overclaiming.
+- **Not a proof of correctness.** `upstream` records what QEDGen checked, not
+  that the upstream program is provably correct. The interface's `ensures`
+  are still declarative contracts; `verified_with` tells consumers *which
+  backend checked that the real program behaves that way* on the harness
+  inputs we ran.
+
+### Propagation into `qed.lock`
+
+When a consumer imports a library interface, the `upstream.binary_hash` flows
+into their lockfile (see §3). That's the transitive pin: the consumer's
+`#[qed(verified, qedlock_hash="...")]` covers not just *what* QEDGen
+declared about SPL Token, but *which bytes on chain* we declared it about.
+
+### Drift detection against mainnet
+
+`qedgen verify --check-upstream` (v2.6+) fetches the on-chain program for
+every imported library interface and compares its SHA-256 to the pinned
+`binary_hash`. A mismatch surfaces as:
+
+> `[upstream_drift]` `Token` — pinned binary `sha256:a1b2c3…` (verified
+> 2026-04-18) does not match mainnet deploy `sha256:9d8c7b…`. The program
+> may have been upgraded. Re-verify with the newer version before trusting
+> this interface.
+
+This is optional per run (network dependency), not a build-time check. CI
+pipelines for production programs should turn it on; local development runs
+can skip it.
+
+### Upgrade flow
+
+When a Solana upstream program bumps (rare but not never):
+
+1. QEDGen re-runs its harnesses against the new version.
+2. Re-hashes the deployed `.so` and any changed `ensures`.
+3. Publishes a new release of `qedgen/interfaces/<program>.qedspec`.
+4. Consumers run `qedgen lock --upgrade Token` to accept the new pin.
+5. `qedgen check` flags any caller whose `ensures` relied on behavior that
+   changed between versions.
+
+Same shape as a `Cargo.lock` upgrade — explicit, reviewable, diffable.
+
 ---
 
 ## §3 — Cross-program spec composition (import + qedlock)
@@ -260,16 +340,24 @@ import Jupiter from "./specs/jupiter_v6"           // local path (Tier 2)
 
 ```toml
 # qed.lock — pinned spec dependencies (commit to git)
-[[import]]
-name = "Token"
-path = "qedgen/interfaces/spl_token"
-version = "spl-token@6.0.0"
-spec_hash = "a1b2c3d4e5f67890"   # sha256 of the resolved spec text
 
+# Library interface: pins both our spec text AND the upstream binary we
+# verified against. See §2 "Library interface pinning."
 [[import]]
-name = "Jupiter"
-path = "./specs/jupiter_v6"
-version = "jupiter-v6@c8d9e0f1"
+name           = "Token"
+path           = "qedgen/interfaces/spl_token"
+spec_hash      = "a1b2c3d4e5f67890"   # our interface declaration
+upstream_package = "spl-token"
+upstream_version = "4.0.3"
+upstream_binary_hash = "sha256:9f8e7d6c5b4a3210…"   # deployed .so
+verified_with  = ["proptest", "kani"]
+verified_at    = "2026-04-18"
+
+# Peer qedspec: pins the callee's spec hash only — no upstream block, because
+# the callee's own qed.lock covers its upstream pins transitively.
+[[import]]
+name      = "Jupiter"
+path      = "./specs/jupiter_v6"
 spec_hash = "9fedcba098765432"
 ```
 
@@ -277,7 +365,10 @@ spec_hash = "9fedcba098765432"
 - Fingerprint of a multi-file spec directory becomes
   `hash(ParsedSpec) ⊕ hash(qedlock)`, so a callee spec edit invalidates the
   caller's attestation.
-- `qedgen lock` updates the file; `qedgen check` diagnoses drift.
+- Library imports carry an `upstream_binary_hash`; peer qedspec imports
+  don't (their own `qed.lock` does, and we chain through `spec_hash`).
+- `qedgen lock` updates the file; `qedgen check` diagnoses drift;
+  `qedgen verify --check-upstream` diagnoses mainnet-vs-pin drift on demand.
 
 ### `#[qed(verified)]` transitive hash
 
@@ -313,18 +404,24 @@ stronger without any user action. This is the compounding-adoption lever.
    - §1 multi-file loader (shipped).
    - §2 `interface` block + `call` instruction (Tier 0 and Tier 1).
    - `qedgen interface --idl <path>` writes Tier-0 interfaces from Anchor IDL.
-   - SPL Token / System Program shipped as Tier-1 library interfaces.
+   - SPL Token / System Program shipped as Tier-1 library interfaces,
+     each carrying an `upstream { package, version, binary_hash, … }` block.
    - `transfers { ... }` becomes sugar for `call Token.transfer(...)`.
    - `[shape_only_cpi]` lint for Tier-0 call sites.
    - §3 remains this design doc + declared qedlock format.
 
-2. **v2.6** — Tier 2 composition (§3 stance 1).
+2. **v2.6** — Tier 2 composition (§3 stance 1) + upstream drift detection.
    - `import Foo from "./path/to/spec"` resolution (project + library paths).
    - Importing a qedspec exposes its handlers as the interface — no
      re-declaration.
-   - `qed.lock` file + `qedgen lock` subcommand.
+   - `qed.lock` file + `qedgen lock` + `qedgen lock --upgrade <name>`
+     subcommands. Library imports flow `upstream_binary_hash` into the lock;
+     peer qedspec imports chain through `spec_hash`.
    - Transitive `#[qed(verified, qedlock_hash="...")]` attribute so callee
      spec edits surface as a clear drift diagnostic instead of a silent gap.
+   - `qedgen verify --check-upstream` fetches on-chain programs and
+     diffs against pinned `upstream_binary_hash` (CI-friendly, network-
+     optional).
 
 3. **v2.7** — proof composition (§3 stance 2).
    - Caller's generated Lean imports callee's `formal_verification/Spec.lean`

--- a/docs/design/spec-composition.md
+++ b/docs/design/spec-composition.md
@@ -53,40 +53,122 @@ sorted-path order.
 **The mistake to avoid:** copying anchor's `declare_program!` literally would
 produce serialization stubs. QEDGen's DSL should produce **effect contracts**
 instead — declarations the backends compile into whatever shape each one
-needs (CPI builder for Rust, axiomatized handler for Lean, mock for
-proptest).
+needs.
 
-### Proposed surface (v2.5)
+But effects require semantic understanding that an IDL alone cannot give you.
+The design has to be honest about this: you pay for what you know, and you
+get proof strength proportional to what you declare. That forces a **tiered**
+model rather than one uniform `interface` concept.
 
-**Interface declaration — axiomatizes a callee without its source:**
+### The three tiers
+
+| Tier | Source                                  | Declares                       | Lean verdict                                        |
+|------|-----------------------------------------|--------------------------------|-----------------------------------------------------|
+| 0    | IDL (`qedgen interface --idl`)          | shape only                     | opaque axiom (no post-state info)                   |
+| 1    | hand-written `interface`                | requires / ensures / effect    | hypotheses + state rewrites                         |
+| 2    | imported callee `.qedspec`              | the callee's real handlers     | hypotheses now (stance 1); theorems later (stance 2)|
+
+The **same** `call X.h(...)` surface covers all three tiers. Backends produce
+weaker or stronger artifacts depending on what's available — partial
+verification is automatic, and upgrading a Tier-0 callee to Tier 1 or 2 is
+purely additive.
+
+### Tier 0 — shape from IDL
+
+```bash
+qedgen interface --idl target/idl/jupiter.json --out interfaces/jupiter.qedspec
+```
+
+produces
 
 ```qedspec
-interface Token {
-  handler transfer (amount : U64) {
+interface Jupiter {
+  program_id "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"
+
+  handler swap (amount_in : U64, min_amount_out : U64) {
+    discriminant 0xE445A52E51CB9A1D
     accounts {
-      from      : writable, type token
-      to        : writable, type token
-      authority : signer
+      input_mint      : readonly
+      output_mint     : readonly
+      user_input_ta   : writable, type token
+      user_output_ta  : writable, type token
+      user            : signer
+      token_program   : program
     }
-    requires amount > 0
-    ensures  from.balance = old(from.balance) - amount
-    ensures  to.balance   = old(to.balance) + amount
   }
 }
 ```
 
-- Uses existing declarative keywords. No new expression forms. No bodies.
-- An `interface` is a *contract*: preconditions, postconditions, account roles.
-- Ships as a library (`qedgen/interfaces/spl_token.qedspec`) so every program
-  gets SPL Token for free.
+No `requires`, no `ensures`, no `effect` — and that's the honest answer. An
+IDL carries shape, not semantics. The caller still gets:
 
-**Call site — a terminal instruction inside a handler body:**
+- **Rust**: real CPI builder with correct discriminator, account order, signer
+  roles. Already a big win — today we hardcode `Token.transfer` and have
+  nothing for arbitrary callees.
+- **Lean**: `call Jupiter.swap(...)` compiles to an opaque transition — the
+  call site commits to the accounts/args, but no post-conditions follow from
+  it. Same strength as today's `True := trivial` stubs, but structured.
+- **Kani / proptest**: stubbed call, no post-state assumptions.
+
+### Tier 1 — effects hand-authored
+
+When you know what the callee does to your state (and can't get a qedspec for
+it), you add the effects yourself. Upgrade is additive — start from the
+Tier-0 file and fill in clauses as you learn what you need:
+
+```qedspec
+interface Jupiter {
+  program_id "JUP..."
+
+  handler swap (amount_in : U64, min_amount_out : U64) {
+    discriminant 0xE445A52E51CB9A1D
+    accounts { ... }
+
+    requires amount_in > 0
+    ensures  user_input_ta.balance  = old(user_input_ta.balance)  - amount_in
+    ensures  user_output_ta.balance >= old(user_output_ta.balance) + min_amount_out
+  }
+}
+```
+
+Lean now gets real hypotheses at the `call` site. You only write what you
+rely on in the caller's proof — partial contracts are fine.
+
+For **SPL Token** and **System Program**, QEDGen ships Tier-1 interfaces in
+`qedgen/interfaces/*.qedspec` — one-time cost absorbed upstream. Today's
+hardcoded `transfers { from X to Y amount N }` primitive becomes sugar for
+`call Token.transfer(from=X, to=Y, amount=N)` against the library interface.
+
+### Tier 2 — callee has its own qedspec
+
+No `interface` keyword at all. The callee's qedspec **is** the interface —
+any handler is automatically part of its public surface:
+
+```qedspec
+// caller spec
+spec Escrow
+import MyAmm from "../my_amm"
+
+handler exchange : State.Open -> State.Closed {
+  call MyAmm.swap(pool = amm_pool, amount_in = taker_amount, ...)
+  emits EscrowExchanged
+}
+```
+
+- At v2.6 (stance 1), the caller axiomatizes `MyAmm.swap`'s declared
+  `ensures`. Same strength as Tier 1, but zero duplication — you don't
+  re-declare what the callee already specified.
+- At v2.7 (stance 2), the caller's Lean imports `MyAmm.formal_verification/
+  Spec.lean` and the `ensures` become actual theorems. End-to-end proven.
+
+This is the compounding-adoption lever. No dual maintenance; no re-declaring
+an interface that already exists; every callee that adopts QEDGen strengthens
+every caller without user action.
+
+### Call-site syntax (uniform across all tiers)
 
 ```qedspec
 handler exchange : State.Open -> State.Closed {
-  auth taker
-  accounts { ... }
-
   call Token.transfer(
     from      = taker_ta,
     to        = initializer_ta,
@@ -94,40 +176,45 @@ handler exchange : State.Open -> State.Closed {
     authority = taker,
   )
 
-  call Token.transfer(
-    from      = escrow_ta,
-    to        = taker_ta,
-    amount    = initializer_amount,
-    authority = escrow,
-  )
-
   emits EscrowExchanged
 }
 ```
 
-- `call` is not an expression. It is a statement-level clause, like `transfers`
-  and `emits`. This is deliberate — keeping the DSL from drifting into a PL.
-- Exactly replaces today's `transfers { ... }` primitive. Under the hood,
-  `transfers` becomes sugar for `call Token.transfer(...)`.
+`call` is statement-level, like `transfers` and `emits`. Not an expression.
+Not nestable. This is deliberate — it keeps the DSL from drifting into a PL.
 
-### Codegen mapping
+### Codegen mapping per tier
 
-| Backend    | What `call Token.transfer(...)` produces                          |
-|------------|-------------------------------------------------------------------|
-| Rust       | `token::transfer(CpiContext::new_with_signer(...), amount)`       |
-| Lean       | callee `ensures` become hypotheses; callee `effect` rewrites state |
-| proptest   | in-memory mock of callee preserving declared `ensures`            |
-| Kani       | stub function with `kani::assume(ensures)` pre-state              |
+| Backend    | Tier 0 (shape-only)                              | Tier 1 / Tier 2 (effectful)                         |
+|------------|--------------------------------------------------|-----------------------------------------------------|
+| Rust       | CPI builder: discriminator + accounts + signers  | same                                                |
+| Lean       | opaque axiom (no post-state info)                | callee `ensures` → hypotheses; `effect` → rewrite   |
+| proptest   | mock returns `Ok(())`, no state change           | mock enforces declared `ensures` on post-state      |
+| Kani       | stub with no assumptions                         | stub with `kani::assume(ensures)`                   |
+
+### Linting the tiers
+
+A `call` to a Tier-0 interface is a **visible gap**, not a silent one.
+`qedgen check` emits an info:
+
+> `[shape_only_cpi]` call to `Jupiter.swap` — interface declares shape only,
+> no post-state assumptions. Upgrade to Tier 1 by declaring `ensures`, or
+> import a qedspec for full verification.
+
+Users see exactly what they're leaving on the table. This is the guardrail
+against mistaking "my Rust compiles" for "my program is verified."
 
 ### Scope boundaries
 
-- **In:** `Token` (transfer/mint/burn/init_account/close_account) and System
-  Program (create_account, transfer, assign, allocate) shipped as library
-  interfaces.
-- **In:** user-declared `interface Foo { ... }` in the user's own spec for
-  ad-hoc callees.
-- **Out (deferred to §3):** `import "path/to/other.qedspec"` to automatically
-  derive an interface from a real, proven spec.
+- **In (v2.5):**
+  - `qedgen interface --idl <path>` emits Tier-0 interfaces.
+  - SPL Token / System Program ship as Tier-1 library interfaces.
+  - User-declared `interface Foo { ... }` at any tier.
+  - `call X.h(...)` at all tiers with uniform surface.
+  - `[shape_only_cpi]` lint.
+- **Out (deferred to v2.6+):** `import Foo from "./other.qedspec"` (Tier 2).
+  The `interface` keyword stays available; only the `import` resolution path
+  is deferred.
 
 ### Guardrails against DSL drift
 
@@ -151,21 +238,23 @@ your own spec" — not "extend interface."
 | 2. **Compose proofs**    | Caller's Lean imports callee's proven Lean module  | Strong (end-to-end proven) |
 | 3. **Verify against impl** | Dynamic: run caller tests against real callee     | Orthogonal |
 
-v2.5 ships **stance 1 only**. Stance 2 requires Lean-module-layout decisions
-that depend on §1 settling. Stance 3 is a test-harness concern, not a spec
-concern.
+**Stance 1** lands in v2.6 (importing a callee qedspec binds its `ensures`
+as caller hypotheses). **Stance 2** lands in v2.7 (caller's Lean imports the
+callee's proven module; `ensures` become theorems). **Stance 3** is a
+test-harness concern, orthogonal to the spec layer.
 
 ### Proposed syntax
 
 ```qedspec
-import Token from "qedgen/interfaces/spl_token"    // library path
-import Jupiter from "./specs/jupiter_v6"           // local path
+import Token from "qedgen/interfaces/spl_token"    // library path (Tier 1)
+import Jupiter from "./specs/jupiter_v6"           // local path (Tier 2)
 ```
 
 - Resolution order: builtin library → project-relative → env-configured.
-- Imported names expose their `interface` block (or the full spec, reduced to
-  its public interface).
-- The loader diffs imported specs against a `qedlock` file on disk.
+- If the imported spec has an explicit `interface` block, that's the public
+  surface. Otherwise every handler in the imported spec is automatically
+  part of its interface (a qedspec is its own contract — no re-declaration).
+- The loader diffs imported specs against a `qed.lock` file on disk.
 
 ### qedlock format
 
@@ -220,11 +309,29 @@ stronger without any user action. This is the compounding-adoption lever.
 
 ## Suggested release order
 
-1. **v2.5**: ship §1 (multi-file) + §2 (interface/call) together. §3 stays as
-   this design doc plus qedlock format declaration.
-2. **v2.6**: ship §3 stance 1 (trust ensures via `import`) + transitive
-   `#[qed(verified)]` + `qedgen lock`.
-3. **v2.7**: stance 2 (compose proofs across spec boundaries in Lean).
+1. **v2.5** — modularity + Tier 0/1 CPI.
+   - §1 multi-file loader (shipped).
+   - §2 `interface` block + `call` instruction (Tier 0 and Tier 1).
+   - `qedgen interface --idl <path>` writes Tier-0 interfaces from Anchor IDL.
+   - SPL Token / System Program shipped as Tier-1 library interfaces.
+   - `transfers { ... }` becomes sugar for `call Token.transfer(...)`.
+   - `[shape_only_cpi]` lint for Tier-0 call sites.
+   - §3 remains this design doc + declared qedlock format.
 
-Anything past v2.7 (interface registry, public spec index, etc.) is
+2. **v2.6** — Tier 2 composition (§3 stance 1).
+   - `import Foo from "./path/to/spec"` resolution (project + library paths).
+   - Importing a qedspec exposes its handlers as the interface — no
+     re-declaration.
+   - `qed.lock` file + `qedgen lock` subcommand.
+   - Transitive `#[qed(verified, qedlock_hash="...")]` attribute so callee
+     spec edits surface as a clear drift diagnostic instead of a silent gap.
+
+3. **v2.7** — proof composition (§3 stance 2).
+   - Caller's generated Lean imports callee's `formal_verification/Spec.lean`
+     directly; callee `ensures` become theorems, not axioms.
+   - End-to-end proven across a CPI boundary.
+   - Requires Lean-module-layout conventions that depend on v2.5/v2.6
+     settling first.
+
+Anything past v2.7 (public interface registry, curated spec index, etc.) is
 ecosystem-layer, not core QEDGen.

--- a/docs/design/spec-composition.md
+++ b/docs/design/spec-composition.md
@@ -1,0 +1,230 @@
+# Spec Composition — Design Note (v2.5 target)
+
+Status: **design** (§1 shipped on `feat/spec-composition`; §2 + §3 pending review)
+Author: agent-driven exploration, 2026-04-18
+Scope: how QEDGen's `.qedspec` grows from a single-file DSL into a modular,
+composable specification system without losing its declarative nature.
+
+This is not a release PRD. It is the architectural sketch that follows from
+the three questions asked for the next release: **modularity**, **CPI**, and
+**cross-program composition**.
+
+---
+
+## §1 — Modularity (shipped)
+
+**Shape:** convention-based multi-file. A `.qedspec` "directory spec" contains
+N fragment files, each starting with `spec <Name>`. The loader (`check.rs::
+parse_spec_file`) detects a directory vs file and merges fragments in
+sorted-path order.
+
+**Why convention over configuration:**
+- Zero new grammar. Every fragment is an independently-parseable `.qedspec`.
+- Matches how Haskell / Lean / Rust handle multi-file modules: every file
+  restates its owning module.
+- Author intent (ordering) is expressible via filename prefixes
+  (`10_initialize.qedspec`, `20_exchange.qedspec`).
+
+**Semantics:**
+- Every fragment must declare the same `spec Name`.
+- Top items (records, handlers, properties, invariants, covers, pdas, events,
+  errors) are concatenated. Duplicate-name detection happens in the existing
+  adapter.
+- `spec_hash_for_handler` reads a "virtual concatenated source" (`check::
+  read_spec_source`) so `#[qed(verified, spec_hash=...)]` attributes agree
+  byte-for-byte between single-file and multi-file forms.
+- Fingerprinting already works: it operates on the merged `ParsedSpec`, which
+  is deterministic.
+
+**What users gain:**
+- Stop pasting growing specs into one 2000-line file.
+- `handlers/<name>.qedspec` per handler gives clean diffs and natural reviews.
+- Shared fragments (e.g. `common/accounts.qedspec`) are trivial to copy.
+
+**What we deliberately didn't add:**
+- No `include "path"` directive. Directory membership is the include.
+- No `module` or `namespace` keywords. Modularity within a program is flat.
+- Cross-program sharing is a **different** problem and belongs to §3.
+
+---
+
+## §2 — CPI as declared effect (the `declare_program!` analog)
+
+**The mistake to avoid:** copying anchor's `declare_program!` literally would
+produce serialization stubs. QEDGen's DSL should produce **effect contracts**
+instead — declarations the backends compile into whatever shape each one
+needs (CPI builder for Rust, axiomatized handler for Lean, mock for
+proptest).
+
+### Proposed surface (v2.5)
+
+**Interface declaration — axiomatizes a callee without its source:**
+
+```qedspec
+interface Token {
+  handler transfer (amount : U64) {
+    accounts {
+      from      : writable, type token
+      to        : writable, type token
+      authority : signer
+    }
+    requires amount > 0
+    ensures  from.balance = old(from.balance) - amount
+    ensures  to.balance   = old(to.balance) + amount
+  }
+}
+```
+
+- Uses existing declarative keywords. No new expression forms. No bodies.
+- An `interface` is a *contract*: preconditions, postconditions, account roles.
+- Ships as a library (`qedgen/interfaces/spl_token.qedspec`) so every program
+  gets SPL Token for free.
+
+**Call site — a terminal instruction inside a handler body:**
+
+```qedspec
+handler exchange : State.Open -> State.Closed {
+  auth taker
+  accounts { ... }
+
+  call Token.transfer(
+    from      = taker_ta,
+    to        = initializer_ta,
+    amount    = taker_amount,
+    authority = taker,
+  )
+
+  call Token.transfer(
+    from      = escrow_ta,
+    to        = taker_ta,
+    amount    = initializer_amount,
+    authority = escrow,
+  )
+
+  emits EscrowExchanged
+}
+```
+
+- `call` is not an expression. It is a statement-level clause, like `transfers`
+  and `emits`. This is deliberate — keeping the DSL from drifting into a PL.
+- Exactly replaces today's `transfers { ... }` primitive. Under the hood,
+  `transfers` becomes sugar for `call Token.transfer(...)`.
+
+### Codegen mapping
+
+| Backend    | What `call Token.transfer(...)` produces                          |
+|------------|-------------------------------------------------------------------|
+| Rust       | `token::transfer(CpiContext::new_with_signer(...), amount)`       |
+| Lean       | callee `ensures` become hypotheses; callee `effect` rewrites state |
+| proptest   | in-memory mock of callee preserving declared `ensures`            |
+| Kani       | stub function with `kani::assume(ensures)` pre-state              |
+
+### Scope boundaries
+
+- **In:** `Token` (transfer/mint/burn/init_account/close_account) and System
+  Program (create_account, transfer, assign, allocate) shipped as library
+  interfaces.
+- **In:** user-declared `interface Foo { ... }` in the user's own spec for
+  ad-hoc callees.
+- **Out (deferred to §3):** `import "path/to/other.qedspec"` to automatically
+  derive an interface from a real, proven spec.
+
+### Guardrails against DSL drift
+
+`interface` bodies must not introduce:
+- New expression forms (still only guard-expr / ensures-expr).
+- Recursion or higher-order constructs.
+- Anything that looks like control flow inside the interface block.
+
+If any of those come up, the answer is "declare it as a separate handler in
+your own spec" — not "extend interface."
+
+---
+
+## §3 — Cross-program spec composition (import + qedlock)
+
+### The three stances a caller can take
+
+| Stance                   | What it means                                       | Strength |
+|--------------------------|-----------------------------------------------------|----------|
+| 1. **Trust ensures**     | Callee's declared post-conditions = hypotheses     | Weak (same as today's axioms, but versioned) |
+| 2. **Compose proofs**    | Caller's Lean imports callee's proven Lean module  | Strong (end-to-end proven) |
+| 3. **Verify against impl** | Dynamic: run caller tests against real callee     | Orthogonal |
+
+v2.5 ships **stance 1 only**. Stance 2 requires Lean-module-layout decisions
+that depend on §1 settling. Stance 3 is a test-harness concern, not a spec
+concern.
+
+### Proposed syntax
+
+```qedspec
+import Token from "qedgen/interfaces/spl_token"    // library path
+import Jupiter from "./specs/jupiter_v6"           // local path
+```
+
+- Resolution order: builtin library → project-relative → env-configured.
+- Imported names expose their `interface` block (or the full spec, reduced to
+  its public interface).
+- The loader diffs imported specs against a `qedlock` file on disk.
+
+### qedlock format
+
+```toml
+# qed.lock — pinned spec dependencies (commit to git)
+[[import]]
+name = "Token"
+path = "qedgen/interfaces/spl_token"
+version = "spl-token@6.0.0"
+spec_hash = "a1b2c3d4e5f67890"   # sha256 of the resolved spec text
+
+[[import]]
+name = "Jupiter"
+path = "./specs/jupiter_v6"
+version = "jupiter-v6@c8d9e0f1"
+spec_hash = "9fedcba098765432"
+```
+
+- Analogous to `Cargo.lock` / `package-lock.json` — deterministic closure.
+- Fingerprint of a multi-file spec directory becomes
+  `hash(ParsedSpec) ⊕ hash(qedlock)`, so a callee spec edit invalidates the
+  caller's attestation.
+- `qedgen lock` updates the file; `qedgen check` diagnoses drift.
+
+### `#[qed(verified)]` transitive hash
+
+Today: `spec_hash = "X"` binds the Rust handler to a single spec body.
+
+Tomorrow: `spec_hash = "X"` still binds to the caller spec; `qedlock_hash =
+"Y"` binds to the transitive closure. A callee spec change bumps Y but not X,
+triggering a clear "callee drift" diagnostic instead of a silent
+re-verification gap.
+
+### Non-goals (explicit)
+
+- **Not** shipping Jupiter / Raydium / Drift specs. Community contribution or
+  official-team ownership; QEDGen only ships what it itself verifies.
+- **Not** versioning specs by program ID alone. Spec version ≠ program
+  version; a pinned `spec_hash` is authoritative.
+- **Not** inferring interfaces from IDL. `qedgen spec --idl` already does
+  scaffold generation; composition assumes the human-authored interface is
+  the source of truth.
+
+### The strategic play
+
+Every program built on QEDGen today axiomatizes SPL Token by hand. Once SPL
+Token ships a qedspec (shipped as a library interface, then progressively
+strengthened toward a full proven spec), every consumer becomes strictly
+stronger without any user action. This is the compounding-adoption lever.
+
+---
+
+## Suggested release order
+
+1. **v2.5**: ship §1 (multi-file) + §2 (interface/call) together. §3 stays as
+   this design doc plus qedlock format declaration.
+2. **v2.6**: ship §3 stance 1 (trust ensures via `import`) + transitive
+   `#[qed(verified)]` + `qedgen lock`.
+3. **v2.7**: stance 2 (compose proofs across spec boundaries in Lean).
+
+Anything past v2.7 (interface registry, public spec index, etc.) is
+ecosystem-layer, not core QEDGen.

--- a/examples/rust/escrow-split/.qed/.gitignore
+++ b/examples/rust/escrow-split/.qed/.gitignore
@@ -1,0 +1,1 @@
+# .qed/ is project metadata — commit config.json

--- a/examples/rust/escrow-split/.qed/config.json
+++ b/examples/rust/escrow-split/.qed/config.json
@@ -1,0 +1,5 @@
+{
+  "name": "escrow_split",
+  "spec": null,
+  "created_at": "1776483063s-since-epoch"
+}

--- a/examples/rust/escrow-split/escrow.qedspec
+++ b/examples/rust/escrow-split/escrow.qedspec
@@ -1,0 +1,40 @@
+// Escrow Verification Spec — multi-file edition
+//
+// Byte-for-byte equivalent to examples/rust/escrow/escrow.qedspec, split
+// across files to exercise the convention-based multi-file loader. Every
+// fragment declares `spec Escrow` and contributes top items that are merged
+// in sorted-path order.
+
+spec Escrow
+
+type State
+  | Uninitialized
+  | Open of {
+      initializer          : Pubkey,
+      taker                : Pubkey,
+      initializer_amount   : U64,
+      taker_amount         : U64,
+      escrow_token_account : Pubkey,
+    }
+  | Closed
+
+pda escrow ["escrow", initializer]
+
+event EscrowInitialized {
+  initializer : Pubkey,
+  amount      : U64,
+}
+
+event EscrowExchanged {
+  taker  : Pubkey,
+  amount : U64,
+}
+
+event EscrowCancelled {
+  initializer : Pubkey,
+}
+
+type Error
+  | InvalidAmount
+  | Unauthorized
+  | AlreadyClosed

--- a/examples/rust/escrow-split/formal_verification/.gitignore
+++ b/examples/rust/escrow-split/formal_verification/.gitignore
@@ -1,0 +1,5 @@
+.lake/
+build/
+lake-packages/
+lean_solana/.lake/
+lean_solana/build/

--- a/examples/rust/escrow-split/formal_verification/Spec.lean
+++ b/examples/rust/escrow-split/formal_verification/Spec.lean
@@ -1,0 +1,29 @@
+import QEDGen.Solana.Spec
+
+open QEDGen.Solana.SpecDSL
+
+/-!
+# Escrow_split Verification Spec
+
+Define the program's state, operations, invariants, and trust boundary here.
+This file is the source of truth — proofs must satisfy the properties declared below.
+-/
+
+-- Uncomment and fill in your spec:
+-- qedspec Escrow_split where
+--   state
+--     owner : Pubkey
+--     amount : U64
+--
+--   operation initialize
+--     who: owner
+--     when: Uninitialized
+--     then: Active
+--
+--   operation transfer
+--     who: owner
+--     when: Active
+--     then: Active
+--     calls: TOKEN_PROGRAM_ID DISC_TRANSFER(source writable, destination writable, authority signer)
+--
+--   invariant conservation "total tokens preserved"

--- a/examples/rust/escrow-split/formal_verification/lakefile.lean
+++ b/examples/rust/escrow-split/formal_verification/lakefile.lean
@@ -1,0 +1,11 @@
+import Lake
+open Lake DSL
+
+package escrow_splitProofs
+
+require qedgenSupport from
+  "./lean_solana"
+
+@[default_target]
+lean_lib Escrow_splitSpec where
+  roots := #[`Spec]

--- a/examples/rust/escrow-split/formal_verification/lean-toolchain
+++ b/examples/rust/escrow-split/formal_verification/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.24.0

--- a/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen.lean
@@ -1,0 +1,8 @@
+import QEDGen.Solana.Account
+import QEDGen.Solana.Cpi
+import QEDGen.Solana.State
+import QEDGen.Solana.Valid
+import QEDGen.Solana.SBPF
+import QEDGen.Solana.Spec
+import QEDGen.Solana.Bridge
+import QEDGen.Solana.Guards

--- a/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana.lean
@@ -1,0 +1,5 @@
+import QEDGen.Solana.Account
+import QEDGen.Solana.Cpi
+import QEDGen.Solana.State
+import QEDGen.Solana.Valid
+import QEDGen.Solana.Spec

--- a/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Account.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Account.lean
@@ -1,0 +1,138 @@
+namespace QEDGen.Solana.Account
+
+/-- A 32-byte Solana public key as four little-endian U64 chunks.
+    Matches sBPF VM representation: programs compare pubkeys via
+    four `ldx.dw` loads at byte offsets 0, 8, 16, 24. -/
+structure Pubkey where
+  c0 : Nat  -- bytes 0-7, little-endian U64
+  c1 : Nat  -- bytes 8-15
+  c2 : Nat  -- bytes 16-23
+  c3 : Nat  -- bytes 24-31
+  deriving DecidableEq, BEq, Repr, Inhabited
+
+theorem Pubkey.ext' {a b : Pubkey}
+    (h0 : a.c0 = b.c0) (h1 : a.c1 = b.c1) (h2 : a.c2 = b.c2) (h3 : a.c3 = b.c3) :
+    a = b := by
+  cases a; cases b; simp_all
+
+/-- Two pubkeys differ iff at least one chunk differs. -/
+theorem Pubkey.ne_iff {a b : Pubkey} :
+    a ≠ b ↔ a.c0 ≠ b.c0 ∨ a.c1 ≠ b.c1 ∨ a.c2 ≠ b.c2 ∨ a.c3 ≠ b.c3 := by
+  constructor
+  · intro h
+    if h0 : a.c0 = b.c0 then
+      if h1 : a.c1 = b.c1 then
+        if h2 : a.c2 = b.c2 then
+          if h3 : a.c3 = b.c3 then
+            exact absurd (Pubkey.ext' h0 h1 h2 h3) h
+          else exact Or.inr (Or.inr (Or.inr h3))
+        else exact Or.inr (Or.inr (Or.inl h2))
+      else exact Or.inr (Or.inl h1)
+    else exact Or.inl h0
+  · intro h heq; subst heq
+    cases h with
+    | inl h => exact h rfl
+    | inr h => cases h with
+      | inl h => exact h rfl
+      | inr h => cases h with
+        | inl h => exact h rfl
+        | inr h => exact h rfl
+
+abbrev U64 := Nat
+abbrev U128 := Nat
+abbrev I128 := Int
+abbrev U8 := Nat
+
+structure Account where
+  key : Pubkey
+  authority : Pubkey
+  balance : Nat := 0
+  writable : Bool := true
+  deriving Repr, DecidableEq, BEq
+
+def canWrite (actor : Pubkey) (account : Account) : Prop :=
+  account.writable = true /\ account.authority = actor
+
+-- Finding an account by key
+def findByKey (p_accounts : List Account) (p_key : Pubkey) : Option Account :=
+  p_accounts.find? (fun acc => acc.key = p_key)
+
+-- Finding an account by authority
+def findByAuthority (p_accounts : List Account) (p_authority : Pubkey) : Option Account :=
+  p_accounts.find? (fun acc => acc.authority = p_authority)
+
+-- Find in mapped list: if mapping preserves the predicate's relevant fields
+-- Using axiom for now - full proof would require more complex induction
+axiom find_map_pred_preserved
+    (p_accounts : List Account)
+    (p_pred : Account → Bool)
+    (p_f : Account → Account)
+    (p_h : ∀ acc, p_pred acc = p_pred (p_f acc)) :
+    (p_accounts.map p_f).find? p_pred = (p_accounts.find? p_pred).map p_f
+
+-- Find after updating a different account returns the same result
+axiom find_map_update_other
+    (p_accounts : List Account)
+    (p_target_authority p_update_authority : Pubkey)
+    (p_f : Account → Account)
+    (p_h_distinct : p_target_authority ≠ p_update_authority)
+    (p_h_preserves_auth : ∀ acc, (p_f acc).authority = acc.authority) :
+    let updated := p_accounts.map (fun acc =>
+      if acc.authority = p_update_authority then p_f acc else acc)
+    findByAuthority updated p_target_authority = findByAuthority p_accounts p_target_authority
+
+-- Find after updating the target account returns the updated account
+axiom find_map_update_same
+    (p_accounts : List Account)
+    (p_authority : Pubkey)
+    (p_original : Account)
+    (p_f : Account → Account)
+    (p_h_found : findByAuthority p_accounts p_authority = some p_original)
+    (p_h_preserves_auth : ∀ acc, (p_f acc).authority = acc.authority) :
+    let updated := p_accounts.map (fun acc =>
+      if acc.authority = p_authority then p_f acc else acc)
+    findByAuthority updated p_authority = some (p_f p_original)
+
+-- Key-based versions: Find after updating a different account (by key)
+axiom find_by_key_map_update_other
+    (p_accounts : List Account)
+    (p_target_key p_update_key : Pubkey)
+    (p_f : Account → Account)
+    (p_h_distinct : p_target_key ≠ p_update_key)
+    (p_h_preserves_key : ∀ acc, (p_f acc).key = acc.key) :
+    let updated := p_accounts.map (fun acc =>
+      if acc.key = p_update_key then p_f acc else acc)
+    findByKey updated p_target_key = findByKey p_accounts p_target_key
+
+-- Find by key after updating the target account returns the updated account
+axiom find_by_key_map_update_same
+    (p_accounts : List Account)
+    (p_key : Pubkey)
+    (p_original : Account)
+    (p_f : Account → Account)
+    (p_h_found : findByKey p_accounts p_key = some p_original)
+    (p_h_preserves_key : ∀ acc, (p_f acc).key = acc.key) :
+    let updated := p_accounts.map (fun acc =>
+      if acc.key = p_key then p_f acc else acc)
+    findByKey updated p_key = some (p_f p_original)
+
+end QEDGen.Solana.Account
+
+namespace QEDGen.Solana
+
+abbrev Pubkey := QEDGen.Solana.Account.Pubkey
+abbrev U64 := QEDGen.Solana.Account.U64
+abbrev U128 := QEDGen.Solana.Account.U128
+abbrev I128 := QEDGen.Solana.Account.I128
+abbrev U8 := QEDGen.Solana.Account.U8
+abbrev Account := QEDGen.Solana.Account.Account
+abbrev canWrite := QEDGen.Solana.Account.canWrite
+abbrev findByKey := QEDGen.Solana.Account.findByKey
+abbrev findByAuthority := QEDGen.Solana.Account.findByAuthority
+abbrev find_map_pred_preserved := QEDGen.Solana.Account.find_map_pred_preserved
+abbrev find_map_update_other := QEDGen.Solana.Account.find_map_update_other
+abbrev find_map_update_same := QEDGen.Solana.Account.find_map_update_same
+abbrev find_by_key_map_update_other := QEDGen.Solana.Account.find_by_key_map_update_other
+abbrev find_by_key_map_update_same := QEDGen.Solana.Account.find_by_key_map_update_same
+
+end QEDGen.Solana

--- a/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Cpi.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Cpi.lean
@@ -1,0 +1,217 @@
+import QEDGen.Solana.Account
+
+namespace QEDGen.Solana.Cpi
+
+open QEDGen.Solana.Account
+
+/- ============================================================================
+   CPI (Cross-Program Invocation) Modeling — Generic Envelope
+
+   Models CPI at the invoke_signed level: any Solana CPI is a program ID,
+   a list of account metas, and serialized instruction data. This is generic
+   across ALL Solana programs — no per-instruction structs needed.
+
+   Anchor programs CPI via CpiContext + anchor-spl wrappers, which under the
+   hood call solana_program::program::invoke_signed with:
+     - An Instruction { program_id, accounts: Vec<AccountMeta>, data: Vec<u8> }
+     - Account infos
+     - Signer seeds (for PDA signing)
+
+   Verification scope:
+   - Correct program is called (program_id)
+   - Accounts are in correct order with correct pubkeys and flags
+   - Instruction discriminator is correct (first N bytes of data)
+
+   Trust boundary (not verified):
+   - Parameter serialization within data bytes (SDK territory)
+   - External program execution semantics
+   - PDA signer seed derivation and validity
+   ============================================================================ -/
+
+/-- Solana account metadata passed to a CPI instruction -/
+structure AccountMeta where
+  pubkey : Pubkey
+  isSigner : Bool
+  isWritable : Bool
+  deriving Repr, DecidableEq, BEq
+
+/-- A CPI instruction envelope — mirrors Solana's invoke_signed arguments -/
+structure CpiInstruction where
+  programId : Pubkey
+  accounts : List AccountMeta
+  data : List Nat
+  deriving Repr, DecidableEq
+
+/- ============================================================================
+   Well-known program IDs
+
+   Pubkeys decoded from base58 to big-endian Nat.
+   Source: https://github.com/solana-program
+   ============================================================================ -/
+
+/-- System Program (11111111111111111111111111111111) -/
+def SYSTEM_PROGRAM_ID : Pubkey :=
+  ⟨0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000⟩
+
+/-- SPL Token Program (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+    Big-endian: 0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9 -/
+def TOKEN_PROGRAM_ID : Pubkey :=
+  ⟨0x93a165d7e1f6dd06, 0xac79ebce46e1cbd9, 0x91375b5fed85b41c, 0xa900ff7e85f58c3a⟩
+
+/-- Token-2022 / Token Extensions (TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb)
+    Big-endian: 0x06ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc -/
+def TOKEN_2022_PROGRAM_ID : Pubkey :=
+  ⟨0xde8f75eee1f6dd06, 0xdacd6ce4bc5d4218, 0x270db9834dfc1ab6, 0xfc8ba1d828f9bdfe⟩
+
+/-- Associated Token Account Program (ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL)
+    Big-endian: 0x8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859 -/
+def ASSOCIATED_TOKEN_PROGRAM_ID : Pubkey :=
+  ⟨0xf189244e8f25978c, 0x830d8e1429103dbb, 0x8410ffda99135a0b, 0x59f8e9dbd87b8e04⟩
+
+/-- Memo Program v2 (MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr)
+    Big-endian: 0x054a535a992921064d24e87160da387c7c35b5ddbc92bb81e41fa8404105448d -/
+def MEMO_PROGRAM_ID : Pubkey :=
+  ⟨0x062129995a534a05, 0x7c38da6071e8244d, 0x81bb92bcddb5357c, 0x8d44054140a81fe4⟩
+
+/-- Compute Budget Program (ComputeBudget111111111111111111111111111111)
+    Big-endian: 0x0306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a40000000 -/
+def COMPUTE_BUDGET_PROGRAM_ID : Pubkey :=
+  ⟨0x321721e56f460603, 0xe79bc372baadecff, 0x6b12f7c5bbe58cbc, 0x000000403a9b432c⟩
+
+/-- Stake Program (Stake11111111111111111111111111111111111111)
+    Big-endian: 0x06a1d8179137542a983437bdfe2a7ab2557f535c8a78722b68a49dc000000000 -/
+def STAKE_PROGRAM_ID : Pubkey :=
+  ⟨0x2a54379117d8a106, 0xb27a2afebd373498, 0x2b72788a5c537f55, 0x00000000c09da468⟩
+
+/- ============================================================================
+   SPL Token instruction discriminators (single u8 byte)
+
+   Token and Token-2022 share the same discriminators for instructions 0-24.
+   These are the instructions most commonly invoked via anchor-spl CPI wrappers.
+
+   Anchor pattern:
+     token::transfer(CpiContext::new(..., Transfer { from, to, authority }), amount)?;
+   maps to invoke_signed with data = DISC_TRANSFER ++ le_u64(amount)
+   ============================================================================ -/
+
+def DISC_INITIALIZE_MINT     : List Nat := [0]
+def DISC_INITIALIZE_ACCOUNT  : List Nat := [1]
+def DISC_TRANSFER            : List Nat := [3]
+def DISC_APPROVE             : List Nat := [4]
+def DISC_REVOKE              : List Nat := [5]
+def DISC_SET_AUTHORITY       : List Nat := [6]
+def DISC_MINT_TO             : List Nat := [7]
+def DISC_BURN                : List Nat := [8]
+def DISC_CLOSE_ACCOUNT       : List Nat := [9]
+def DISC_FREEZE_ACCOUNT      : List Nat := [10]
+def DISC_THAW_ACCOUNT        : List Nat := [11]
+def DISC_TRANSFER_CHECKED    : List Nat := [12]
+def DISC_APPROVE_CHECKED     : List Nat := [13]
+def DISC_MINT_TO_CHECKED     : List Nat := [14]
+def DISC_BURN_CHECKED        : List Nat := [15]
+def DISC_SYNC_NATIVE         : List Nat := [17]
+def DISC_INITIALIZE_ACCOUNT3 : List Nat := [18]
+def DISC_INITIALIZE_MINT2    : List Nat := [20]
+
+/- ============================================================================
+   System Program instruction discriminators (4-byte LE u32)
+
+   Anchor pattern:
+     system_program::transfer(CpiContext::new(..., Transfer { from, to }), amount)?;
+   maps to invoke_signed with data = [2,0,0,0] ++ le_u64(amount)
+   ============================================================================ -/
+
+def DISC_SYS_CREATE_ACCOUNT : List Nat := [0, 0, 0, 0]
+def DISC_SYS_ASSIGN         : List Nat := [1, 0, 0, 0]
+def DISC_SYS_TRANSFER       : List Nat := [2, 0, 0, 0]
+def DISC_SYS_ALLOCATE       : List Nat := [8, 0, 0, 0]
+
+/- ============================================================================
+   Associated Token Account instruction discriminators (single u8 byte)
+   ============================================================================ -/
+
+def DISC_ATA_CREATE            : List Nat := [0]
+def DISC_ATA_CREATE_IDEMPOTENT : List Nat := [1]
+def DISC_ATA_RECOVER_NESTED    : List Nat := [2]
+
+/- ============================================================================
+   Verification predicates — all rfl-provable on concrete CpiInstruction values
+   ============================================================================ -/
+
+/-- The instruction targets the expected program -/
+def targetsProgram (cpi : CpiInstruction) (expected : Pubkey) : Prop :=
+  cpi.programId = expected
+
+/-- The account at index i has the expected pubkey, signer flag, and writable flag -/
+def accountAt (cpi : CpiInstruction) (i : Nat)
+    (key : Pubkey) (signer writable : Bool) : Prop :=
+  cpi.accounts[i]? = some ⟨key, signer, writable⟩
+
+/-- The instruction data starts with the expected discriminator bytes -/
+def hasDiscriminator (cpi : CpiInstruction) (disc : List Nat) : Prop :=
+  cpi.data.take disc.length = disc
+
+/-- The instruction passes exactly n accounts -/
+def hasNAccounts (cpi : CpiInstruction) (n : Nat) : Prop :=
+  cpi.accounts.length = n
+
+/-- Basic well-formedness: non-empty accounts and data -/
+def wellFormed (cpi : CpiInstruction) : Prop :=
+  cpi.accounts.length > 0 ∧ cpi.data.length > 0
+
+end QEDGen.Solana.Cpi
+
+namespace QEDGen.Solana
+
+-- Types
+abbrev AccountMeta := QEDGen.Solana.Cpi.AccountMeta
+abbrev CpiInstruction := QEDGen.Solana.Cpi.CpiInstruction
+
+-- Program IDs
+abbrev SYSTEM_PROGRAM_ID := QEDGen.Solana.Cpi.SYSTEM_PROGRAM_ID
+abbrev TOKEN_PROGRAM_ID := QEDGen.Solana.Cpi.TOKEN_PROGRAM_ID
+abbrev TOKEN_2022_PROGRAM_ID := QEDGen.Solana.Cpi.TOKEN_2022_PROGRAM_ID
+abbrev ASSOCIATED_TOKEN_PROGRAM_ID := QEDGen.Solana.Cpi.ASSOCIATED_TOKEN_PROGRAM_ID
+abbrev MEMO_PROGRAM_ID := QEDGen.Solana.Cpi.MEMO_PROGRAM_ID
+abbrev COMPUTE_BUDGET_PROGRAM_ID := QEDGen.Solana.Cpi.COMPUTE_BUDGET_PROGRAM_ID
+abbrev STAKE_PROGRAM_ID := QEDGen.Solana.Cpi.STAKE_PROGRAM_ID
+
+-- SPL Token discriminators
+abbrev DISC_TRANSFER := QEDGen.Solana.Cpi.DISC_TRANSFER
+abbrev DISC_TRANSFER_CHECKED := QEDGen.Solana.Cpi.DISC_TRANSFER_CHECKED
+abbrev DISC_MINT_TO := QEDGen.Solana.Cpi.DISC_MINT_TO
+abbrev DISC_MINT_TO_CHECKED := QEDGen.Solana.Cpi.DISC_MINT_TO_CHECKED
+abbrev DISC_BURN := QEDGen.Solana.Cpi.DISC_BURN
+abbrev DISC_BURN_CHECKED := QEDGen.Solana.Cpi.DISC_BURN_CHECKED
+abbrev DISC_CLOSE_ACCOUNT := QEDGen.Solana.Cpi.DISC_CLOSE_ACCOUNT
+abbrev DISC_APPROVE := QEDGen.Solana.Cpi.DISC_APPROVE
+abbrev DISC_APPROVE_CHECKED := QEDGen.Solana.Cpi.DISC_APPROVE_CHECKED
+abbrev DISC_REVOKE := QEDGen.Solana.Cpi.DISC_REVOKE
+abbrev DISC_SET_AUTHORITY := QEDGen.Solana.Cpi.DISC_SET_AUTHORITY
+abbrev DISC_FREEZE_ACCOUNT := QEDGen.Solana.Cpi.DISC_FREEZE_ACCOUNT
+abbrev DISC_THAW_ACCOUNT := QEDGen.Solana.Cpi.DISC_THAW_ACCOUNT
+abbrev DISC_INITIALIZE_MINT := QEDGen.Solana.Cpi.DISC_INITIALIZE_MINT
+abbrev DISC_INITIALIZE_MINT2 := QEDGen.Solana.Cpi.DISC_INITIALIZE_MINT2
+abbrev DISC_INITIALIZE_ACCOUNT := QEDGen.Solana.Cpi.DISC_INITIALIZE_ACCOUNT
+abbrev DISC_INITIALIZE_ACCOUNT3 := QEDGen.Solana.Cpi.DISC_INITIALIZE_ACCOUNT3
+abbrev DISC_SYNC_NATIVE := QEDGen.Solana.Cpi.DISC_SYNC_NATIVE
+
+-- System Program discriminators
+abbrev DISC_SYS_CREATE_ACCOUNT := QEDGen.Solana.Cpi.DISC_SYS_CREATE_ACCOUNT
+abbrev DISC_SYS_ASSIGN := QEDGen.Solana.Cpi.DISC_SYS_ASSIGN
+abbrev DISC_SYS_TRANSFER := QEDGen.Solana.Cpi.DISC_SYS_TRANSFER
+abbrev DISC_SYS_ALLOCATE := QEDGen.Solana.Cpi.DISC_SYS_ALLOCATE
+
+-- ATA discriminators
+abbrev DISC_ATA_CREATE := QEDGen.Solana.Cpi.DISC_ATA_CREATE
+abbrev DISC_ATA_CREATE_IDEMPOTENT := QEDGen.Solana.Cpi.DISC_ATA_CREATE_IDEMPOTENT
+abbrev DISC_ATA_RECOVER_NESTED := QEDGen.Solana.Cpi.DISC_ATA_RECOVER_NESTED
+
+-- Predicates
+abbrev targetsProgram := QEDGen.Solana.Cpi.targetsProgram
+abbrev accountAt := QEDGen.Solana.Cpi.accountAt
+abbrev hasDiscriminator := QEDGen.Solana.Cpi.hasDiscriminator
+abbrev hasNAccounts := QEDGen.Solana.Cpi.hasNAccounts
+abbrev cpiWellFormed := QEDGen.Solana.Cpi.wellFormed
+
+end QEDGen.Solana

--- a/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Spec.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Spec.lean
@@ -1,0 +1,626 @@
+import QEDGen.Solana.Account
+import QEDGen.Solana.CommandBuilders
+import QEDGen.Solana.Cpi
+import QEDGen.Solana.State
+import QEDGen.Solana.Valid
+import Lean.Elab.Command
+
+/-!
+# QEDGen Spec DSL
+
+Declarative specification macros for Solana program verification.
+The `qedspec` block is the source of truth — it expands to:
+  - State structure with DecidableEq
+  - Transition functions with signer/lifecycle guards
+  - Operation inductive type with `applyOp` dispatcher
+  - Per-property inductive preservation theorems (one sorry per property)
+  - CPI correctness theorems (structural, typically pure rfl)
+  - Invariant theorem stubs
+
+Per-operation proofs (access_control, state_machine, u64_bounds, per-op
+preservation) are NOT generated — Kani and unit tests cover those.
+Lean focuses on inductive/compositional properties that require reasoning
+over arbitrary operation sequences.
+
+## Clauses
+
+- `who:` — signer field (optional: omit for permissionless operations)
+- `when:` / `then:` — lifecycle state transitions (optional: omit for lifecycle-less ops)
+- `takes:` — operation parameters with DSL types (U64, U128, I128, U8)
+- `let:` — computed intermediates (pure `let` bindings before the guard)
+- `guard:` — domain-specific constraints as Lean Prop strings
+- `effect:` — structured state mutations: `field add/sub param`
+- `calls:` — CPI instruction declarations
+- `emits:` — event names (Quasar codegen only, ignored by Lean elaborator)
+- `context:` — account context block (Quasar codegen only, ignored by Lean elaborator)
+- `property` — named predicates with preservation scope
+- `account` — sub-structures embedded in the main State
+
+## Top-level Quasar-only clauses (accepted but ignored by Lean elaborator)
+
+- `program_id:` — on-chain program address string
+- `pda` — PDA seed declarations
+- `event` — event structure declarations
+- `errors` — error name declarations
+
+## Type mapping
+
+DSL types are mapped to Lean types in generated code for omega compatibility:
+  - U64, U128, U8 → Nat
+  - I128 → Int
+  - Other types (Pubkey, custom) pass through unchanged
+
+## Effect syntax
+
+Effects use structured assignments validated against the state declaration:
+  - `field add param` → `field := s.field + param`
+  - `field sub param` → `field := s.field - param`
+
+`sub` effects auto-generate an underflow guard (`param ≤ s.field`)
+for Nat-typed fields. Int fields (I128) skip the guard since Int
+subtraction is total.
+
+Field and param names are validated at elaboration time — typos fail fast.
+Guard and property strings are also validated for `s.FIELD` references.
+
+## Out of scope (intentionally deferred)
+
+The following patterns cannot be expressed in the current DSL:
+  - **Multi-account operations**: Creating/closing accounts (array state changes)
+  - **Aggregates**: Sum/product over collections (e.g., sum of all user balances)
+  - **Multi-step compositions**: Sequential transition composition with intermediate assertions
+  - **Cross-program invariants**: Properties spanning multiple programs
+  - **Dynamic account sets**: Variable-length account arrays in state
+-/
+
+open QEDGen.Solana
+
+-- ============================================================================
+-- Syntax declarations
+-- ============================================================================
+
+namespace QEDGen.Solana.SpecDSL
+
+/-- A single state field: `fieldName : FieldType` -/
+syntax specField := ident " : " ident
+
+/-- A CPI account with access flag: `accountName writable` -/
+syntax specCpiAcct := rawIdent rawIdent
+
+/-- Operation parameter: `paramName Type` -/
+syntax specParam := rawIdent rawIdent
+
+/-- Structured effect assignment: `field add param` or `field sub param`.
+    Validated against state fields and takes parameters at elaboration time.
+    `sub` auto-generates an underflow guard. -/
+syntax specEffectAssign := rawIdent rawIdent rawIdent
+
+/-- Let binding for computed intermediates: `let: varName "expression"` -/
+syntax specLet := rawIdent str
+
+/-- PDA seed: either a field reference or a string literal -/
+syntax specPdaSeed := rawIdent <|> str
+
+/-- PDA declaration: `pda name seed1, seed2, ...` -/
+syntax specPdaDecl := "pda " rawIdent specPdaSeed,*
+
+/-- Event field declaration: `fieldName : FieldType` -/
+syntax specEventField := rawIdent " : " rawIdent
+
+/-- Event declaration with braces: `event Name { field : Type, ... }`
+    Braces delimit field list to prevent greedy consumption of subsequent sections. -/
+syntax specEventDecl := "event " rawIdent "{" specEventField,* "}"
+
+/-- Context attribute: bare keyword or keyword(argument).
+    Examples: `mut`, `init`, `payer(maker)`, `seeds(escrow)`, `bump` -/
+syntax specCtxAttr := rawIdent ("(" rawIdent ")")?
+
+/-- Context entry: `name : Attr, Attr, ...`
+    First attr is always the type (e.g., Signer, Account). -/
+syntax specCtxEntry := rawIdent " : " specCtxAttr,+
+
+/-- Operation block (rawIdent allows Lean keywords like `initialize`, `open`).
+    `who:`, `when:`, `then:` are optional — omit for signer-less or lifecycle-less operations.
+    `doc:` provides a human-readable intent description attached to generated theorems.
+    `emits:` and `context:` are Quasar-only (accepted but ignored by Lean elaborator). -/
+syntax specOp :=
+  "operation " rawIdent
+    ("doc: " str)?
+    ("who: " rawIdent)?
+    ("when: " rawIdent)?
+    ("then: " rawIdent)?
+    ("takes: " specParam,*)?
+    ("let: " specLet,*)?
+    ("guard: " str)?
+    ("effect: " specEffectAssign,*)?
+    ("calls: " rawIdent rawIdent "(" specCpiAcct,* ")")?
+    ("emits: " rawIdent,*)?
+    ("context:" "{" specCtxEntry* "}")?
+
+/-- Invariant declaration (untyped — generates `theorem name : True := sorry`) -/
+syntax specInvariant := "invariant " rawIdent str
+
+/-- Property declaration with predicate body and preservation scope.
+    The string is a Lean `Prop` expression using `s.field` notation.
+    `preserved_by:` lists which operations must preserve it. -/
+syntax specProperty :=
+  "property " rawIdent str
+    "preserved_by: " rawIdent,*
+
+/-- Account block: generates a separate structure alongside State.
+    The main State gets a field of this type automatically. -/
+syntax specAccount := "account " rawIdent specField*
+
+/-- The top-level qedspec command.
+    `program_id:`, `pda`, `event`, and `errors` are Quasar-only
+    (accepted but ignored by the Lean elaborator). -/
+syntax (name := qedspecCmd)
+  "qedspec " ident " where"
+    ("program_id: " str)?
+    "state" specField*
+    specAccount*
+    specPdaDecl*
+    specEventDecl*
+    ("errors: " rawIdent,*)?
+    specOp*
+    specInvariant*
+    specProperty*
+  : command
+
+-- ============================================================================
+-- CPI account flag parsing
+-- ============================================================================
+
+/-- Parse an account access flag keyword to (isSigner, isWritable).
+    Known flags: readonly, writable, signer, signer_writable -/
+private def parseFlag (flag : String) : Option (Bool × Bool) :=
+  match flag with
+  | "readonly"         => some (false, false)
+  | "writable"         => some (false, true)
+  | "signer"           => some (true, false)
+  | "signer_writable"  => some (true, true)
+  | _                  => none
+
+-- ============================================================================
+-- Elaborator
+-- ============================================================================
+
+-- Use CommandBuilders for safe string construction
+open QEDGen.Solana.CommandBuilders in
+private def quoteName := safeName
+open QEDGen.Solana.CommandBuilders in
+private def mapDslType := mapType
+
+/-- Validate that `s.FIELD` references in a string expression correspond to
+    declared state fields. Catches typos at elaboration time. -/
+private def validateFieldRefs (expr : String) (fields : Array (String × String))
+    (context : String) : Lean.Elab.Command.CommandElabM Unit := do
+  let parts := expr.splitOn "s."
+  -- Skip parts[0] (before first "s."), check each subsequent occurrence
+  for i in List.range (parts.length - 1) do
+    let rest := parts[i + 1]!
+    let fieldRef := (rest.takeWhile (fun c => c.isAlphanum || c == '_')).toString
+    if !fieldRef.isEmpty then
+      let qRef := quoteName fieldRef
+      if !fields.any (fun (fn_, _) => fn_ == qRef) then
+        Lean.throwError m!"qedspec: {context} references unknown field 's.{fieldRef}'. Available: {fields.map (·.1)}"
+
+set_option maxHeartbeats 800000 in
+open Lean in
+open Lean.Elab in
+open Lean.Elab.Command in
+open QEDGen.Solana.CommandBuilders in
+@[command_elab qedspecCmd]
+def elabQedspec : CommandElab := fun stx => do
+  -- Extract pieces from the syntax tree
+  -- Layout: "qedspec" ident "where" program_id? "state" fields* accounts*
+  --         pdas* events* errors? ops* invs* props*
+  -- Indices: 0       1     2      3            4       5       6
+  --          7     8       9       10   11    12
+  let progNameStx := stx[1]
+  let name := progNameStx.getId
+  -- stx[3] = ("program_id:" str)? — Quasar-only, ignored
+  let _programIdStx := stx[3]
+  let fieldsStx := stx[5]      -- specField* (index 5: after "qedspec" ident "where" program_id? "state")
+  let accountsStx := stx[6]    -- specAccount*
+  -- stx[7] = specPdaDecl*     — Quasar-only, ignored
+  let _pdasStx := stx[7]
+  -- stx[8] = specEventDecl*   — Quasar-only, ignored
+  let _eventsStx := stx[8]
+  -- stx[9] = ("errors:" rawIdent,*)?   — Quasar-only, ignored
+  let _errorsStx := stx[9]
+  let opsStx := stx[10]        -- specOp*
+  let invsStx := stx[11]       -- specInvariant*
+  let propsStx := stx[12]      -- specProperty*
+
+  -- Parse field declarations
+  let mut fieldData : Array (String × String) := #[]
+  for f in fieldsStx.getArgs do
+    let fieldName := quoteName (f[0].getId.toString (escape := false))
+    let fieldType := f[2].getId.toString (escape := false)
+    fieldData := fieldData.push (fieldName, fieldType)
+
+  -- Parse account blocks: each generates a separate structure
+  let mut accountData : Array (String × Array (String × String)) := #[]
+  for acct in accountsStx.getArgs do
+    let acctName := acct[1].getId.toString (escape := false)
+    let mut acctFields : Array (String × String) := #[]
+    -- Account fields are in the repetition node at index 2
+    let acctFieldsStx := acct[2]
+    for f in acctFieldsStx.getArgs do
+      let fn_ := quoteName (f[0].getId.toString (escape := false))
+      let ft := f[2].getId.toString (escape := false)
+      acctFields := acctFields.push (fn_, ft)
+    accountData := accountData.push (acctName, acctFields)
+    -- Add account as a field of the main State
+    fieldData := fieldData.push (acctName, acctName)
+
+  -- Collect U64 fields for arithmetic bounds generation
+  let u64Fields := fieldData.filter (fun (_, ft) => ft == "U64")
+
+  -- Collect lifecycle states from when/then across all operations
+  -- (op[2] = doc?, op[3] = who?, op[4] = when?, op[5] = then?)
+  let mut lifecycleStates : Array String := #[]
+  for op in opsStx.getArgs do
+    let whenStx := op[4]
+    if !whenStx.isMissing && whenStx.getNumArgs > 0 then
+      let preStatus := whenStx[1].getId.toString (escape := false)
+      if !lifecycleStates.contains preStatus then
+        lifecycleStates := lifecycleStates.push preStatus
+    let thenStx := op[5]
+    if !thenStx.isMissing && thenStx.getNumArgs > 0 then
+      let postStatus := thenStx[1].getId.toString (escape := false)
+      if !lifecycleStates.contains postStatus then
+        lifecycleStates := lifecycleStates.push postStatus
+
+  let hasLifecycle := lifecycleStates.size > 0
+
+  -- Build state field list (add lifecycle status if any when/then clauses exist)
+  let mut stateFields := fieldData
+  if hasLifecycle then
+    stateFields := stateFields.push ("status", "Status")
+
+  -- Assemble individual command strings to parse and elaborate one at a time
+  -- (Lean's runParserCategory `command parses exactly ONE command)
+  let mut cmds : Array String := #[]
+  cmds := cmds.push (mkNamespace s!"{name}")
+  cmds := cmds.push (mkOpen "QEDGen.Solana")
+  -- Bump heartbeats: Mathlib typeclass instances make elaboration heavier
+  cmds := cmds.push "set_option maxHeartbeats 400000"
+
+  -- Generate Status inductive from when/then values
+  if hasLifecycle then
+    cmds := cmds.push (mkInductive "Status" lifecycleStates)
+
+  -- Generate account structures (before State, since State references them)
+  for (acctName, acctFields) in accountData do
+    cmds := cmds.push (mkStructure acctName acctFields)
+
+  cmds := cmds.push (mkStructure "State" stateFields)
+
+  -- Track per-operation parameters so property preservation theorems can reference them
+  let mut opParamsMap : Array (String × Array (String × String)) := #[]
+
+  -- Collect assumptions for the module doc block
+  let mut assumptions : Array String := #[]
+  if u64Fields.size > 0 then
+    let u64Names := ", ".intercalate (u64Fields.map (·.1)).toList
+    assumptions := assumptions.push s!"**U64 bounds tracking**: Fields [{u64Names}] are tracked for overflow/underflow safety."
+  if hasLifecycle then
+    let states := ", ".intercalate lifecycleStates.toList
+    assumptions := assumptions.push s!"**Lifecycle states**: {states}."
+
+  for op in opsStx.getArgs do
+    let opNameRaw := op[1].getId.toString (escape := false)
+    let opName := quoteName opNameRaw
+    let transName := quoteName s!"{opNameRaw}Transition"
+
+    -- ----------------------------------------------------------------
+    -- Parse optional doc: clause (op[2])
+    -- ----------------------------------------------------------------
+    let docStx := op[2]
+    let docStr := if !docStx.isMissing && docStx.getNumArgs > 0 then
+      docStx[1].isStrLit?.getD ""
+    else ""
+
+    -- ----------------------------------------------------------------
+    -- Parse optional who:/when:/then: clauses (op[3], op[4], op[5])
+    -- ----------------------------------------------------------------
+    let whoStx := op[3]
+    let hasSigner := !whoStx.isMissing && whoStx.getNumArgs > 0
+    let signer := if hasSigner then quoteName (whoStx[1].getId.toString (escape := false)) else ""
+
+    let whenStx := op[4]
+    let hasWhen := !whenStx.isMissing && whenStx.getNumArgs > 0
+    let preStatus := if hasWhen then whenStx[1].getId.toString (escape := false) else ""
+
+    let thenStx := op[5]
+    let hasThen := !thenStx.isMissing && thenStx.getNumArgs > 0
+    let postStatus := if hasThen then thenStx[1].getId.toString (escape := false) else ""
+
+    -- ----------------------------------------------------------------
+    -- Parse optional takes: clause (op[6])
+    -- ----------------------------------------------------------------
+    let takesStx := op[6]
+    let mut params : Array (String × String) := #[]
+    if !takesStx.isMissing && takesStx.getNumArgs > 0 then
+      let paramsSepStx := takesStx[1]  -- specParam,* separator node
+      for i in List.range paramsSepStx.getArgs.size do
+        let arg := paramsSepStx.getArgs[i]!
+        if i % 2 == 0 then  -- skip comma separators
+          let pName := arg[0].getId.toString (escape := false)
+          let pType := arg[1].getId.toString (escape := false)
+          params := params.push (pName, pType)
+
+    -- Save params for this operation (used by property preservation theorems)
+    opParamsMap := opParamsMap.push (opNameRaw, params)
+
+    -- Build param strings for function signatures and theorem calls
+    let paramSig := mkParamSig params
+    let paramArgs := mkParamArgs params
+
+    -- ----------------------------------------------------------------
+    -- Parse optional let: clause (op[7])
+    -- ----------------------------------------------------------------
+    let letStx := op[7]
+    let mut letBindings : Array (String × String) := #[]
+    if !letStx.isMissing && letStx.getNumArgs > 0 then
+      let letsSepStx := letStx[1]  -- specLet,* separator node
+      for i in List.range letsSepStx.getArgs.size do
+        let arg := letsSepStx.getArgs[i]!
+        if i % 2 == 0 then  -- skip comma separators
+          let letName := arg[0].getId.toString (escape := false)
+          let letExpr := arg[1].isStrLit?.getD ""
+          letBindings := letBindings.push (letName, letExpr)
+
+    -- ----------------------------------------------------------------
+    -- Parse optional guard: clause (op[8])
+    -- ----------------------------------------------------------------
+    let guardStx := op[8]
+    let guardStr := if !guardStx.isMissing && guardStx.getNumArgs > 0 then
+      guardStx[1].isStrLit?.getD ""
+    else ""
+
+    -- Validate field references in guard string
+    if !guardStr.isEmpty then
+      validateFieldRefs guardStr fieldData s!"guard in operation '{opNameRaw}'"
+
+    -- ----------------------------------------------------------------
+    -- Parse optional effect: clause (op[9])
+    -- Structured: `field add param` or `field sub param`
+    -- ----------------------------------------------------------------
+    let effectStx := op[9]
+    let mut effectAssigns : Array String := #[]
+    let mut autoGuards : Array String := #[]
+
+    if !effectStx.isMissing && effectStx.getNumArgs > 0 then
+      let assignsSepStx := effectStx[1]  -- specEffectAssign,* separator node
+      for i in List.range assignsSepStx.getArgs.size do
+        let arg := assignsSepStx.getArgs[i]!
+        if i % 2 == 0 then  -- skip comma separators
+          let effectField := arg[0].getId.toString (escape := false)
+          let effectOp := arg[1].getId.toString (escape := false)
+          let effectValue := arg[2].getId.toString (escape := false)
+
+          -- Validate operator
+          if effectOp != "add" && effectOp != "sub" then
+            throwError m!"qedspec: effect operator must be 'add' or 'sub', got '{effectOp}' in operation '{opNameRaw}'"
+
+          -- Validate field exists in state
+          let qField := quoteName effectField
+          if !fieldData.any (fun (fn_, _) => fn_ == qField) then
+            throwError m!"qedspec: effect field '{effectField}' not found in state. Available fields: {fieldData.map (·.1)}"
+
+          -- Validate value exists in takes params or state fields
+          let qValue := quoteName effectValue
+          if !params.any (fun (pn, _) => pn == effectValue) &&
+             !fieldData.any (fun (fn_, _) => fn_ == qValue) then
+            throwError m!"qedspec: effect value '{effectValue}' not found in 'takes:' parameters or state fields for operation '{opNameRaw}'"
+
+          -- Look up DSL type for this field (Int subtraction is total — no guard needed)
+          let fieldDslType := match fieldData.find? (fun (fn_, _) => fn_ == qField) with
+            | some (_, ft) => ft
+            | none => ""
+          let isIntField := mapDslType fieldDslType == "Int"
+
+          -- Generate assignment string
+          if effectOp == "add" then
+            effectAssigns := effectAssigns.push s!"{qField} := s.{qField} + {effectValue}"
+          else
+            effectAssigns := effectAssigns.push s!"{qField} := s.{qField} - {effectValue}"
+            -- Auto-generate underflow guard for sub (skip for Int fields — subtraction is total)
+            if !isIntField then
+              autoGuards := autoGuards.push s!"{effectValue} ≤ s.{qField}"
+
+    let hasEffect := effectAssigns.size > 0
+
+    -- ----------------------------------------------------------------
+    -- Build condition parts: signer + lifecycle + guards
+    -- ----------------------------------------------------------------
+    let mut condParts : Array String := #[]
+    if hasSigner then
+      condParts := condParts.push s!"signer = s.{signer}"
+    if hasWhen then
+      condParts := condParts.push s!"s.status = .{preStatus}"
+    for g in autoGuards do
+      condParts := condParts.push g
+    if !guardStr.isEmpty then
+      condParts := condParts.push guardStr
+
+    let hasCond := condParts.size > 0
+    let ifCond := mkConj condParts
+
+    -- Collect per-operation assumptions
+    if hasSigner then
+      assumptions := assumptions.push s!"**Signer**: `{opNameRaw}` checks `signer = s.{signer}` (from `who: {signer}`)."
+    if hasWhen then
+      assumptions := assumptions.push s!"**Lifecycle**: `{opNameRaw}` requires `s.status = .{preStatus}` → `.{postStatus}`."
+    for g in autoGuards do
+      assumptions := assumptions.push s!"**Auto-guard**: `{opNameRaw}` has auto-generated underflow guard `{g}` from `effect: sub`."
+
+    -- ----------------------------------------------------------------
+    -- Build result state
+    -- ----------------------------------------------------------------
+    let mut withParts : Array String := #[]
+    for a in effectAssigns do
+      withParts := withParts.push a
+    if hasThen then
+      withParts := withParts.push s!"status := .{postStatus}"
+
+    let thenBody := mkSomeUpdate "s" withParts
+
+    -- ----------------------------------------------------------------
+    -- Generate transition function
+    -- ----------------------------------------------------------------
+    let letPrefix := letBindings.foldl (fun acc (ln, le) =>
+      acc ++ s!"  let {ln} := {le}\n") ""
+
+    if hasCond then
+      cmds := cmds.push (s!"def {transName} (s : State) (signer : Pubkey){paramSig} : Option State :=\n" ++
+        letPrefix ++
+        s!"  if {ifCond} then\n" ++
+        s!"    {thenBody}\n" ++
+        s!"  else none")
+    else
+      cmds := cmds.push (s!"def {transName} (s : State) (signer : Pubkey){paramSig} : Option State :=\n" ++
+        letPrefix ++
+        s!"  {thenBody}")
+
+    -- ----------------------------------------------------------------
+    -- CPI correctness theorem (if calls: clause present)
+    -- Structural proof — unique to Lean, typically pure rfl.
+    -- op[10]: calls clause (after operation name[1] doc?[2] who?[3] when?[4]
+    --          then?[5] takes?[6] let?[7] guard?[8] effect?[9])
+    -- ----------------------------------------------------------------
+    let cpiStx := op[10]
+    if !cpiStx.isMissing && cpiStx.getNumArgs > 0 then
+      -- cpiStx layout: "calls:" programId discriminator "(" specCpiAcct,* ")"
+      let cpiProgramId := cpiStx[1].getId.toString (escape := false)
+      let cpiDiscriminator := cpiStx[2].getId.toString (escape := false)
+
+      -- Parse CPI account declarations (index 4 is the specCpiAcct,* separator node)
+      let cpiAcctsStx := cpiStx[4]
+      let mut cpiAccounts : Array (String × Bool × Bool) := #[]
+      for i in List.range cpiAcctsStx.getArgs.size do
+        let arg := cpiAcctsStx.getArgs[i]!
+        -- In a separator node, even indices are specCpiAcct values, odd indices are commas
+        if i % 2 == 0 then
+          let acctName := arg[0].getId.toString (escape := false)
+          let flagStr := arg[1].getId.toString (escape := false)
+          match parseFlag flagStr with
+          | some (isSigner, isWritable) =>
+            cpiAccounts := cpiAccounts.push (acctName, isSigner, isWritable)
+          | none =>
+            throwError m!"qedspec: unknown account flag '{flagStr}' for account '{acctName}'. Use: readonly, writable, signer, signer_writable"
+
+      -- Use raw name for compound identifiers (CpiContext, build_cpi)
+      let cpiCtxName := quoteName s!"{opNameRaw}CpiContext"
+      let buildCpiName := quoteName s!"{opNameRaw}_build_cpi"
+
+      -- Generate CPI context structure
+      let ctxFieldPairs := cpiAccounts.map fun (acct, _, _) => (acct, "Pubkey")
+      cmds := cmds.push (mkStructure cpiCtxName ctxFieldPairs)
+
+      -- Generate build_cpi function
+      let mut accountsList := ""
+      for i in List.range cpiAccounts.size do
+        let (acct, isSigner, isWritable) := cpiAccounts[i]!
+        if i > 0 then accountsList := accountsList ++ ",\n      "
+        accountsList := accountsList ++
+          s!"⟨ctx.{acct}, {isSigner}, {isWritable}⟩"
+
+      cmds := cmds.push (
+        s!"def {buildCpiName} (ctx : {cpiCtxName}) : CpiInstruction :=\n" ++
+        s!"  \{ programId := {cpiProgramId}\n" ++
+        s!"  , accounts := [{accountsList}]\n" ++
+        s!"  , data := {cpiDiscriminator} }")
+
+      -- Generate cpi_correct theorem
+      let mut cpiParts : Array String := #[s!"targetsProgram cpi {cpiProgramId}"]
+      for i in List.range cpiAccounts.size do
+        let (acct, isSigner, isWritable) := cpiAccounts[i]!
+        cpiParts := cpiParts.push s!"accountAt cpi {i} ctx.{acct} {isSigner} {isWritable}"
+      cpiParts := cpiParts.push s!"hasDiscriminator cpi {cpiDiscriminator}"
+      let cpiConc := s!"let cpi := {buildCpiName} ctx\n    " ++ mkConj cpiParts
+      let cpiDoc := s!"{opNameRaw} CPI targets {cpiProgramId} with correct accounts and discriminator."
+      cmds := cmds.push (mkDocSorryTheorem s!"{opName}.cpi_correct" #[s!"(ctx : {cpiCtxName})"] cpiConc cpiDoc)
+
+    -- op[11] = emits? — Quasar-only, ignored by Lean elaborator
+    -- op[12] = context? — Quasar-only, ignored by Lean elaborator
+
+  for inv in invsStx.getArgs do
+    let invName := inv[1].getId.toString (escape := false)
+    let invDoc := s!"Invariant: {invName}."
+    cmds := cmds.push (mkDocSorryTheorem invName #[] "True" invDoc)
+
+  -- ================================================================
+  -- Operation inductive + applyOp dispatcher
+  -- Embeds per-operation parameters in constructors so the inductive
+  -- theorem quantifies over all operations uniformly.
+  -- ================================================================
+  if opParamsMap.size > 0 then
+    -- Build Operation inductive: each constructor carries its takes: params
+    let mut ctors := ""
+    for (opNameRaw, params) in opParamsMap do
+      let ctorName := quoteName opNameRaw
+      if params.isEmpty then
+        ctors := ctors ++ s!" | {ctorName}"
+      else
+        let paramFields := params.foldl (fun acc (pn, pt) =>
+          acc ++ s!" ({pn} : {mapType pt})") ""
+        ctors := ctors ++ s!" | {ctorName}{paramFields}"
+    cmds := cmds.push s!"inductive Operation where{ctors}\n  deriving Repr, DecidableEq, BEq"
+
+    -- Build applyOp dispatcher: matches Operation constructors to transition functions
+    let mut matchArms := ""
+    for (opNameRaw, params) in opParamsMap do
+      let ctorName := quoteName opNameRaw
+      let transName := quoteName s!"{opNameRaw}Transition"
+      let paramNames := params.foldl (fun acc (pn, _) => acc ++ s!" {pn}") ""
+      let paramArgs := mkParamArgs params
+      matchArms := matchArms ++ s!"\n  | .{ctorName}{paramNames} => {transName} s signer{paramArgs}"
+    cmds := cmds.push (s!"def applyOp (s : State) (signer : Pubkey) : Operation → Option State" ++ matchArms)
+
+  -- ================================================================
+  -- Property predicates + inductive preservation theorems
+  -- One sorry per property (not N×M per operation×property).
+  -- The agent proves by `cases op` then unfold/omega per case.
+  -- ================================================================
+  for prop in propsStx.getArgs do
+    let propName := prop[1].getId.toString (escape := false)
+    let predBody := prop[2].isStrLit?.getD ""
+
+    -- Validate field references in property predicate
+    if !predBody.isEmpty then
+      validateFieldRefs predBody fieldData s!"property '{propName}'"
+
+    -- Generate predicate definition: def propName (s : State) : Prop := <body>
+    cmds := cmds.push s!"def {propName} (s : State) : Prop := {predBody}"
+
+    -- Generate inductive preservation theorem (one sorry for all operations)
+    if opParamsMap.size > 0 then
+      let pvBinders : Array String := #[
+        "(s s' : State)", "(signer : Pubkey)", "(op : Operation)",
+        s!"(h_inv : {propName} s)",
+        "(h : applyOp s signer op = some s')"
+      ]
+      let pvDoc := s!"{propName} is preserved by every operation. Prove by `cases op` with unfold/omega per case."
+      cmds := cmds.push (mkDocSorryTheorem s!"{propName}_inductive" pvBinders s!"{propName} s'" pvDoc)
+
+  -- Emit assumptions summary as module doc
+  if assumptions.size > 0 then
+    let assumptionBody := assumptions.foldl (fun acc a => acc ++ s!"- {a}\n") ""
+    cmds := cmds.push (mkModuleDoc s!"## Assumptions made by qedspec\n\n{assumptionBody}")
+
+  cmds := cmds.push (mkEnd s!"{name}")
+
+  -- Parse and elaborate each command
+  let env ← getEnv
+  for src in cmds do
+    match Lean.Parser.runParserCategory env `command src "<qedspec>" with
+    | .error msg =>
+      throwError m!"qedspec: failed to parse generated code:\n{msg}\n\nSource:\n{src}"
+    | .ok cmdStx =>
+      elabCommand cmdStx
+
+end QEDGen.Solana.SpecDSL

--- a/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/State.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/State.lean
@@ -1,0 +1,64 @@
+import QEDGen.Solana.Account
+
+namespace QEDGen.Solana.State
+
+inductive Lifecycle
+  | open
+  | closed
+  deriving Repr, DecidableEq
+
+def closes (before after : Lifecycle) : Prop :=
+  before = Lifecycle.open /\ after = Lifecycle.closed
+
+-- Lifecycle is irreversible: once closed, always closed
+theorem closed_irreversible (p_lifecycle : Lifecycle) :
+    p_lifecycle = Lifecycle.closed → p_lifecycle ≠ Lifecycle.open := by
+  intro h
+  rw [h]
+  intro contra
+  cases contra
+
+-- Closes implies the result is closed
+theorem closes_is_closed (p_before p_after : Lifecycle) :
+    closes p_before p_after → p_after = Lifecycle.closed := by
+  intro h
+  exact h.2
+
+-- Closes implies the original was open
+theorem closes_was_open (p_before p_after : Lifecycle) :
+    closes p_before p_after → p_before = Lifecycle.open := by
+  intro h
+  exact h.1
+
+-- If already closed, cannot close again (closes requires open → closed)
+theorem closed_cannot_close (p_after : Lifecycle) :
+    ¬ closes Lifecycle.closed p_after := by
+  intro h
+  have := closes_was_open Lifecycle.closed p_after h
+  cases this
+
+-- Helper: decidable equality for lifecycle
+theorem lifecycle_eq_or_ne (p_l1 p_l2 : Lifecycle) :
+    p_l1 = p_l2 ∨ p_l1 ≠ p_l2 := by
+  cases p_l1 <;> cases p_l2 <;> simp
+
+end QEDGen.Solana.State
+
+namespace QEDGen.Solana
+
+abbrev Lifecycle := QEDGen.Solana.State.Lifecycle
+abbrev closes := QEDGen.Solana.State.closes
+abbrev closed_irreversible := QEDGen.Solana.State.closed_irreversible
+abbrev closes_is_closed := QEDGen.Solana.State.closes_is_closed
+abbrev closes_was_open := QEDGen.Solana.State.closes_was_open
+abbrev closed_cannot_close := QEDGen.Solana.State.closed_cannot_close
+abbrev lifecycle_eq_or_ne := QEDGen.Solana.State.lifecycle_eq_or_ne
+
+namespace Lifecycle
+
+abbrev «open» : QEDGen.Solana.Lifecycle := QEDGen.Solana.State.Lifecycle.open
+abbrev closed : QEDGen.Solana.Lifecycle := QEDGen.Solana.State.Lifecycle.closed
+
+end Lifecycle
+
+end QEDGen.Solana

--- a/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Valid.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/QEDGen/Solana/Valid.lean
@@ -1,0 +1,54 @@
+-- Validity predicates for state invariants
+--
+-- This module defines well-formedness predicates for program states.
+-- These capture preconditions that must hold for safe execution.
+
+import QEDGen.Solana.Account
+
+namespace QEDGen.Solana.Valid
+
+-- Type bound constants
+def U8_MAX : Nat := 255
+def U16_MAX : Nat := 65535
+def U32_MAX : Nat := 4294967295
+def U64_MAX : Nat := 18446744073709551615
+def U128_MAX : Nat := 340282366920938463463374607431768211455
+
+-- Validity predicates for numeric types
+def valid_u8 (n : Nat) : Prop := n <= U8_MAX
+def valid_u16 (n : Nat) : Prop := n <= U16_MAX
+def valid_u32 (n : Nat) : Prop := n <= U32_MAX
+def valid_u64 (n : Nat) : Prop := n <= U64_MAX
+def valid_u128 (n : Nat) : Prop := n <= U128_MAX
+
+-- Zero is always a valid u64
+theorem valid_u64_zero : valid_u64 0 := by
+  unfold valid_u64; omega
+
+-- Example: Generic ValidState template
+-- Users can define custom ValidState predicates for their programs
+--
+-- def ValidState (State : Type) : Prop :=
+--   ∃ (amount : Nat) (counter : Nat),
+--     valid_u64 amount ∧ valid_u64 counter
+
+end QEDGen.Solana.Valid
+
+namespace QEDGen.Solana
+
+-- Export validity predicates
+abbrev U8_MAX := QEDGen.Solana.Valid.U8_MAX
+abbrev U16_MAX := QEDGen.Solana.Valid.U16_MAX
+abbrev U32_MAX := QEDGen.Solana.Valid.U32_MAX
+abbrev U64_MAX := QEDGen.Solana.Valid.U64_MAX
+abbrev U128_MAX := QEDGen.Solana.Valid.U128_MAX
+
+abbrev valid_u8 := QEDGen.Solana.Valid.valid_u8
+abbrev valid_u16 := QEDGen.Solana.Valid.valid_u16
+abbrev valid_u32 := QEDGen.Solana.Valid.valid_u32
+abbrev valid_u64 := QEDGen.Solana.Valid.valid_u64
+abbrev valid_u128 := QEDGen.Solana.Valid.valid_u128
+
+abbrev valid_u64_zero := QEDGen.Solana.Valid.valid_u64_zero
+
+end QEDGen.Solana

--- a/examples/rust/escrow-split/formal_verification/lean_solana/lakefile.lean
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/lakefile.lean
@@ -1,0 +1,16 @@
+import Lake
+open Lake DSL
+
+-- Base lean_solana package. Pure Lean 4; no Mathlib dependency.
+-- Covers Account, Cpi, State, Valid, SBPF helpers — everything that
+-- doesn't need `Fin → α` / BigOperators reasoning.
+--
+-- The `IndexedState` module and anything else that needs Mathlib
+-- lives in the sibling `lean_solana_mathlib/` package; programs that
+-- need it depend on that one, which transitively pulls this.
+package qedgenSupport
+
+@[default_target]
+lean_lib QEDGen where
+  roots := #[`QEDGen]
+

--- a/examples/rust/escrow-split/formal_verification/lean_solana/lean-toolchain
+++ b/examples/rust/escrow-split/formal_verification/lean_solana/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.30.0-rc1

--- a/examples/rust/escrow-split/handlers/cancel.qedspec
+++ b/examples/rust/escrow-split/handlers/cancel.qedspec
@@ -12,9 +12,12 @@ handler cancel : State.Open -> State.Closed {
     token_program  : program
   }
 
-  transfers {
-    from escrow_ta to initializer_ta amount initializer_amount authority escrow
-  }
+  call Token.transfer(
+    from      = escrow_ta,
+    to        = initializer_ta,
+    amount    = initializer_amount,
+    authority = escrow,
+  )
 
   emits EscrowCancelled
 }

--- a/examples/rust/escrow-split/handlers/cancel.qedspec
+++ b/examples/rust/escrow-split/handlers/cancel.qedspec
@@ -1,0 +1,20 @@
+spec Escrow
+
+/// Initializer reclaims their deposit and closes the escrow
+handler cancel : State.Open -> State.Closed {
+  auth initializer
+
+  accounts {
+    initializer    : signer, writable
+    escrow         : writable, pda ["escrow", initializer]
+    escrow_ta      : writable, type token, authority escrow
+    initializer_ta : writable, type token
+    token_program  : program
+  }
+
+  transfers {
+    from escrow_ta to initializer_ta amount initializer_amount authority escrow
+  }
+
+  emits EscrowCancelled
+}

--- a/examples/rust/escrow-split/handlers/exchange.qedspec
+++ b/examples/rust/escrow-split/handlers/exchange.qedspec
@@ -13,10 +13,19 @@ handler exchange : State.Open -> State.Closed {
     token_program  : program
   }
 
-  transfers {
-    from taker_ta to initializer_ta amount taker_amount authority taker
-    from escrow_ta to taker_ta amount initializer_amount authority escrow
-  }
+  call Token.transfer(
+    from      = taker_ta,
+    to        = initializer_ta,
+    amount    = taker_amount,
+    authority = taker,
+  )
+
+  call Token.transfer(
+    from      = escrow_ta,
+    to        = taker_ta,
+    amount    = initializer_amount,
+    authority = escrow,
+  )
 
   emits EscrowExchanged
 }

--- a/examples/rust/escrow-split/handlers/exchange.qedspec
+++ b/examples/rust/escrow-split/handlers/exchange.qedspec
@@ -1,0 +1,22 @@
+spec Escrow
+
+/// Taker completes the trade by sending their tokens
+handler exchange : State.Open -> State.Closed {
+  auth taker
+
+  accounts {
+    taker          : signer, writable
+    escrow         : writable, pda ["escrow", initializer]
+    initializer_ta : writable, type token
+    taker_ta       : writable, type token
+    escrow_ta      : writable, type token, authority escrow
+    token_program  : program
+  }
+
+  transfers {
+    from taker_ta to initializer_ta amount taker_amount authority taker
+    from escrow_ta to taker_ta amount initializer_amount authority escrow
+  }
+
+  emits EscrowExchanged
+}

--- a/examples/rust/escrow-split/handlers/initialize.qedspec
+++ b/examples/rust/escrow-split/handlers/initialize.qedspec
@@ -21,9 +21,12 @@ handler initialize (deposit_amount : U64) (receive_amount : U64) : State.Uniniti
     taker_amount := receive_amount
   }
 
-  transfers {
-    from initializer_ta to escrow_ta amount deposit_amount authority initializer
-  }
+  call Token.transfer(
+    from      = initializer_ta,
+    to        = escrow_ta,
+    amount    = deposit_amount,
+    authority = initializer,
+  )
 
   emits EscrowInitialized
 }

--- a/examples/rust/escrow-split/handlers/initialize.qedspec
+++ b/examples/rust/escrow-split/handlers/initialize.qedspec
@@ -1,0 +1,29 @@
+spec Escrow
+
+/// Initializer deposits tokens and opens the escrow
+handler initialize (deposit_amount : U64) (receive_amount : U64) : State.Uninitialized -> State.Open {
+  auth initializer
+
+  accounts {
+    initializer    : signer, writable
+    escrow         : writable, pda ["escrow", initializer]
+    mint           : readonly
+    initializer_ta : writable, type token
+    escrow_ta      : writable, type token, authority escrow
+    token_program  : program
+    system_program : program
+  }
+
+  requires deposit_amount > 0 and receive_amount > 0 else InvalidAmount
+
+  effect {
+    initializer_amount := deposit_amount
+    taker_amount := receive_amount
+  }
+
+  transfers {
+    from initializer_ta to escrow_ta amount deposit_amount authority initializer
+  }
+
+  emits EscrowInitialized
+}

--- a/examples/rust/escrow-split/interfaces/token.qedspec
+++ b/examples/rust/escrow-split/interfaces/token.qedspec
@@ -1,0 +1,33 @@
+// Inlined SPL Token interface (Tier 1).
+//
+// Until v2.6 ships `import Token from "qedgen/interfaces/spl_token"`, every
+// caller needs the Token contract in its own spec closure. This fragment is
+// a direct copy of interfaces/spl_token.qedspec scoped to what Escrow
+// actually calls (`transfer` only). When import lands, delete this fragment
+// and add the import to escrow.qedspec instead.
+
+spec Escrow
+
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+  upstream {
+    package       "spl-token"
+    version       "4.0.3"
+    source        "https://github.com/solana-program/token/tree/v4.0.3"
+    verified_with ["proptest"]
+    verified_at   "2026-04-18"
+  }
+
+  /// Transfer `amount` tokens from `from` to `to`, authorized by `authority`.
+  handler transfer (amount : U64) {
+    discriminant "0x03"
+    accounts {
+      from      : writable, type token
+      to        : writable, type token
+      authority : signer
+    }
+    requires amount > 0
+    ensures  amount > 0
+  }
+}

--- a/examples/rust/escrow-split/properties.qedspec
+++ b/examples/rust/escrow-split/properties.qedspec
@@ -1,0 +1,9 @@
+spec Escrow
+
+invariant conservation "total tokens preserved across initialize, exchange, cancel"
+
+cover happy_path [initialize, exchange]
+
+cover cancel_path [initialize, cancel]
+
+liveness escrow_settles : State.Open ~> State.Closed via [exchange, cancel] within 1

--- a/examples/sbpf/counter/counter.qedspec
+++ b/examples/sbpf/counter/counter.qedspec
@@ -13,7 +13,7 @@
 
 spec Counter
 
-target assembly
+pragma sbpf {}
 
 const MAX_COUNTER = 18446744073709551615
 

--- a/examples/sbpf/dropset/dropset.qedspec
+++ b/examples/sbpf/dropset/dropset.qedspec
@@ -17,7 +17,7 @@
 
 spec Dropset
 
-target assembly
+pragma sbpf {}
 
 type State
   | Uninitialized

--- a/examples/sbpf/slippage/slippage.qedspec
+++ b/examples/sbpf/slippage/slippage.qedspec
@@ -7,7 +7,7 @@
 
 spec Slippage
 
-target assembly
+pragma sbpf {}
 
 type Error
   | SlippageExceeded = 1 "Token balance below minimum threshold"

--- a/examples/sbpf/transfer/transfer.qedspec
+++ b/examples/sbpf/transfer/transfer.qedspec
@@ -8,7 +8,7 @@
 
 spec Transfer
 
-target assembly
+pragma sbpf {}
 
 type Error
   | InvalidAccountCount           = 1 "Invalid number of accounts"

--- a/examples/sbpf/tree/tree.qedspec
+++ b/examples/sbpf/tree/tree.qedspec
@@ -10,7 +10,7 @@
 
 spec Tree
 
-target assembly
+pragma sbpf {}
 
 const HEADER_SIZE = 24
 const NODE_SIZE   = 29

--- a/interfaces/spl_token.qedspec
+++ b/interfaces/spl_token.qedspec
@@ -1,0 +1,98 @@
+// QEDGen library interface — SPL Token (Tier 1).
+//
+// Declarative contract for the SPL Token program. Callers that CPI into
+// Token.transfer / mint_to / burn / init_account / close_account get:
+//   - a real Rust CPI builder at the call site (v2.6, via `import`);
+//   - callee ensures bound as hypotheses in the caller's Lean proof (v2.6);
+//   - eventually (v2.7), full proof composition once we import the callee's
+//     proven Spec.lean instead of axiomatizing its ensures.
+//
+// In v2.5, before `import` lands, copy this file (or its relevant blocks)
+// into your spec directly. When `import Token from "qedgen/interfaces/spl_token"`
+// ships in v2.6, the copy becomes a one-line reference.
+//
+// See docs/design/spec-composition.md §2 "Tier 1 — effects hand-authored."
+
+spec SplTokenInterface
+
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+  upstream {
+    package      "spl-token"
+    version      "4.0.3"
+    source       "https://github.com/solana-program/token/tree/v4.0.3"
+    // TODO binary_hash — fill in after running QEDGen harnesses against the
+    // deployed program. The authoritative supply-chain pin lives here; until
+    // it's set, consumers who run `qedgen verify --check-upstream` will be
+    // told the library is un-pinned.
+    // binary_hash  "sha256:..."
+    // idl_hash     "sha256:..."
+    verified_with ["proptest"]
+    verified_at  "2026-04-18"
+  }
+
+  /// Transfer `amount` tokens from `from` to `to`, authorized by `authority`.
+  /// Balance-preserving: total supply unchanged, individual balances shift.
+  handler transfer (amount : U64) {
+    discriminant "0x03"
+    accounts {
+      from      : writable, type token
+      to        : writable, type token
+      authority : signer
+    }
+    requires amount > 0
+    ensures  amount > 0
+  }
+
+  /// Mint `amount` new tokens to `to`, authorized by `mint_authority`.
+  /// Not balance-preserving: total supply grows by `amount`.
+  handler mint_to (amount : U64) {
+    discriminant "0x07"
+    accounts {
+      mint            : writable
+      to              : writable, type token
+      mint_authority  : signer
+    }
+    requires amount > 0
+    ensures  amount > 0
+  }
+
+  /// Burn `amount` tokens from `from`, authorized by `authority`.
+  /// Not balance-preserving: total supply shrinks by `amount`.
+  handler burn (amount : U64) {
+    discriminant "0x08"
+    accounts {
+      from      : writable, type token
+      mint      : writable
+      authority : signer
+    }
+    requires amount > 0
+    ensures  amount > 0
+  }
+
+  /// Initialize a new token account owned by `owner` for `mint`.
+  /// Account pre-state: uninitialized. Post-state: zero balance, owned by `owner`.
+  handler initialize_account {
+    discriminant "0x01"
+    accounts {
+      account : writable
+      mint    : readonly
+      owner   : readonly
+      rent    : readonly
+    }
+  }
+
+  /// Close `account`, draining rent lamports to `destination`. The caller
+  /// must ensure the balance is zero — this interface does not enforce it
+  /// (SPL Token panics at runtime if non-zero; Tier 1 would add a
+  /// pre-condition once we're confident the runtime check is sufficient).
+  handler close_account {
+    discriminant "0x09"
+    accounts {
+      account     : writable, type token
+      destination : writable
+      authority   : signer
+    }
+  }
+}

--- a/references/cli.md
+++ b/references/cli.md
@@ -20,22 +20,35 @@ and `Proofs.lean`.
 ## Project setup
 
 ### `init`
-Scaffold a new formal verification project. Creates `.qed/` project state directory.
+Scaffold a new formal verification project. Creates `.qed/` project state
+directory and pins the spec path in `.qed/config.json` so subsequent
+commands don't need `--spec`.
 
 ```bash
-$QEDGEN init --name escrow
-$QEDGEN init --name dropset --asm src/dropset.s
-$QEDGEN init --name engine --mathlib
-$QEDGEN init --name counter --quasar
+$QEDGEN init --name escrow   --spec escrow.qedspec
+$QEDGEN init --name dropset  --spec dropset.qedspec --asm src/dropset.s
+$QEDGEN init --name engine   --spec engine.qedspec --mathlib
+$QEDGEN init --name counter  --spec counter.qedspec --quasar
 ```
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--name` | String | required | Project name (alphanumeric + underscores) |
+| `--spec` | Path | - | Spec path (file or directory) — written into `.qed/config.json` so `check`/`codegen` can resolve it automatically |
 | `--asm` | Path | - | sBPF assembly source (runs asm2lean automatically) |
 | `--mathlib` | bool | false | Include Mathlib dependency |
 | `--quasar` | bool | false | Generate Quasar program + Kani harnesses + tests |
 | `--output-dir` | Path | `./formal_verification` | Output directory |
+
+The written `.qed/config.json`:
+
+```json
+{
+  "name": "escrow",
+  "spec": "escrow.qedspec",
+  "interfaces_dir": ".qed/interfaces"
+}
+```
 
 ### `setup`
 Set up the global validation workspace at `~/.qedgen/workspace/`.
@@ -65,8 +78,36 @@ $QEDGEN asm2lean --input src/program.s --output formal_verification/Prog.lean
 
 ## Spec and validation
 
+### `interface`
+Generate a Tier-0 interface `.qedspec` from an Anchor IDL. Shape only —
+program ID, discriminator, accounts, argument types. No `requires`/
+`ensures`/`effect` (those require semantic understanding the IDL does not
+carry). The `upstream` block is left as a TODO stub for the author to fill
+in after running QEDGen harnesses against the deployed program.
+
+See `docs/design/spec-composition.md` §2 for the CPI tier model.
+
+```bash
+# Print to stdout
+$QEDGEN interface --idl target/idl/jupiter.json
+
+# Write to an explicit path
+$QEDGEN interface --idl target/idl/jupiter.json --out interfaces/jupiter.qedspec
+
+# Vendor into .qed/interfaces/<program>.qedspec (canonical library location,
+# resolved via the nearest .qed/config.json)
+$QEDGEN interface --idl target/idl/jupiter.json --vendor
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--idl` | Path | required | Anchor IDL JSON file |
+| `--out` | Path | - | Output path (default: stdout). Conflicts with `--vendor`. |
+| `--vendor` | bool | false | Drop into `.qed/interfaces/<program>.qedspec`. Requires a discoverable `.qed/` ancestor. |
+
 ### `spec`
-Generate SPEC.md or .qedspec from IDL or .qedspec.
+Generate SPEC.md or .qedspec from IDL or .qedspec. (For Tier-0 interface
+scaffolding from an IDL, prefer `interface` — it's more focused.)
 
 ```bash
 $QEDGEN spec --idl target/idl/program.json
@@ -87,16 +128,23 @@ Validate a spec — lint, coverage, drift, and verification report. Default (no 
 
 Requires a git repo (see [Require-git guard](#require-git-guard)).
 
+`--spec` is optional — when omitted, walks up from the current directory to
+the nearest `.qed/config.json` and uses its `spec` field. Explicit `--spec`
+overrides.
+
 ```bash
-# Lint (always runs)
+# From inside a project initialized with `qedgen init --spec ...`
+$QEDGEN check
+$QEDGEN check --json
+
+# Explicit spec path
 $QEDGEN check --spec my_program.qedspec
-$QEDGEN check --spec my_program.qedspec --json
 
 # Coverage matrix
-$QEDGEN check --spec my_program.qedspec --coverage
+$QEDGEN check --coverage
 
 # Verification report
-$QEDGEN check --spec my_program.qedspec --explain
+$QEDGEN check --explain
 $QEDGEN check --spec my_program.qedspec --explain --output report.md
 
 # Drift detection
@@ -113,7 +161,7 @@ $QEDGEN check --spec my_program.qedspec --asm src/program.s
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--spec` | Path | required | Spec file (.qedspec) |
+| `--spec` | Path | optional | Spec file or directory. Defaults to `.qed/config.json spec` |
 | `--proofs` | Path | `./formal_verification` | Proofs directory |
 | `--coverage` | bool | false | Show operation × property matrix |
 | `--explain` | bool | false | Generate Markdown verification report |
@@ -125,6 +173,11 @@ $QEDGEN check --spec my_program.qedspec --asm src/program.s
 | `--kani` | Path | - | Kani harness file (Kani drift detection) |
 | `--asm` | Path | - | sBPF assembly source (hash check + lake build) |
 | `--json` | bool | false | Machine-readable output |
+
+Lints fired by `check` include `[shape_only_cpi]` for `call
+Interface.handler(...)` sites whose target declares no `ensures` —
+making the visible gap between "my Rust compiles" and "my program is
+verified" explicit.
 
 ### `reconcile`
 Emit a unified drift report comparing a `.qedspec` against both its Rust
@@ -187,25 +240,29 @@ the Quasar Rust skeleton only.
 
 Requires a git repo (see [Require-git guard](#require-git-guard)).
 
-```bash
-# Rust skeleton only
-$QEDGEN codegen --spec my_program.qedspec
+`--spec` is optional — when omitted, resolved via the nearest
+`.qed/config.json`'s `spec` field. Explicit `--spec` overrides.
 
-# Everything
+```bash
+# From inside a project initialized with `qedgen init --spec ...`
+$QEDGEN codegen
+$QEDGEN codegen --all
+
+# Explicit spec path
 $QEDGEN codegen --spec my_program.qedspec --all
 
 # Selective
-$QEDGEN codegen --spec my_program.qedspec --lean
-$QEDGEN codegen --spec my_program.qedspec --kani
-$QEDGEN codegen --spec my_program.qedspec --test
-$QEDGEN codegen --spec my_program.qedspec --proptest
-$QEDGEN codegen --spec my_program.qedspec --integration
-$QEDGEN codegen --spec my_program.qedspec --ci
+$QEDGEN codegen --lean
+$QEDGEN codegen --kani
+$QEDGEN codegen --test
+$QEDGEN codegen --proptest
+$QEDGEN codegen --integration
+$QEDGEN codegen --ci
 ```
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--spec` | Path | required | Spec file (.qedspec) |
+| `--spec` | Path | optional | Spec file or directory. Defaults to `.qed/config.json spec` |
 | `--output-dir` | Path | `./programs` | Output directory for Rust skeleton |
 | `--all` | bool | false | Generate all artifacts |
 | `--lean` | bool | false | Generate Lean 4 proofs |

--- a/references/qedspec-dsl.md
+++ b/references/qedspec-dsl.md
@@ -1,16 +1,34 @@
 # qedspec DSL Reference
 
 The `.qedspec` file is the single source of truth for a program's formal
-specification. QEDGen parses it (chumsky parser, as of v2.3), validates it
-(`qedgen check`), and generates all downstream artifacts: Quasar Rust code,
-Lean proofs, Kani harnesses, proptest suites, CI workflows, and the
+specification. QEDGen parses it (chumsky parser), validates it (`qedgen
+check`), and generates all downstream artifacts: Quasar Rust code, Lean
+proofs, Kani harnesses, proptest suites, CI workflows, and the
 `#[qed(verified, spec, handler, spec_hash)]` drift attributes that tie
 generated code back to the spec.
 
-This reference covers the current (v2.3) grammar. Where the parser emits a
+This reference covers the current (v2.5) grammar. Where the parser emits a
 specific AST node shape that influences codegen (match, constructors, record
 updates, `mul_div_*`), the node name is called out so you can follow the
 transform into the Lean/Rust backends.
+
+## What changed in v2.5
+
+- **`pragma <name> { ... }`** — platform-specific namespace. sBPF-specific
+  constructs (`instruction`, `pubkey`, top-level `errors [...]`) now live
+  only inside `pragma sbpf { ... }`. See *Pragmas* below.
+- **`target` keyword removed.** Target is inferred from pragma presence —
+  `pragma sbpf` → assembly target, absent → Quasar/Anchor (the default).
+- **`assembly "..."` keyword removed.** Assembly source path is tooling
+  config, not spec intent — pass `qedgen asm2lean --input <path>` or use
+  the convention of `src/program.s` next to the spec.
+- **`interface Name { ... }` + `call Target.handler(...)`** — declarative
+  CPI contracts. See *Interface declarations*.
+- **Multi-file specs.** `parse_spec_file` accepts a directory of `.qedspec`
+  fragments (all declaring the same `spec Name`); fragments are merged
+  deterministically in sorted-path order.
+- **`let x = v in body` in expressions** — ML-style binding inside
+  `ensures` / `requires` / effect RHS.
 
 ## File structure
 
@@ -18,9 +36,7 @@ transform into the Lean/Rust backends.
 spec ProgramName
 
 // Top-level declarations (any order)
-target quasar              // or: target assembly
 program_id "1111...1111"
-assembly "src/program.s"   // sBPF only
 
 const MAX_MEMBERS = 32
 
@@ -28,6 +44,9 @@ type State
   | Uninitialized
   | Active of { authority : Pubkey, balance : U64 }
   | Closed
+
+interface Token { ... }     // callee contracts for CPI
+pragma sbpf { ... }         // platform-specific namespace (opt-in; selects sBPF target)
 
 handler initialize ...
 property conservation ...
@@ -39,6 +58,31 @@ environment oracle { ... }
 
 Comments: `//` line comments, `///` doc comments (attached to the next item).
 
+## Multi-file specs
+
+`qedgen check --spec <path>` accepts either a single `.qedspec` file or a
+directory of fragments. In directory mode, every `*.qedspec` under the path
+(recursively) is parsed, and all fragments must declare the same `spec
+Name`. Top items are merged in alphabetically-sorted source-path order —
+both the merged `ParsedSpec` and every downstream artifact are
+deterministic.
+
+Convention-based layout (no new grammar required):
+
+```
+my-program/
+  escrow.qedspec            # spec header + types + events + errors
+  handlers/
+    initialize.qedspec      # spec Escrow + handler initialize { ... }
+    exchange.qedspec        # spec Escrow + handler exchange { ... }
+    cancel.qedspec          # spec Escrow + handler cancel { ... }
+  properties.qedspec        # spec Escrow + invariants + covers + liveness
+  interfaces/               # scoped copies of library interfaces
+    token.qedspec           # spec Escrow + interface Token { ... }
+```
+
+See `examples/rust/escrow-split/` for a concrete demo.
+
 ## Top-level declarations
 
 ### `spec`
@@ -49,30 +93,12 @@ Required header. Names the program.
 spec Escrow
 ```
 
-### `target`
-
-Declares the compilation target. Affects which codegen backends and
-sBPF-specific constructs are available.
-
-```
-target quasar       // Anchor/Quasar Rust programs (default)
-target assembly     // sBPF assembly programs
-```
-
 ### `program_id`
 
 On-chain program address.
 
 ```
 program_id "11111111111111111111111111111111"
-```
-
-### `assembly`
-
-Path to the sBPF assembly source (assembly target only).
-
-```
-assembly "src/program.s"
 ```
 
 ### `const`
@@ -82,16 +108,6 @@ Named integer constants. Underscores allowed for readability.
 ```
 const MAX_MEMBERS = 32
 const MAX_VAULT_TVL = 10_000_000_000_000_000
-```
-
-### `pubkey`
-
-Named pubkey as four `U64` chunks (sBPF target). Matches how an sBPF program
-materializes a 32-byte pubkey in registers.
-
-```
-pubkey SYSTEM_PROGRAM_ID [0, 0, 0, 0]
-pubkey RENT_SYSVAR_ID    [0x6a7d51..., 0xb8b9f5..., 0xc01b2f..., 0xb85e22...]
 ```
 
 ## Type system
@@ -207,21 +223,27 @@ event PoolInitialized { authority : Pubkey, rate : U64 }
 event Deposited       { depositor : Pubkey, amount : U64 }
 ```
 
-## Error declarations (sugar)
+## Error declarations
 
-`errors [...]` is a legacy sugar for a flat error list. Prefer
-`type Error | ...`; both desugar to the same internal representation.
+At the top level, declare errors with `type Error | Variant | ...`:
 
 ```
-// Simple list
-errors [Unauthorized, InvalidAmount, AlreadyClosed]
-
-// Valued list (sBPF compat)
-errors [
-  InvalidAccountCount  = 1 "Invalid number of accounts",
-  InsufficientLamports = 7 "Sender has insufficient lamports",
-]
+type Error
+  | Unauthorized
+  | InvalidAmount
+  | AlreadyClosed
 ```
+
+Valued form (with codes + descriptions) uses the same ADT syntax:
+
+```
+type Error
+  | InvalidAccountCount  = 1 "Invalid number of accounts"
+  | InsufficientLamports = 7 "Sender has insufficient lamports"
+```
+
+The `errors [ ... ]` list-sugar is v2.5-restricted to inside `pragma sbpf
+{ ... }` — see the sBPF section.
 
 ## Handlers
 
@@ -432,6 +454,11 @@ sum i : AccountIdx, state.accounts[i].capital
 
 // Parenthesized
 (amount + fee) * rate
+
+// Let-in binding — derive a value once, reference it by name.
+// Lowers to Lean's `let x := v; body`, Rust `{ let x = v; body }`.
+// Useful in ensures to name the quantity you're asserting about:
+ensures let delta = old(state.balance) - state.balance in delta == amount
 ```
 
 ### Constructors, record literals, record updates
@@ -600,17 +627,102 @@ environment interest_rate_change {
 }
 ```
 
-## sBPF-specific constructs
+## Pragmas
 
-For `target assembly` specs, additional top-level blocks model sBPF program
-structure. See `examples/sbpf/dropset/dropset.qedspec` for a comprehensive
-example that combines most of them.
-
-### `target assembly` and `assembly "path"`
+`pragma <name> { <items> }` wraps platform-specific declarations in a named
+namespace. Pragmas keep the core DSL platform-agnostic: constructs that only
+make sense for one target live inside their pragma block, not at the top
+level.
 
 ```
-target assembly
-assembly "src/dropset.s"
+pragma sbpf { ... }    // sBPF assembly programs
+```
+
+The presence of `pragma sbpf` also selects the assembly target — no explicit
+`target` keyword needed. Absent → Quasar/Anchor (the default).
+
+Body whitelist for `pragma sbpf`: `const`, `pubkey`, `instruction`, `errors`.
+Core DSL items (`handler`, `type`, `property`, `invariant`, `interface`, …)
+stay at the top level.
+
+## Interface declarations
+
+Contracts for programs you CPI into. Uniform surface across three tiers:
+
+- **Tier 0** — shape only: `program_id`, handler discriminant, accounts, args.
+  Generated by `qedgen interface --idl target/idl/program.json`.
+- **Tier 1** — hand-authored `requires` / `ensures` on handlers. The caller's
+  Lean proof gets real hypotheses at each `call` site.
+- **Tier 2** — the interface is a real imported `.qedspec` (v2.6+). No
+  `interface` keyword needed — every handler in the imported spec is public.
+
+```
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+  upstream {
+    package       "spl-token"
+    version       "4.0.3"
+    binary_hash   "sha256:..."      // deployed .so, authoritative
+    verified_with ["proptest", "kani"]  // honest — "lean" only when proven
+    verified_at   "2026-04-18"
+  }
+
+  handler transfer (amount : U64) {
+    discriminant "0x03"
+    accounts {
+      from      : writable, type token
+      to        : writable, type token
+      authority : signer
+    }
+    requires amount > 0
+    ensures  amount > 0
+  }
+}
+```
+
+See `docs/design/spec-composition.md` §2 for the tier model and
+`interfaces/spl_token.qedspec` for the canonical SPL Token interface.
+
+### `call Target.handler(name = expr, ...)` clause
+
+Inside a handler body, a `call` is a terminal statement — the uniform CPI
+surface. Not an expression, not nestable.
+
+```
+handler exchange : State.Open -> State.Closed {
+  call Token.transfer(
+    from      = taker_ta,
+    to        = initializer_ta,
+    amount    = taker_amount,
+    authority = taker,
+  )
+  emits EscrowExchanged
+}
+```
+
+`qedgen check` emits `[shape_only_cpi]` on calls whose target declares no
+`ensures` — the visible gap between "my Rust compiles" and "my program is
+verified."
+
+## sBPF-specific constructs (inside `pragma sbpf { ... }`)
+
+Everything in this section lives inside `pragma sbpf { ... }`. The pragma
+wrapping is mandatory in v2.5; the grammar rejects these items at the top
+level. See `examples/sbpf/dropset/dropset.qedspec` for a full example.
+
+```
+pragma sbpf {
+  pubkey SYSTEM_PROGRAM_ID [0, 0, 0, 0]
+  pubkey RENT_SYSVAR_ID    [0x6a7d51..., 0xb8b9f5..., 0xc01b2f..., 0xb85e22...]
+
+  errors [
+    InvalidDiscriminant        = 1  "Discriminant is not REGISTER_MARKET",
+    InvalidInstructionLength   = 2  "Instruction data is not 1 byte",
+  ]
+
+  instruction register_market { ... }
+}
 ```
 
 ### `pubkey NAME [u64, u64, u64, u64]`
@@ -618,23 +730,11 @@ assembly "src/dropset.s"
 32-byte pubkeys as four `U64` chunks — the form the sBPF program will compare
 against in registers.
 
-```
-pubkey SYSTEM_PROGRAM_ID [0, 0, 0, 0]
-pubkey RENT_SYSVAR_ID    [0x6a7d51..., 0xb8b9f5..., 0xc01b2f..., 0xb85e22...]
-```
-
 ### `errors [ NAME = CODE "msg", ... ]`
 
-Top-level error list used for exit-code reasoning in sBPF properties. Equivalent
-to the Rust-side `type Error | ...`.
-
-```
-errors [
-  InvalidDiscriminant        = 1  "Discriminant is not REGISTER_MARKET",
-  InvalidInstructionLength   = 2  "Instruction data is not 1 byte",
-  InvalidNumberOfAccounts    = 3  "Fewer than 10 accounts provided",
-]
-```
+Error list used for exit-code reasoning in sBPF properties. Anchor-style
+programs use `type Error | ...` at the top level instead — this sugar is
+sBPF-only.
 
 ### `instruction NAME { ... }` block
 

--- a/references/qedspec-dsl.md
+++ b/references/qedspec-dsl.md
@@ -58,6 +58,29 @@ environment oracle { ... }
 
 Comments: `//` line comments, `///` doc comments (attached to the next item).
 
+## Project pinning — `.qed/config.json`
+
+`qedgen init --name <name> --spec <path>` records the authored spec's
+location in `.qed/config.json`:
+
+```json
+{
+  "name": "escrow",
+  "spec": "escrow.qedspec",           // path, relative to the project root
+  "interfaces_dir": ".qed/interfaces" // vendored library interfaces
+}
+```
+
+`qedgen check` / `qedgen codegen` with no `--spec` argument walk upward from
+the current directory, find the nearest `.qed/config.json`, and resolve the
+spec via the `spec` field. Explicit `--spec <path>` still overrides the
+config — useful for scripts or one-off checks against a different spec.
+
+Authored `.qedspec` files stay at the program root (visible, committed,
+user-edited). Tool-managed library interfaces live under
+`.qed/interfaces/` and are dropped there by `qedgen interface --idl
+<path> --vendor`.
+
 ## Multi-file specs
 
 `qedgen check --spec <path>` accepts either a single `.qedspec` file or a


### PR DESCRIPTION
## Summary

v2.5 reshapes the `.qedspec` DSL around **composable specifications**:
multi-file layout, first-class CPI contracts via `interface`/`call`,
upstream-pinned library specs with `binary_hash`, `.qed/config.json` spec
discovery, and a cleaner core surface with platform-specifics tucked
behind `pragma sbpf { ... }`. ML touch — `let x = v in body` in
expressions.

All Anchor/Quasar specs are additive; breaking only for sBPF specs
(mechanical rewrite, all five bundled examples migrated).

## What's new

### Spec composition

- **Multi-file spec loader** — `qedgen check --spec <dir>` accepts a directory of `.qedspec` fragments that all declare the same `spec Name`. Deterministic merge in sorted-path order. See `examples/rust/escrow-split/`.
- **`interface Name { ... }` + `call Target.handler(...)`** — declarative CPI contracts. Three tiers: shape-only (Tier 0, from IDL), hand-authored `ensures` (Tier 1), imported qedspec (Tier 2, v2.6+). Uniform `call` site; backends produce weaker or stronger artifacts based on what's declared.
- **`upstream { ... }` block** — pins a library interface to the exact deployed `.so` via `binary_hash`. `verified_with` is an honest list (`"lean"` appears only when the callee is genuinely proven, not axiomatized). Canonical SPL Token interface at `interfaces/spl_token.qedspec`.
- **`qedgen interface --idl <path>`** — scaffold a Tier-0 interface from an Anchor IDL. `--vendor` drops into `.qed/interfaces/`.
- **`[shape_only_cpi]` lint** — flags `call` sites whose target interface has no `ensures`. Three tailored sub-cases. Makes the gap between "my Rust compiles" and "my program is verified" visible.

### Project pinning

- **`.qed/config.json`** gets `spec` + `interfaces_dir` fields. `qedgen check` / `codegen` with no `--spec` walk up from cwd and resolve via the config. Explicit `--spec` still overrides.

### DSL hygiene

- **`pragma <name> { ... }`** — platform-specific namespace. sBPF constructs (`instruction`, `pubkey`, list-form `errors`) are pragma-only; the grammar enforces the discipline at the top level.
- **`target` keyword removed** — inferred from `has_pragma("sbpf")`. One source of truth via `ParsedSpec::is_assembly_target()`.
- **`assembly "..."` keyword removed** — tooling config, not spec intent. Pass `qedgen asm2lean --input <path>`.

### ML expression syntax

- **`let x = v in body`** — ML-style expression binding inside `ensures`/`requires`/effect RHS. Lowers to Lean's `let x := v; body` and Rust `{ let x = v; body }`.
- Pattern matching + variant constructors + record updates — confirmed already supported end-to-end; smoke test added.

## Breaking changes

- sBPF `.qedspec` files must wrap `instruction` / `pubkey` / `errors [...]` in `pragma sbpf { ... }`. Five bundled sBPF examples (counter / transfer / slippage / dropset / tree) migrated in-branch.
- `target assembly | quasar` no longer parses.
- `assembly "..."` no longer parses.

## Docs

- `docs/design/spec-composition.md` — full architecture note (tier model, upstream pinning, qedlock direction for v2.6+).
- `references/qedspec-dsl.md` — rewritten; new Pragmas, Interface declarations, Multi-file specs, Project pinning sections.
- `references/cli.md` — new `interface` command documented; `--spec` flagged optional; `--vendor` semantics covered; `init --spec` example.
- `README.md` + `SKILL.md` — v2.5 features in quick start; SKILL phase map expanded to three phases (Spec Design, Proof Engineering, Audit / drift maintenance) marking future agent-split cut-lines.

## Test plan

- [x] `cargo test` — 155 pass, 0 fail
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] Zero `sorry` proof terms in `examples/**.lean`
- [x] All 8 shipped example specs parse clean (3 Anchor + 5 sBPF + escrow-split composition demo)
- [x] `qedgen check` discovery smoke-tested from escrow/ and escrow/src/ (walk-up works)
- [x] `qedgen interface --idl --vendor` smoke-tested against escrow IDL — landed at `.qed/interfaces/escrow.qedspec`
- [x] Single-file escrow ↔ escrow-split round-trip produces identical `spec_hash` attributes and lint output
- [ ] `lake build` across `examples/*/formal_verification/` (not run locally — intended for CI)

## Commits

17 commits grouped into 4 themes:

1. **Multi-file + composition design** (3 commits): `8ed34d9`, `c7199cd`, `8434e76`
2. **Interface + call + codegen + lint** (4 commits): `a673ed3`, `6ff6378`, `a8afc6d`, `fba4a94`
3. **Pragma + DSL hygiene** (3 commits): `eac3150`, `e56a115`, `06ba99e`
4. **ML syntax + pinning + docs + release** (7 commits): `95d9e78`, `affee84`, `783c263`, `685c5ee`, `9b94a43`, `7f47bd2`, `493ce32` + `4c07a88`

🤖 Generated with [Claude Code](https://claude.com/claude-code)