### PR TITLE
feat(qed): address deferred review items from #6 — list-rules + dep trim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,32 +247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,12 +288,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1146,15 +1114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,12 +1178,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1338,14 +1291,13 @@ dependencies = [
 
 [[package]]
 name = "solana-ratchet-anchor"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e8eae5b0d3cae5004618783ae666cd831e1c140e790182ab46ee2746b0b6b"
+checksum = "3a44935f2f286a4e5b9a02e7bf5123ca402116a25cce6ed564224f2e32f843f3"
 dependencies = [
  "anyhow",
  "base64",
  "bs58",
- "curve25519-dalek",
  "flate2",
  "serde",
  "serde_json",
@@ -1355,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ratchet-core"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cecef771b04bee977bfe369c790ea6623d0c5b60e9dbd030e6487e01ca20e7"
+checksum = "6915975b819408bfee35ff2257079db3a31c03831942610242b1b6944cbc54b1"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ qedgen check-upgrade --old ratchet.lock --new target/idl/my_program.json \
   --unsafe allow-field-append --migrated-account EscrowState
 ```
 
-Exit codes mirror ratchet's CLI conventions: `0 = additive/safe`, `1 = breaking`, `2 = unsafe`. Under the hood qedgen embeds [ratchet](https://github.com/saicharanpogul/ratchet) as a library, so the rule catalog stays in sync with upstream — run `ratchet list-rules` to see the full P-rule and R-rule set (22 rules at the time of writing).
+Exit codes mirror ratchet's CLI conventions: `0 = additive/safe`, `1 = breaking`, `2 = unsafe`. Under the hood qedgen embeds [ratchet](https://github.com/saicharanpogul/ratchet) as a library, so the rule catalog stays in sync with upstream — run `qedgen readiness --list-rules` (P-rules) or `qedgen check-upgrade --list-rules` (R-rules) to see the full set (22 rules at the time of writing). Pair with `--json` for a machine-readable dump.
 
 **Why both.** qedgen's `#[qed(verified)]` hash-stamps the *function body*, so a rename of an `#[account]` struct compiles with a stale-but-valid proof even though the on-chain discriminator is now different and every existing account of that type is orphaned. `qedgen check-upgrade`'s `R006 account-discriminator-change` catches that class of failure; the proof layer alone doesn't look at it.
 

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -33,8 +33,8 @@ chumsky = "0.12"
 # already has on disk, never an on-chain pubkey. The `package = …`
 # aliases keep the import path (`ratchet_core::`, `ratchet_anchor::`)
 # short without renaming the upstream crates.
-ratchet-core = { package = "solana-ratchet-core", version = "0.3" }
-ratchet-anchor = { package = "solana-ratchet-anchor", version = "0.3", default-features = false }
+ratchet-core = { package = "solana-ratchet-core", version = "0.3.1" }
+ratchet-anchor = { package = "solana-ratchet-anchor", version = "0.3.1", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -333,8 +333,16 @@ enum Commands {
     /// Exit codes: 0 = additive/safe, 1 = breaking, 2 = unsafe.
     Readiness {
         /// Path to the Anchor IDL JSON (typically target/idl/<program>.json)
+        #[arg(long, required_unless_present = "list_rules")]
+        idl: Option<PathBuf>,
+
+        /// Print the catalog of P-rules applied by `readiness` and exit.
+        /// Replaces the pre-embed `ratchet list-rules` step: users who
+        /// installed qedgen via `install.sh` / `npx skills add` don't
+        /// have the standalone `ratchet` CLI on PATH, but the rule set
+        /// is linked in as a library, so surface it here.
         #[arg(long)]
-        idl: PathBuf,
+        list_rules: bool,
 
         /// Output as JSON (for agent / CI consumption)
         #[arg(long)]
@@ -351,16 +359,16 @@ enum Commands {
     /// Exit codes: 0 = additive/safe, 1 = breaking, 2 = unsafe.
     CheckUpgrade {
         /// Path to the baseline IDL (the one on-chain today).
-        #[arg(long)]
-        old: PathBuf,
+        #[arg(long, required_unless_present = "list_rules")]
+        old: Option<PathBuf>,
 
         /// Path to the candidate IDL (the one the upgrade would ship).
-        #[arg(long)]
-        new: PathBuf,
+        #[arg(long, required_unless_present = "list_rules")]
+        new: Option<PathBuf>,
 
         /// Acknowledge a specific unsafe finding so it reports as
-        /// additive instead (repeatable). See `ratchet list-rules` for
-        /// the full flag catalog.
+        /// additive instead (repeatable). Pass `--list-rules` to see the
+        /// full flag catalog.
         #[arg(long = "unsafe")]
         unsafes: Vec<String>,
 
@@ -373,6 +381,13 @@ enum Commands {
         /// demotes R005 for that account to Additive (repeatable).
         #[arg(long = "realloc-account")]
         realloc_accounts: Vec<String>,
+
+        /// Print the catalog of R-rules applied by `check-upgrade` and
+        /// exit. Same motivation as on `readiness`: the rule set is
+        /// linked in as a library so there's no `ratchet list-rules`
+        /// binary on PATH — this flag fills the gap.
+        #[arg(long)]
+        list_rules: bool,
 
         /// Output as JSON (for agent / CI consumption)
         #[arg(long)]
@@ -1174,7 +1189,18 @@ async fn main() -> Result<()> {
         // (missing IDL, unparseable JSON) exit 3 so CI scripts can
         // distinguish "your program has a breaking change" from "your
         // pipeline is misconfigured."
-        Commands::Readiness { idl, json } => {
+        Commands::Readiness {
+            idl,
+            list_rules,
+            json,
+        } => {
+            if list_rules {
+                ratchet::print_rules_preflight(json)?;
+                return Ok(());
+            }
+            // clap's `required_unless_present = "list_rules"` guarantees
+            // `idl` is Some here — unwrap is safe in shape.
+            let idl = idl.expect("--idl is required unless --list-rules");
             let report = match ratchet::run_readiness(&ratchet::ReadinessOpts { idl }) {
                 Ok(r) => r,
                 Err(e) => {
@@ -1202,8 +1228,15 @@ async fn main() -> Result<()> {
             unsafes,
             migrated_accounts,
             realloc_accounts,
+            list_rules,
             json,
         } => {
+            if list_rules {
+                ratchet::print_rules_diff(json)?;
+                return Ok(());
+            }
+            let old = old.expect("--old is required unless --list-rules");
+            let new = new.expect("--new is required unless --list-rules");
             let report = match ratchet::run_check_upgrade(&ratchet::CheckUpgradeOpts {
                 old,
                 new,

--- a/crates/qedgen/src/ratchet.rs
+++ b/crates/qedgen/src/ratchet.rs
@@ -22,6 +22,7 @@ use ratchet_anchor::{normalize, AnchorIdl};
 use ratchet_core::{
     check, default_preflight_rules, default_rules, preflight, CheckContext, Report, Severity,
 };
+use serde::Serialize;
 use std::path::{Path, PathBuf};
 
 /// Options accepted by the `qedgen readiness` subcommand.
@@ -136,6 +137,60 @@ pub fn print_human(report: &Report) {
 pub fn print_json(report: &Report) -> Result<()> {
     let s = serde_json::to_string_pretty(report).context("serializing ratchet report")?;
     println!("{}", s);
+    Ok(())
+}
+
+/// One row in a `--list-rules` dump. Kept minimal — id / name /
+/// description are the only fields the upstream ratchet CLI prints
+/// and the only fields stable across rule catalog revisions.
+#[derive(Serialize)]
+struct RuleEntry {
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+}
+
+/// Print every preflight (`P001`–`P006`) rule shipped with the
+/// embedded ratchet. `--json` switches to a machine-parseable payload
+/// (stdout) so agents can consume the catalog without regex-matching
+/// the human table.
+pub fn print_rules_preflight(json: bool) -> Result<()> {
+    let entries: Vec<RuleEntry> = default_preflight_rules()
+        .iter()
+        .map(|r| RuleEntry {
+            id: r.id(),
+            name: r.name(),
+            description: r.description(),
+        })
+        .collect();
+    render_rule_catalog("readiness (preflight, P-rules)", &entries, json)
+}
+
+/// Print every diff (`R001`–`R016`) rule shipped with the embedded
+/// ratchet. Same JSON / human split as
+/// [`print_rules_preflight`].
+pub fn print_rules_diff(json: bool) -> Result<()> {
+    let entries: Vec<RuleEntry> = default_rules()
+        .iter()
+        .map(|r| RuleEntry {
+            id: r.id(),
+            name: r.name(),
+            description: r.description(),
+        })
+        .collect();
+    render_rule_catalog("check-upgrade (diff, R-rules)", &entries, json)
+}
+
+fn render_rule_catalog(header: &str, entries: &[RuleEntry], json: bool) -> Result<()> {
+    if json {
+        let s = serde_json::to_string_pretty(entries).context("serializing rule catalog")?;
+        println!("{}", s);
+        return Ok(());
+    }
+    eprintln!("qedgen {} — {} rule(s):", header, entries.len());
+    for entry in entries {
+        eprintln!("  {}  {:<40}  {}", entry.id, entry.name, entry.description);
+    }
     Ok(())
 }
 
@@ -258,5 +313,38 @@ mod tests {
         let idl = write(tmp.path(), "t.json", "not json");
         let err = run_readiness(&ReadinessOpts { idl }).unwrap_err();
         assert!(format!("{err:#}").contains("parsing"));
+    }
+
+    // Catalog-shape guards for `--list-rules`. These tests snapshot the
+    // `id` / `name` / `description` tuples the embedded ratchet exposes;
+    // if an upstream rule is renamed without updating the P / R ID
+    // prefixes, the contains-check catches it. The counts are pinned at
+    // the v0.3.1 catalog (6 P-rules + 16 R-rules = 22); bump here when
+    // the upstream catalog grows.
+    #[test]
+    fn list_rules_preflight_covers_full_p_catalog() {
+        let entries: Vec<_> = default_preflight_rules()
+            .iter()
+            .map(|r| (r.id(), r.name()))
+            .collect();
+        assert_eq!(entries.len(), 6);
+        assert!(entries.iter().all(|(id, _)| id.starts_with('P')));
+        let ids: Vec<&str> = entries.iter().map(|(id, _)| *id).collect();
+        for expected in &["P001", "P002", "P003", "P004", "P005", "P006"] {
+            assert!(ids.contains(expected), "missing {expected} in catalog");
+        }
+    }
+
+    #[test]
+    fn list_rules_diff_covers_full_r_catalog() {
+        let entries: Vec<_> = default_rules().iter().map(|r| (r.id(), r.name())).collect();
+        assert_eq!(entries.len(), 16);
+        assert!(entries.iter().all(|(id, _)| id.starts_with('R')));
+        // Spot-check a few key rule ids — these are the ones the PR body
+        // and README reference by number, so they must stay discoverable.
+        let ids: Vec<&str> = entries.iter().map(|(id, _)| *id).collect();
+        for expected in &["R001", "R006", "R007", "R013", "R016"] {
+            assert!(ids.contains(expected), "missing {expected} in catalog");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to [#6](https://github.com/QEDGen/solana-skills/pull/6). Addresses the two items you flagged as deferred in the review:

1. **`ratchet list-rules` → `qedgen readiness --list-rules` / `qedgen check-upgrade --list-rules`.** The README referenced the upstream CLI, but qedgen embeds ratchet as a library — users installing via `install.sh` / `npx skills add` don't have the `ratchet` binary on PATH. Now the catalog is discoverable through qedgen itself.
2. **`curve25519-dalek` + `fiat-crypto` dropped from qedgen's dep tree.** Published `ratchet 0.3.1` this morning that gates those behind the `rpc` feature; bumping the pin here picks them up.

## What's new

### `qedgen readiness --list-rules`
Prints the 6-rule P-catalog (human table to stderr). Pair with `--json` for a machine-readable dump to stdout.

```
$ qedgen readiness --list-rules
qedgen readiness (preflight, P-rules) — 6 rule(s):
  P001  account-missing-version-field             Accounts without a leading `version: u8` have no in-band signal for layout-version branching…
  P002  account-missing-reserved-padding          Accounts without a trailing `_reserved: [u8; N]` padding require a realloc or migration on every future field append.
  P003  account-missing-discriminator-pin         Account uses Anchor's default discriminator; pinning it explicitly survives struct renames without firing R006.
  P004  event-missing-discriminator-pin           Event uses Anchor's default discriminator; pinning it survives renames without desyncing indexers.
  P005  account-name-collision                    Account struct is named after a well-known Solana type, making tooling and docs ambiguous.
  P006  instruction-missing-signer                Instruction writes to accounts with no signer slot — anyone can mutate state unless CPI authority is checked elsewhere.
```

### `qedgen check-upgrade --list-rules`
Same shape for the 16-rule R-catalog.

### CLI shape
`--idl` / `--old` / `--new` become optional via clap's `required_unless_present = "list_rules"`, so the happy-path signatures are unchanged:
- `qedgen readiness --idl x.json` — still works exactly as before
- `qedgen readiness --list-rules` — skips the engine, dumps the catalog, exit 0

### Ratchet 0.3.1 dep bump
`ratchet-anchor 0.3.1` gates `curve25519-dalek` (and its `fiat-crypto` sub-tree) behind the `rpc` feature. qedgen sets `default-features = false`, so those crates were dead weight in the dep graph since #6. Verified dropped:

```
$ cargo tree -p qedgen-solana-skills | grep -c curve25519
0
$ cargo tree -p qedgen-solana-skills | grep -c fiat-crypto
0
```

Release notes + publish log: https://github.com/saicharanpogul/ratchet/releases/tag/v0.3.1

No behavioural change — the default ratchet CLI and any consumer with `default-features = true` keeps the old dep path. Patch-level bump, non-breaking.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 222 tests total, +2 new (`list_rules_preflight_covers_full_p_catalog`, `list_rules_diff_covers_full_r_catalog`) lock the rule-catalog shape so a future upstream bump that drops or renames a rule surfaces loudly
- [x] `bash scripts/check-readme-drift.sh` — 15/15 subcommands documented
- [x] End-to-end: `qedgen readiness --list-rules` (human), `qedgen check-upgrade --list-rules --json` (machine) both produce correct output
- [x] `cargo tree` dep-drop verification above

## Files touched

| File | Change |
|---|---|
| `crates/qedgen/Cargo.toml` | `ratchet-core` / `ratchet-anchor` pin `"0.3"` → `"0.3.1"` |
| `crates/qedgen/src/main.rs` | `--list-rules` flag on `Readiness` + `CheckUpgrade`, `--idl` / `--old` / `--new` made conditional, early-exit match-arm path |
| `crates/qedgen/src/ratchet.rs` | `print_rules_preflight()` / `print_rules_diff()` + `RuleEntry` serde struct + 2 catalog-shape snapshot tests |
| `README.md` | Swap `ratchet list-rules` reference for the new `qedgen readiness --list-rules` / `check-upgrade --list-rules` flags |
| `Cargo.lock` | `solana-ratchet-{core,anchor}` pulled in at 0.3.1; `curve25519-dalek` + `fiat-crypto` drop out of qedgen's sub-graph |

Total: ~136 net LOC added, 5 files. Same themed-bundle cadence as #6.

## Also addressed from #6's non-blocking notes

These were already fixed in #6's follow-up commit (`926f34e`):
- Stderr/stdout comment on `print_human` / `print_json`
- Trailing blank line in regenerated `verify.yml`
- README "Deploy safety" row qualified as Anchor-only
- Exit code 3 wired for caller-side errors
- Template-expansion snapshot tests

Nothing outstanding from that review as far as I can tell. Happy to resize or split this PR if either piece warrants a separate review thread.