### PR TITLE
feat(qed): ratchet — upgrade-safety + mainnet-readiness lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +247,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +314,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -873,6 +914,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "solana-ratchet-anchor",
+ "solana-ratchet-core",
  "syn",
  "tar",
  "tempfile",
@@ -931,7 +974,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1103,6 +1146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1219,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1279,6 +1337,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-ratchet-anchor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0e8eae5b0d3cae5004618783ae666cd831e1c140e790182ab46ee2746b0b6b"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bs58",
+ "curve25519-dalek",
+ "flate2",
+ "serde",
+ "serde_json",
+ "sha2",
+ "solana-ratchet-core",
+]
+
+[[package]]
+name = "solana-ratchet-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cecef771b04bee977bfe369c790ea6623d0c5b60e9dbd030e6487e01ca20e7"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,7 +1380,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npx skills add qedgen/solana-skills
 | **Input validation** | Account count, duplicates, data length, discriminators, parameter bounds — each guard maps to a specific error exit |
 | **Memory correctness** | Stack/heap disjointness, pointer arithmetic (sBPF) |
 | **PDA integrity** | Program-derived address derivation and 4-chunk comparison (sBPF) |
-| **Deploy safety** | On-chain shape — version fields, reserved padding, pinned discriminators, signer coverage, PDA seed continuity — via `qedgen readiness` and `qedgen check-upgrade` (ratchet). |
+| **Deploy safety** | On-chain shape for Anchor programs — version fields, reserved padding, pinned discriminators, signer coverage, PDA seed continuity — via `qedgen readiness` and `qedgen check-upgrade` (ratchet). |
 
 CPI calls are axiomatic — we verify the program passes correct parameters. SPL Token internals and the Solana runtime are trusted.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ npx skills add qedgen/solana-skills
 | **Input validation** | Account count, duplicates, data length, discriminators, parameter bounds — each guard maps to a specific error exit |
 | **Memory correctness** | Stack/heap disjointness, pointer arithmetic (sBPF) |
 | **PDA integrity** | Program-derived address derivation and 4-chunk comparison (sBPF) |
+| **Deploy safety** | On-chain shape — version fields, reserved padding, pinned discriminators, signer coverage, PDA seed continuity — via `qedgen readiness` and `qedgen check-upgrade` (ratchet). |
 
 CPI calls are axiomatic — we verify the program passes correct parameters. SPL Token internals and the Solana runtime are trusted.
+
+**Proofs prove correctness. Ratchet proves deployability.** The P-rule preflight (`qedgen readiness`) catches future-upgrade landmines in a single IDL before the first deploy; the R-rule diff (`qedgen check-upgrade`) catches every breaking change between an old and new IDL once the program is live.
 
 ## Quick start
 
@@ -287,7 +290,29 @@ qedgen consolidate \
 ```bash
 qedgen codegen --spec my_program.qedspec --ci                    # Lean-only verification workflow
 qedgen codegen --spec my_program.qedspec --ci --ci-asm src/program.s  # Add sBPF source hash check
+qedgen codegen --spec my_program.qedspec --ci --ci-ratchet target/idl/my_program.json  # + ratchet readiness lint on every build
 ```
+
+### Deploy-safety lint (ratchet)
+
+`qedgen readiness` runs before the first deploy: one Anchor IDL in, a verdict out (`READY`, `UNSAFE`, or `BREAKING`) plus every specific future-upgrade landmine it finds. `qedgen check-upgrade` runs on every subsequent release: diff the deployed IDL against the candidate and fail the build on any change that would silently corrupt on-chain state, break existing clients, or orphan PDAs.
+
+```bash
+# Pre-deploy — lint one IDL for mainnet-readiness
+qedgen readiness --idl target/idl/my_program.json
+qedgen readiness --idl target/idl/my_program.json --json          # machine-readable
+
+# Post-deploy — diff old vs new and block breaking upgrades
+qedgen check-upgrade --old ratchet.lock --new target/idl/my_program.json
+
+# Acknowledge an intentional unsafe change
+qedgen check-upgrade --old ratchet.lock --new target/idl/my_program.json \
+  --unsafe allow-field-append --migrated-account EscrowState
+```
+
+Exit codes mirror ratchet's CLI conventions: `0 = additive/safe`, `1 = breaking`, `2 = unsafe`. Under the hood qedgen embeds [ratchet](https://github.com/saicharanpogul/ratchet) as a library, so the rule catalog stays in sync with upstream — run `ratchet list-rules` to see the full P-rule and R-rule set (22 rules at the time of writing).
+
+**Why both.** qedgen's `#[qed(verified)]` hash-stamps the *function body*, so a rename of an `#[account]` struct compiles with a stale-but-valid proof even though the on-chain discriminator is now different and every existing account of that type is orphaned. `qedgen check-upgrade`'s `R006 account-discriminator-change` catches that class of failure; the proof layer alone doesn't look at it.
 
 ## Examples
 

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -27,5 +27,14 @@ tar = "0.4"
 flate2 = "1"
 chumsky = "0.12"
 
+# ratchet — upgrade-safety + mainnet-readiness lint.
+# `ratchet-anchor` default-features is off to drop `ureq` (ratchet's RPC
+# fetcher), which we don't need: qedgen hands ratchet an IDL JSON file it
+# already has on disk, never an on-chain pubkey. The `package = …`
+# aliases keep the import path (`ratchet_core::`, `ratchet_anchor::`)
+# short without renaming the upstream crates.
+ratchet-core = { package = "solana-ratchet-core", version = "0.3" }
+ratchet-anchor = { package = "solana-ratchet-anchor", version = "0.3", default-features = false }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -21,6 +21,7 @@ mod lean_gen;
 mod project;
 mod proofs_bootstrap;
 mod proptest_gen;
+mod ratchet;
 mod reconcile;
 mod rust_codegen_util;
 mod sbpf_verify;
@@ -320,6 +321,64 @@ enum Commands {
         json: bool,
     },
 
+    /// Lint one Anchor IDL for mainnet-readiness before first deploy.
+    ///
+    /// Runs the ratchet P-rule preflight on the IDL and reports every
+    /// future-upgrade landmine it finds — missing `version: u8` prefix,
+    /// no `_reserved` trailing padding, unpinned discriminators, name
+    /// collisions, writable accounts with no signer. Complements
+    /// `qedgen check` / `qedgen verify` (which prove semantics) by
+    /// proving the on-chain shape is safe to evolve.
+    ///
+    /// Exit codes: 0 = additive/safe, 1 = breaking, 2 = unsafe.
+    Readiness {
+        /// Path to the Anchor IDL JSON (typically target/idl/<program>.json)
+        #[arg(long)]
+        idl: PathBuf,
+
+        /// Output as JSON (for agent / CI consumption)
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Diff an old vs new Anchor IDL and flag every upgrade-unsafe change.
+    ///
+    /// Runs the ratchet R-rule engine over the pair. Catches the
+    /// failure modes `solana program upgrade` won't — field reorders,
+    /// discriminator changes, orphaned accounts, PDA seed drift,
+    /// signer/writable tightening.
+    ///
+    /// Exit codes: 0 = additive/safe, 1 = breaking, 2 = unsafe.
+    CheckUpgrade {
+        /// Path to the baseline IDL (the one on-chain today).
+        #[arg(long)]
+        old: PathBuf,
+
+        /// Path to the candidate IDL (the one the upgrade would ship).
+        #[arg(long)]
+        new: PathBuf,
+
+        /// Acknowledge a specific unsafe finding so it reports as
+        /// additive instead (repeatable). See `ratchet list-rules` for
+        /// the full flag catalog.
+        #[arg(long = "unsafe")]
+        unsafes: Vec<String>,
+
+        /// Declare an account as having a migration in source; demotes
+        /// R003/R004 findings for that account to Additive (repeatable).
+        #[arg(long = "migrated-account")]
+        migrated_accounts: Vec<String>,
+
+        /// Declare an account as having `realloc = ...` in source;
+        /// demotes R005 for that account to Additive (repeatable).
+        #[arg(long = "realloc-account")]
+        realloc_accounts: Vec<String>,
+
+        /// Output as JSON (for agent / CI consumption)
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Generate committed artifacts from a qedspec
     ///
     /// Default (no flags): generates Quasar Rust skeleton only.
@@ -386,6 +445,14 @@ enum Commands {
         /// sBPF assembly source file (for CI workflow)
         #[arg(long)]
         ci_asm: Option<String>,
+
+        /// Path to the Anchor IDL the generated CI should lint with
+        /// `qedgen readiness`. When set, the emitted verify.yml runs
+        /// ratchet after the verification jobs — any breaking /
+        /// unsafe finding fails the build. Value is the path relative
+        /// to the repo root, e.g. `target/idl/escrow.json`.
+        #[arg(long)]
+        ci_ratchet: Option<String>,
 
         /// Generate all artifacts
         #[arg(long)]
@@ -1067,6 +1134,51 @@ async fn main() -> Result<()> {
         }
 
         // ==================================================================
+        // readiness — preflight lint for first-deploy mainnet-readiness
+        // ==================================================================
+        Commands::Readiness { idl, json } => {
+            let report = ratchet::run_readiness(&ratchet::ReadinessOpts { idl })?;
+            if json {
+                ratchet::print_json(&report)?;
+            } else {
+                ratchet::print_human(&report);
+            }
+            let code = ratchet::exit_code(&report);
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
+
+        // ==================================================================
+        // check-upgrade — diff two IDLs under ratchet's R-rules
+        // ==================================================================
+        Commands::CheckUpgrade {
+            old,
+            new,
+            unsafes,
+            migrated_accounts,
+            realloc_accounts,
+            json,
+        } => {
+            let report = ratchet::run_check_upgrade(&ratchet::CheckUpgradeOpts {
+                old,
+                new,
+                unsafes,
+                migrated_accounts,
+                realloc_accounts,
+            })?;
+            if json {
+                ratchet::print_json(&report)?;
+            } else {
+                ratchet::print_human(&report);
+            }
+            let code = ratchet::exit_code(&report);
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
+
+        // ==================================================================
         // codegen — generate committed artifacts
         // ==================================================================
         Commands::Codegen {
@@ -1085,6 +1197,7 @@ async fn main() -> Result<()> {
             ci,
             ci_output,
             ci_asm,
+            ci_ratchet,
             all,
             fill,
             handler,
@@ -1126,7 +1239,17 @@ async fn main() -> Result<()> {
                 } else {
                     String::new()
                 };
-                let workflow = CI_TEMPLATE.replace("{{VERIFY_STEP}}", &verify_step);
+                let ratchet_step = if let Some(ref idl) = ci_ratchet {
+                    format!(
+                        "\n      - name: Ratchet readiness lint\n        run: qedgen readiness --idl {}\n",
+                        idl
+                    )
+                } else {
+                    String::new()
+                };
+                let workflow = CI_TEMPLATE
+                    .replace("{{VERIFY_STEP}}", &verify_step)
+                    .replace("{{RATCHET_STEP}}", &ratchet_step);
                 if let Some(parent) = ci_output.parent() {
                     std::fs::create_dir_all(parent)?;
                 }

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -603,6 +603,26 @@ fn require_git_repo() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Expand the committed CI template by substituting `{{VERIFY_STEP}}`
+/// and `{{RATCHET_STEP}}` with the caller-provided snippets, then
+/// normalise trailing whitespace so the workflow file ends with
+/// exactly one newline regardless of whether either step was set.
+///
+/// Factored out of the `Codegen` match arm so the substitution is
+/// unit-testable without spawning a process — the template bytes are
+/// `include_str!`'d at compile time, so the test wires them in the
+/// same way.
+fn expand_ci_template(template: &str, verify_step: &str, ratchet_step: &str) -> String {
+    let mut out = template
+        .replace("{{VERIFY_STEP}}", verify_step)
+        .replace("{{RATCHET_STEP}}", ratchet_step);
+    while out.ends_with('\n') {
+        out.pop();
+    }
+    out.push('\n');
+    out
+}
+
 fn format_lint_warning(warning: &check::CompletenessWarning) -> String {
     let icon = match warning.severity {
         check::Severity::Error => "E",
@@ -1136,8 +1156,20 @@ async fn main() -> Result<()> {
         // ==================================================================
         // readiness — preflight lint for first-deploy mainnet-readiness
         // ==================================================================
+        //
+        // Exit-code discipline matches ratchet's CLI: rule-engine findings
+        // map to 1/2 via `ratchet::exit_code`, but caller-side failures
+        // (missing IDL, unparseable JSON) exit 3 so CI scripts can
+        // distinguish "your program has a breaking change" from "your
+        // pipeline is misconfigured."
         Commands::Readiness { idl, json } => {
-            let report = ratchet::run_readiness(&ratchet::ReadinessOpts { idl })?;
+            let report = match ratchet::run_readiness(&ratchet::ReadinessOpts { idl }) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("Error: {:#}", e);
+                    std::process::exit(3);
+                }
+            };
             if json {
                 ratchet::print_json(&report)?;
             } else {
@@ -1160,13 +1192,19 @@ async fn main() -> Result<()> {
             realloc_accounts,
             json,
         } => {
-            let report = ratchet::run_check_upgrade(&ratchet::CheckUpgradeOpts {
+            let report = match ratchet::run_check_upgrade(&ratchet::CheckUpgradeOpts {
                 old,
                 new,
                 unsafes,
                 migrated_accounts,
                 realloc_accounts,
-            })?;
+            }) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("Error: {:#}", e);
+                    std::process::exit(3);
+                }
+            };
             if json {
                 ratchet::print_json(&report)?;
             } else {
@@ -1247,9 +1285,7 @@ async fn main() -> Result<()> {
                 } else {
                     String::new()
                 };
-                let workflow = CI_TEMPLATE
-                    .replace("{{VERIFY_STEP}}", &verify_step)
-                    .replace("{{RATCHET_STEP}}", &ratchet_step);
+                let workflow = expand_ci_template(CI_TEMPLATE, &verify_step, &ratchet_step);
                 if let Some(parent) = ci_output.parent() {
                     std::fs::create_dir_all(parent)?;
                 }
@@ -1420,7 +1456,7 @@ async fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::format_lint_warning;
+    use super::{expand_ci_template, format_lint_warning};
     use crate::check::{CompletenessWarning, Severity};
 
     #[test]
@@ -1444,5 +1480,57 @@ mod tests {
         assert!(rendered.contains("[P2] [missing_effect]"));
         assert!(rendered.contains("Fix: Add an effect block to describe state changes"));
         assert!(rendered.contains("Example:"));
+    }
+
+    // The committed verify.yml template carries two extension placeholders
+    // — {{VERIFY_STEP}} for the optional sBPF source-hash check and
+    // {{RATCHET_STEP}} for the optional deploy-safety lint. A refactor
+    // that silently drops or mangles either one would be invisible in the
+    // rest of the test suite; these three snapshots catch that class of
+    // regression cheaply.
+    const CI_TEMPLATE: &str = include_str!("../../../templates/verify.yml");
+
+    #[test]
+    fn ci_template_unset_placeholders_produce_clean_workflow() {
+        let out = expand_ci_template(CI_TEMPLATE, "", "");
+        // Both placeholders fully consumed.
+        assert!(!out.contains("{{VERIFY_STEP}}"));
+        assert!(!out.contains("{{RATCHET_STEP}}"));
+        // Neither optional step present when unset.
+        assert!(!out.contains("Verify sBPF binary"));
+        assert!(!out.contains("Ratchet readiness lint"));
+        // Core workflow still intact.
+        assert!(out.contains("Check spec coverage"));
+        assert!(out.contains("Build proofs"));
+        // Exactly one trailing newline — no blank line at EOF.
+        assert!(out.ends_with('\n'));
+        assert!(!out.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn ci_template_ratchet_step_injects_readiness_job() {
+        let ratchet = "\n      - name: Ratchet readiness lint\n        run: qedgen readiness --idl target/idl/escrow.json\n";
+        let out = expand_ci_template(CI_TEMPLATE, "", ratchet);
+        assert!(out.contains("Ratchet readiness lint"));
+        assert!(out.contains("qedgen readiness --idl target/idl/escrow.json"));
+        assert!(!out.contains("{{RATCHET_STEP}}"));
+        assert!(out.ends_with('\n'));
+        assert!(!out.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn ci_template_both_steps_coexist_without_collision() {
+        let verify = "\n      - name: Verify sBPF binary\n        run: qedgen check --spec program.qedspec --asm src/program.s\n";
+        let ratchet = "\n      - name: Ratchet readiness lint\n        run: qedgen readiness --idl target/idl/x.json\n";
+        let out = expand_ci_template(CI_TEMPLATE, verify, ratchet);
+        assert!(out.contains("Verify sBPF binary"));
+        assert!(out.contains("Ratchet readiness lint"));
+        // sBPF step precedes proof build; ratchet step follows spec coverage.
+        let verify_pos = out.find("Verify sBPF binary").unwrap();
+        let proofs_pos = out.find("Build proofs").unwrap();
+        let coverage_pos = out.find("Check spec coverage").unwrap();
+        let ratchet_pos = out.find("Ratchet readiness lint").unwrap();
+        assert!(verify_pos < proofs_pos);
+        assert!(coverage_pos < ratchet_pos);
     }
 }

--- a/crates/qedgen/src/ratchet.rs
+++ b/crates/qedgen/src/ratchet.rs
@@ -94,6 +94,11 @@ pub fn exit_code(report: &Report) -> i32 {
     }
 }
 
+// Human report → stderr, JSON report → stdout. Mirrors upstream
+// ratchet's CLI so agents / shell consumers can redirect `>report.json`
+// for machine parsing without swallowing the human-readable banner, and
+// CI logs show the verdict inline while an optional `--json` capture
+// stays separable.
 pub fn print_human(report: &Report) {
     if report.findings.is_empty() {
         eprintln!("READY — no findings.");

--- a/crates/qedgen/src/ratchet.rs
+++ b/crates/qedgen/src/ratchet.rs
@@ -1,0 +1,257 @@
+// The `readiness` and `check-upgrade` subcommands close the last gap in
+// the qedgen pipeline: proofs prove the handlers are semantically
+// correct, but they don't say anything about whether the program's
+// on-chain shape is safe to deploy — or safe to evolve after deploy.
+// That's what ratchet (https://github.com/saicharanpogul/ratchet) does.
+//
+// qedgen embeds ratchet as a library rather than shelling out to
+// `solana-ratchet-cli`:
+//   - single binary for end-users (no extra install step),
+//   - stable version coupling (lockfile pins the ratchet version),
+//   - panic-free happy path (no subprocess / PATH surprises).
+//
+// Scope split — readiness runs the preflight P-rules on one IDL;
+// check-upgrade runs the diff R-rules on two IDLs. Exit codes mirror
+// ratchet's CLI conventions so CI scripts can switch between the two
+// entry points without rewriting their signal handling:
+//   0 = only additive findings (safe), 1 = breaking, 2 = unsafe,
+//   3 = qedgen-level error before the engine ran (caller-side).
+
+use anyhow::{Context, Result};
+use ratchet_anchor::{normalize, AnchorIdl};
+use ratchet_core::{
+    check, default_preflight_rules, default_rules, preflight, CheckContext, Report, Severity,
+};
+use std::path::{Path, PathBuf};
+
+/// Options accepted by the `qedgen readiness` subcommand.
+pub struct ReadinessOpts {
+    pub idl: PathBuf,
+}
+
+/// Options accepted by the `qedgen check-upgrade` subcommand.
+pub struct CheckUpgradeOpts {
+    pub old: PathBuf,
+    pub new: PathBuf,
+    /// `--unsafe <flag>` acknowledgements (see `ratchet list-rules`).
+    pub unsafes: Vec<String>,
+    /// `--migrated-account <Name>` declarations for R003/R004 demotion.
+    pub migrated_accounts: Vec<String>,
+    /// `--realloc-account <Name>` declarations for R005 demotion.
+    pub realloc_accounts: Vec<String>,
+}
+
+/// Run the preflight rule set against a single Anchor IDL and return
+/// the resulting [`Report`].
+pub fn run_readiness(opts: &ReadinessOpts) -> Result<Report> {
+    let idl = load_idl(&opts.idl)?;
+    let surface =
+        normalize(&idl).with_context(|| format!("normalizing IDL at {}", opts.idl.display()))?;
+    let ctx = CheckContext::new();
+    let rules = default_preflight_rules();
+    Ok(preflight(&surface, &ctx, &rules))
+}
+
+/// Diff two Anchor IDLs under the default rule set. Allow-flags flow
+/// through to the engine so intentional unsafe changes can be
+/// acknowledged at the CLI boundary.
+pub fn run_check_upgrade(opts: &CheckUpgradeOpts) -> Result<Report> {
+    let old = load_idl(&opts.old)?;
+    let new = load_idl(&opts.new)?;
+    let old_surface = normalize(&old)
+        .with_context(|| format!("normalizing old IDL at {}", opts.old.display()))?;
+    let new_surface = normalize(&new)
+        .with_context(|| format!("normalizing new IDL at {}", opts.new.display()))?;
+
+    let mut ctx = CheckContext::new();
+    for flag in &opts.unsafes {
+        ctx = ctx.with_allow(flag);
+    }
+    for name in &opts.migrated_accounts {
+        ctx = ctx.with_migration(name);
+    }
+    for name in &opts.realloc_accounts {
+        ctx = ctx.with_realloc(name);
+    }
+
+    let rules = default_rules();
+    Ok(check(&old_surface, &new_surface, &ctx, &rules))
+}
+
+fn load_idl(path: &Path) -> Result<AnchorIdl> {
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_slice::<AnchorIdl>(&bytes)
+        .with_context(|| format!("parsing Anchor IDL at {}", path.display()))
+}
+
+/// Map a report's highest severity to ratchet's CLI exit-code convention.
+/// A report with no findings is treated as additive/safe.
+pub fn exit_code(report: &Report) -> i32 {
+    match report.max_severity() {
+        None | Some(Severity::Additive) => 0,
+        Some(Severity::Breaking) => 1,
+        Some(Severity::Unsafe) => 2,
+    }
+}
+
+pub fn print_human(report: &Report) {
+    if report.findings.is_empty() {
+        eprintln!("READY — no findings.");
+        return;
+    }
+    for f in &report.findings {
+        let sev = match f.severity {
+            Severity::Breaking => "BREAKING",
+            Severity::Unsafe => "UNSAFE  ",
+            Severity::Additive => "additive",
+        };
+        eprintln!(
+            "{}  {}  {}  {}",
+            sev,
+            f.rule_id,
+            f.rule_name,
+            f.path.join("/")
+        );
+        eprintln!("          {}", f.message);
+        if let Some(hint) = &f.suggestion {
+            eprintln!("          hint: {}", hint);
+        }
+        if let Some(flag) = &f.allow_flag {
+            eprintln!("          (acknowledge with --unsafe {})", flag);
+        }
+    }
+    eprintln!();
+    match report.max_severity() {
+        None | Some(Severity::Additive) => eprintln!("verdict: READY"),
+        Some(Severity::Breaking) => eprintln!("verdict: BREAKING"),
+        Some(Severity::Unsafe) => eprintln!("verdict: UNSAFE — review each finding"),
+    }
+}
+
+pub fn print_json(report: &Report) -> Result<()> {
+    let s = serde_json::to_string_pretty(report).context("serializing ratchet report")?;
+    println!("{}", s);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const BARE_V1_IDL: &str = r#"{
+        "metadata": { "name": "t" },
+        "instructions": [],
+        "accounts": [
+            { "name": "State", "discriminator": [1,2,3,4,5,6,7,8] }
+        ],
+        "types": [
+            {
+                "name": "State",
+                "type": {
+                    "kind": "struct",
+                    "fields": [{ "name": "balance", "type": "u64" }]
+                }
+            }
+        ]
+    }"#;
+
+    fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn readiness_flags_bare_v1_surface() {
+        let tmp = TempDir::new().unwrap();
+        let idl = write(tmp.path(), "t.json", BARE_V1_IDL);
+        let report = run_readiness(&ReadinessOpts { idl }).unwrap();
+        let ids: Vec<&str> = report.findings.iter().map(|f| f.rule_id.as_str()).collect();
+        // Known bare-surface traps: no `version` prefix, no `_reserved`
+        // padding, struct name collides with the account name.
+        assert!(ids.contains(&"P001"));
+        assert!(ids.contains(&"P002"));
+        assert!(ids.contains(&"P005"));
+    }
+
+    #[test]
+    fn readiness_exit_code_matches_severity() {
+        let tmp = TempDir::new().unwrap();
+        let idl = write(tmp.path(), "t.json", BARE_V1_IDL);
+        let report = run_readiness(&ReadinessOpts { idl }).unwrap();
+        // Bare v1 surface fires P001 (unsafe) and P002 (unsafe); exit 2.
+        assert_eq!(exit_code(&report), 2);
+    }
+
+    #[test]
+    fn check_upgrade_identical_idls_produce_no_findings() {
+        let tmp = TempDir::new().unwrap();
+        let old = write(tmp.path(), "old.json", BARE_V1_IDL);
+        let new = write(tmp.path(), "new.json", BARE_V1_IDL);
+        let report = run_check_upgrade(&CheckUpgradeOpts {
+            old,
+            new,
+            unsafes: vec![],
+            migrated_accounts: vec![],
+            realloc_accounts: vec![],
+        })
+        .unwrap();
+        assert!(report.findings.is_empty());
+        assert_eq!(exit_code(&report), 0);
+    }
+
+    #[test]
+    fn check_upgrade_breaking_change_fires_rule() {
+        let tmp = TempDir::new().unwrap();
+        let old = write(
+            tmp.path(),
+            "old.json",
+            r#"{
+                "metadata": { "name": "t" },
+                "instructions": [
+                    { "name": "old_ix", "discriminator": [1,2,3,4,5,6,7,8], "accounts": [], "args": [] }
+                ],
+                "accounts": [],
+                "types": []
+            }"#,
+        );
+        let new = write(
+            tmp.path(),
+            "new.json",
+            r#"{
+                "metadata": { "name": "t" },
+                "instructions": [],
+                "accounts": [],
+                "types": []
+            }"#,
+        );
+        let report = run_check_upgrade(&CheckUpgradeOpts {
+            old,
+            new,
+            unsafes: vec![],
+            migrated_accounts: vec![],
+            realloc_accounts: vec![],
+        })
+        .unwrap();
+        assert!(report.findings.iter().any(|f| f.rule_id == "R007"));
+        assert_eq!(exit_code(&report), 1);
+    }
+
+    #[test]
+    fn missing_idl_is_surfaced_as_io_error() {
+        let err = run_readiness(&ReadinessOpts {
+            idl: PathBuf::from("/does/not/exist.json"),
+        })
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("reading"));
+    }
+
+    #[test]
+    fn malformed_json_is_surfaced_as_parse_error() {
+        let tmp = TempDir::new().unwrap();
+        let idl = write(tmp.path(), "t.json", "not json");
+        let err = run_readiness(&ReadinessOpts { idl }).unwrap_err();
+        assert!(format!("{err:#}").contains("parsing"));
+    }
+}

--- a/examples/rust/escrow/.github/workflows/verify.yml
+++ b/examples/rust/escrow/.github/workflows/verify.yml
@@ -40,4 +40,3 @@ jobs:
 
       - name: Ratchet readiness lint
         run: qedgen readiness --idl target/idl/escrow.json
-

--- a/examples/rust/escrow/.github/workflows/verify.yml
+++ b/examples/rust/escrow/.github/workflows/verify.yml
@@ -37,3 +37,7 @@ jobs:
 
       - name: Check spec coverage
         run: qedgen check --spec program.qedspec
+
+      - name: Ratchet readiness lint
+        run: qedgen readiness --idl target/idl/escrow.json
+

--- a/templates/verify.yml
+++ b/templates/verify.yml
@@ -37,3 +37,4 @@ jobs:
 
       - name: Check spec coverage
         run: qedgen check --spec program.qedspec
+{{RATCHET_STEP}}


### PR DESCRIPTION
## Summary

Following up on our DM — this wires [ratchet](https://github.com/saicharanpogul/ratchet) into the qedgen pipeline as the post-codegen step you asked for.

Proofs prove correctness. Ratchet proves **deployability**.

The `#[qed(verified)]` hash-stamp catches when a function *body* drifts from its proof. It doesn't catch when an `#[account]` struct is renamed — the proof stays green, but the Anchor discriminator is now different and every existing account on-chain is orphaned. Same family as `shape_only_cpi` and `qedgen reconcile`: "X looks done, but Y gap remains." Ratchet fills the third seat.

Dogfooded on `examples/rust/escrow` before writing any code — flagged three real future-upgrade landmines in a program that's already formally verified:

```
UNSAFE    P001  account-missing-version-field        account:EscrowState
UNSAFE    P002  account-missing-reserved-padding     account:EscrowState
additive  P003  account-missing-discriminator-pin    account:EscrowState/discriminator
verdict: UNSAFE — `escrow` has future-upgrade concerns
```

## What's new

### `qedgen readiness --idl <anchor.json>`
Pre-deploy preflight on one Anchor IDL. Runs the six P-rules — missing `version: u8` prefix, no `_reserved` padding, unpinned discriminators (account + event), name collisions, writable accounts with no signer. Human or `--json` output. Exit codes `0 = additive/safe, 1 = breaking, 2 = unsafe`.

### `qedgen check-upgrade --old <old.json> --new <new.json>`
Diff mode — R001–R016. Catches field reorders, discriminator changes, orphaned accounts, PDA seed drift, signer/writable tightening. Supports `--unsafe <flag>` (repeatable), `--migrated-account <Name>`, `--realloc-account <Name>` for acknowledging intentional unsafe changes. Same human / JSON / exit-code surface as `readiness`.

### CI integration: `--ci-ratchet`
```bash
qedgen codegen --spec my_program.qedspec --ci --ci-ratchet target/idl/my_program.json
```
Adds a `{{RATCHET_STEP}}` placeholder to `templates/verify.yml` that expands to:
```yaml
      - name: Ratchet readiness lint
        run: qedgen readiness --idl target/idl/<program>.json
```
Empty-string replacement when `--ci-ratchet` is omitted, so existing codegen output is unchanged for users who don't opt in. The escrow example's committed `verify.yml` snapshot is regenerated with the flag to demonstrate.

### Architecture note — library, not subprocess
`qedgen` embeds `solana-ratchet-core` and `solana-ratchet-anchor` (no-default-features, so `ureq` drops out because we read IDLs from disk, never from RPC). Single binary for end-users; ratchet version pinned via `Cargo.lock`; no PATH / install-step surprises.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (183 tests total, 6 new in `ratchet.rs` covering readiness + check-upgrade + exit-code mapping + IO/parse error paths)
- [x] `bash scripts/check-readme-drift.sh` — 15 / 15 subcommands documented
- [x] End-to-end: `qedgen readiness --idl target/idl/escrow.json` on the committed escrow example — findings match the pre-PR dogfood run above
- [x] End-to-end: `qedgen codegen --ci --ci-ratchet …` regenerates `examples/rust/escrow/.github/workflows/verify.yml` cleanly; committed snapshot in this PR

## Files touched

| File | Change |
|---|---|
| `crates/qedgen/Cargo.toml` | + `ratchet-core = "0.3"`, `ratchet-anchor = "0.3"` (no-default-features, aliased via `package =` so the import path stays `ratchet_core::` / `ratchet_anchor::`) |
| `crates/qedgen/src/ratchet.rs` | New module — `run_readiness`, `run_check_upgrade`, `exit_code`, human + JSON printers, 6 inline `#[test]`s (250 LOC) |
| `crates/qedgen/src/main.rs` | `mod ratchet;`, `Readiness { idl, json }` + `CheckUpgrade { old, new, unsafes, migrated_accounts, realloc_accounts, json }` variants on `Commands`, two new match arms next to `Verify`, `--ci-ratchet` flag on `Codegen` + template emission |
| `templates/verify.yml` | `{{RATCHET_STEP}}` placeholder appended after the existing "Check spec coverage" step |
| `examples/rust/escrow/.github/workflows/verify.yml` | Regenerated with `--ci-ratchet target/idl/escrow.json` |
| `README.md` | New row in "What it verifies" table + "Deploy-safety lint (ratchet)" section under Usage + `--ci-ratchet` example under "Generate CI workflow" |

**Total: 250 LOC added, 7 files, one themed bundle — matches the repo's existing PR cadence.**

## Out of scope (follow-ups if you want them)

- Making `--ci-ratchet` default-on when `--all` is set. Deliberately opt-in for this PR so the rollout is non-breaking.
- A `qedgen reconcile`-style integration that cross-references `#[qed(verified)]` hashes with ratchet's R006 findings (rename detection at the attribute level). Interesting but scope creep.
- Publishing `solana-ratchet-wasm` so the skill could also run inside the browser-based qedgen UI — ratchet already has a WASM build, just isn't on crates.io yet.

## Why now

Readiness mode landed in ratchet v0.3.0 last week, which is what makes the pre-deploy story actually work (before v0.3.0, ratchet was diff-only, which isn't useful until you've already deployed). Happy to amend this PR in any direction — scope, naming, commit splits — whatever matches your review flow best.