### PR TITLE
feat: implement forall/exists quantifier support

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -763,10 +763,17 @@ Accepts comma- or newline-separated fields; desugars to
 alongside the multi-line form.
 
 **`implies`** in property bodies lowers to `(!a) || (b)` in generated
-Rust (Kani/proptest). **`forall` / `exists`** in a property body emit a
-`/* QEDGEN_UNSUPPORTED_QUANTIFIER */` marker — the property fn returns
-`true` and you should express the quantification at the harness level
-via `kani::any()` / proptest generators.
+Rust (Kani/proptest). **`forall` / `exists`** over **U8 or I8** lower to
+`(T::MIN..=T::MAX).all(|v| body)` / `.any(|v| body)` — exhaustive check,
+≤256 iterations, works in both proptest and Kani. Larger types (U16+)
+still emit a `/* QEDGEN_UNSUPPORTED_QUANTIFIER */` sentinel and the
+property fn returns `true`; `qedgen check` fires a P1
+`unchecked_quantifier` warning so the gap is visible rather than silent.
+
+**Quantified-property preservation theorems** (property body contains
+`∀`/`∃`) default to `sorry` in generated Lean — `omega` cannot prove
+universal goals. Fill these via the standard escalation ladder:
+Leanstral first (`qedgen fill-sorry`), then Aristotle for harder goals.
 
 **Multi-variant ADTs with shared field names** deduplicate when
 flattened into the state model (first-variant wins on name collisions).

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -1793,6 +1793,47 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
         }
     }
 
+    // Rule: quantifier over a type that can't be exhausted at test time.
+    // U8/I8 are fine (256 iterations); anything larger emits a stub `true`
+    // body, so the property silently passes without being checked.
+    for prop in &spec.properties {
+        if let Some(ref rust_expr) = prop.rust_expression {
+            if rust_expr_is_unsupported(rust_expr) {
+                // Extract the quantifier kind and binder type from the sentinel
+                // comment so the message is specific.
+                let detail = rust_expr
+                    .trim_start_matches("/*")
+                    .trim_end_matches("*/")
+                    .trim()
+                    .trim_start_matches(QEDGEN_UNSUPPORTED_MARKER)
+                    .trim_start_matches(':')
+                    .trim()
+                    .to_string();
+                warnings.push(CompletenessWarning {
+                    rule: "unchecked_quantifier".to_string(),
+                    severity: Severity::Warning,
+                    priority: 1,
+                    message: format!(
+                        "property '{}' uses a quantifier over a type that proptest/Kani \
+                         cannot exhaust — the harness emits `true` and skips the check ({})",
+                        prop.name, detail
+                    ),
+                    subject: Some(prop.name.clone()),
+                    fix: "Use U8 or I8 as the quantifier binder type (≤256 values, exhausted \
+                          automatically), or split the property into a per-element guard."
+                        .to_string(),
+                    example: Some(format!(
+                        "  // instead of: forall v : U64, …\n  \
+                         property {} :\n    forall v : U8, …",
+                        prop.name
+                    )),
+                    counterexample: None,
+                    fix_options: vec![],
+                });
+            }
+        }
+    }
+
     // Rule 7: takes params (U64) with no guard — suggest input validation
     for op in &spec.handlers {
         if op.has_guard() {
@@ -4115,6 +4156,59 @@ interface Token {
         assert_eq!(h.accounts.len(), 3);
         assert_eq!(h.requires.len(), 1);
         assert_eq!(h.ensures.len(), 1);
+    }
+
+    #[test]
+    fn unchecked_quantifier_lint_fires_for_large_type() {
+        // U64 quantifier can't be exhausted — check.rs must warn so the user
+        // knows the property is being silently skipped in proptest/Kani.
+        let spec = ParsedSpec {
+            properties: vec![ParsedProperty {
+                name: "all_balances_positive".to_string(),
+                expression: Some("∀ v : Nat, v ≥ 0".to_string()),
+                rust_expression: Some(
+                    "/* QEDGEN_UNSUPPORTED_QUANTIFIER: forall v : U64 \
+                     — lower at harness level */"
+                        .to_string(),
+                ),
+                preserved_by: vec![],
+            }],
+            ..empty_spec()
+        };
+        let warnings = check_completeness(&spec);
+        assert!(
+            warnings.iter().any(|w| w.rule == "unchecked_quantifier"),
+            "expected unchecked_quantifier lint for U64 forall, got: {:?}",
+            warnings.iter().map(|w| &w.rule).collect::<Vec<_>>()
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.rule == "unchecked_quantifier")
+            .unwrap();
+        assert_eq!(w.priority, 1, "unchecked_quantifier must be P1");
+        assert!(
+            w.message.contains("all_balances_positive"),
+            "message must name the property"
+        );
+    }
+
+    #[test]
+    fn unchecked_quantifier_lint_does_not_fire_for_u8() {
+        // U8 forall lowers to a real iterator — no lint should fire.
+        let spec = ParsedSpec {
+            properties: vec![ParsedProperty {
+                name: "bytes_nonneg".to_string(),
+                expression: Some("∀ v : Nat, v ≥ 0".to_string()),
+                rust_expression: Some("(u8::MIN..=u8::MAX).all(|v| v >= 0)".to_string()),
+                preserved_by: vec![],
+            }],
+            ..empty_spec()
+        };
+        let warnings = check_completeness(&spec);
+        assert!(
+            !warnings.iter().any(|w| w.rule == "unchecked_quantifier"),
+            "U8 forall must not fire unchecked_quantifier"
+        );
     }
 
     #[test]

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -634,20 +634,37 @@ fn expr_to_rust(e: &Expr, ctx: Ctx, consts: ConstTable) -> String {
             kind,
             binder,
             binder_ty,
-            body: _,
+            body,
         } => {
-            // Quantifiers don't lower to a property-function body directly: the
-            // universal case needs harness-level `kani::any()` scaffolding that's
-            // emitted by the backend, not inlined here. Surface the sentinel so
-            // the caller can replace the generated function body with a skip
-            // marker. See `rust_expr_is_unsupported` in check.rs.
-            let kind_name = match kind {
-                a::Quantifier::Forall => "forall",
-                a::Quantifier::Exists => "exists",
+            // Small integer types (U8, I8) can be exhaustively iterated inside
+            // a property predicate using Rust's RangeInclusive::all / any. This
+            // is correct and cheap enough for test suites (256 iterations max).
+            //
+            // Larger types (U16+) cannot be exhausted in a test loop; surface
+            // the sentinel so the caller knows to skip or escalate.
+            let rust_ty = match binder_ty.as_str() {
+                "U8" => Some("u8"),
+                "I8" => Some("i8"),
+                _ => None,
             };
+            let Some(rust_ty) = rust_ty else {
+                let kind_name = match kind {
+                    a::Quantifier::Forall => "forall",
+                    a::Quantifier::Exists => "exists",
+                };
+                return format!(
+                    "/* QEDGEN_UNSUPPORTED_QUANTIFIER: {} {} : {} — lower at harness level */",
+                    kind_name, binder, binder_ty
+                );
+            };
+            let method = match kind {
+                a::Quantifier::Forall => "all",
+                a::Quantifier::Exists => "any",
+            };
+            let body_rust = expr_to_rust(&body.node, ctx, consts);
             format!(
-                "/* QEDGEN_UNSUPPORTED_QUANTIFIER: {} {} : {} — lower at harness level */",
-                kind_name, binder, binder_ty
+                "({}::MIN..={}::MAX).{}(|{}| {})",
+                rust_ty, rust_ty, method, binder, body_rust
             )
         }
         Expr::BoolOp { op, lhs, rhs } => {
@@ -2525,7 +2542,9 @@ property implies_case :
     }
 
     #[test]
-    fn property_forall_marked_unsupported_in_rust() {
+    fn property_forall_u8_lowers_to_iterator() {
+        // U8 is small enough to exhaust (256 values) — must not emit the
+        // unsupported sentinel; must lower to a `.all(|v| …)` expression.
         let src = r#"spec T
 state { x : U8 }
 property forall_case :
@@ -2540,12 +2559,44 @@ property forall_case :
             .expect("property");
         let rust = prop.rust_expression.as_deref().expect("rust rendering");
         assert!(
-            crate::check::rust_expr_is_unsupported(rust),
-            "forall body should carry the unsupported marker: {}",
+            !crate::check::rust_expr_is_unsupported(rust),
+            "U8 forall must lower to an iterator, not emit the unsupported marker: {}",
             rust
         );
-        // The marker is wrapped in `/* ... */` so downstream emission puts it
-        // inside a comment — no mojibake can leak into compiled Rust.
+        assert!(
+            rust.contains("u8::MIN") && rust.contains("u8::MAX"),
+            "must use u8 range: {}",
+            rust
+        );
+        assert!(rust.contains(".all("), "must use .all(): {}", rust);
+        assert!(
+            !rust.contains('\u{2200}'),
+            "rust must not contain ∀: {}",
+            rust
+        );
+    }
+
+    #[test]
+    fn property_forall_large_type_marked_unsupported_in_rust() {
+        // U64 cannot be exhausted in a test loop — must still emit the sentinel.
+        let src = r#"spec T
+state { x : U64 }
+property forall_u64 :
+  forall v : U64, v >= 0
+  preserved_by all
+"#;
+        let spec = parse_str(src).expect("parse");
+        let prop = spec
+            .properties
+            .iter()
+            .find(|p| p.name == "forall_u64")
+            .expect("property");
+        let rust = prop.rust_expression.as_deref().expect("rust rendering");
+        assert!(
+            crate::check::rust_expr_is_unsupported(rust),
+            "U64 forall must still emit the unsupported sentinel: {}",
+            rust
+        );
         assert!(
             rust.trim_start().starts_with("/*"),
             "marker must be a Rust block comment: {}",

--- a/crates/qedgen/src/lean_gen.rs
+++ b/crates/qedgen/src/lean_gen.rs
@@ -845,6 +845,17 @@ fn preservation_proof_script(
 ) -> String {
     let trans_name = safe_name(&format!("{}Transition", op.name));
     let has_cond = handler_has_condition(op, fields);
+    let has_quantifier = prop
+        .expression
+        .as_deref()
+        .map(|e| e.contains('\u{2200}') || e.contains('\u{2203}'))
+        .unwrap_or(false);
+    if has_quantifier {
+        return format!(
+            " := by\n  unfold {} at h\n  sorry -- quantified property: fill with intro + cases or Leanstral\n",
+            trans_name
+        );
+    }
 
     // Determine which property fields this handler touches
     let prop_fields: Vec<&str> = if let Some(ref expr) = prop.expression {
@@ -908,16 +919,22 @@ fn render_properties_inner(
 ) {
     for prop in properties {
         if let Some(ref expr) = prop.expression {
-            // Strip leading ∀/forall quantifier if present, since the def already binds `s`
-            // e.g., "∀ s : Pool.Active, s.total_deposits ≥ s.total_borrows"
-            //     → "s.total_deposits ≥ s.total_borrows"
+            // strip leading "∀ s : Type," only when the binder is the state
+            // variable `s` — the def already introduces `(s : state_type)`.
+            // do NOT strip for value quantifiers like "∀ v : Nat, v ≥ 0":
+            // those should be kept verbatim so `v` remains bound in the Prop.
             let body = if let Some(rest) = expr
                 .strip_prefix('\u{2200}')
                 .or_else(|| expr.strip_prefix("forall"))
             {
-                // Skip past "var : Type, " to get the body
-                if let Some(comma_pos) = rest.find(',') {
-                    rest[comma_pos + 1..].trim().to_string()
+                let trimmed = rest.trim_start();
+                // only strip if the quantified binder is the state variable `s`.
+                if trimmed.starts_with("s ") || trimmed.starts_with("s:") {
+                    if let Some(comma_pos) = rest.find(',') {
+                        rest[comma_pos + 1..].trim().to_string()
+                    } else {
+                        expr.clone()
+                    }
                 } else {
                     expr.clone()
                 }
@@ -4519,5 +4536,82 @@ type State
                 .unwrap_or_else(|e| panic!("fixture {} failed to parse: {:?}", name, e));
             let _ = render(&spec);
         }
+    }
+
+    #[test]
+    fn lean_gen_quantified_property_preservation_emits_sorry() {
+        //  quantified property preservation theorem must emit sorry --
+        // omega cannot prove universal goals and would generate non-compiling Lean.
+        // Use `preserved_by all` (which expands to include noop after adapt()).
+        // Single-account spec with lifecycle state so render_single_account is used.
+        let src = r#"spec T
+type State
+  | Active of { balance : U64 }
+
+property all_bytes_nonneg :
+  forall v : U8, v >= 0
+  preserved_by all
+handler noop : State.Active -> State.Active {
+  permissionless
+  effect { balance := balance }
+}
+"#;
+        let spec = chumsky_adapter::parse_str(src).expect("parse");
+        // Confirm the expansion happened (property covers noop)
+        let prop = spec
+            .properties
+            .iter()
+            .find(|p| p.name == "all_bytes_nonneg")
+            .expect("property present");
+        assert!(
+            prop.preserved_by.contains(&"noop".to_string()),
+            "preserved_by all must expand to include noop, got: {:?}",
+            prop.preserved_by
+        );
+        let lean = render(&spec);
+        assert!(
+            lean.contains("sorry"),
+            "quantified property preservation must emit sorry, not omega:\n{}",
+            &lean[lean.find("all_bytes_nonneg").unwrap_or(0)..]
+                .chars()
+                .take(500)
+                .collect::<String>()
+        );
+        assert!(
+            !lean.contains("omega"),
+            "must not emit omega for a quantified property"
+        );
+    }
+
+    #[test]
+    fn lean_gen_forall_value_quantifier_not_stripped_in_def() {
+        // `∀ v : Nat, v ≥ 0` must be preserved verbatim in the Lean def —
+        // stripping the `∀` would leave `v` unbound.
+        let src = r#"spec T
+state { balance : U64 }
+property all_bytes_nonneg :
+  forall v : U8, v >= 0
+  preserved_by []
+handler noop : State -> State {
+  permissionless
+  effect { balance := balance }
+}
+"#;
+        let spec = chumsky_adapter::parse_str(src).expect("parse");
+        let lean = render(&spec);
+        assert!(
+            lean.contains("∀ v : Nat, v ≥ 0"),
+            "def must preserve value quantifier: {}",
+            &lean[lean.find("all_bytes_nonneg").unwrap_or(0)..]
+                .chars()
+                .take(200)
+                .collect::<String>()
+        );
+        // must not produce `def all_bytes_nonneg (s : State) : Prop := v ≥ 0`
+        // (unbound `v`).
+        assert!(
+            !lean.contains(":= v ≥ 0"),
+            "def must not strip the quantifier leaving v unbound"
+        );
     }
 }

--- a/examples/regressions/quantifiers/repro-forall-u64.qedspec
+++ b/examples/regressions/quantifiers/repro-forall-u64.qedspec
@@ -1,0 +1,29 @@
+// Quantifier regression — forall over U64 must emit P1 lint, not silently pass
+//
+// Expected: `qedgen check` emits a P1 `unchecked_quantifier` warning:
+//   property 'all_slots_valid' uses a quantifier over a type that
+//   proptest/Kani cannot exhaust — the harness emits `true` and skips the check
+//
+// Actual (pre-fix): passed check with 0 warnings; proptest/Kani harness
+//   silently returned true, giving false confidence the property was checked.
+//
+// Fix site: crates/qedgen/src/check.rs — check_completeness now detects the
+// QEDGEN_UNSUPPORTED_QUANTIFIER sentinel in rust_expression and emits an
+// unchecked_quantifier P1 warning.
+
+spec ReproForallU64
+program_id "11111111111111111111111111111111"
+
+type State
+  | Active of { slot : U64 }
+
+type Error | E
+
+property all_slots_valid :
+  forall v : U64, v >= 0
+  preserved_by all
+
+handler update : State.Active -> State.Active {
+  permissionless
+  effect { slot := slot }
+}

--- a/examples/regressions/quantifiers/repro-forall-u8.qedspec
+++ b/examples/regressions/quantifiers/repro-forall-u8.qedspec
@@ -1,0 +1,30 @@
+// Quantifier regression — forall over U8 must lower to a real iterator
+//
+// Expected: `qedgen codegen --proptest` emits
+//   fn bytes_nonneg(s: &State) -> bool {
+//     (u8::MIN..=u8::MAX).all(|v| v >= 0)
+//   }
+// `qedgen check` emits 0 unchecked_quantifier warnings.
+//
+// Actual (pre-fix): emitted fn body was `true` (stub), silently skipping
+//   the property check in all harnesses (proptest and Kani).
+//
+// Fix site: crates/qedgen/src/chumsky_adapter.rs — expr_to_rust Quant arm
+// now lowers U8/I8 quantifiers to (T::MIN..=T::MAX).all/any(|v| body).
+
+spec ReproForallU8
+program_id "11111111111111111111111111111111"
+
+type State
+  | Active of { balance : U64 }
+
+type Error | E
+
+property bytes_nonneg :
+  forall v : U8, v >= 0
+  preserved_by all
+
+handler noop : State.Active -> State.Active {
+  permissionless
+  effect { balance := balance }
+}

--- a/examples/regressions/quantifiers/repro-forall-value-binder.qedspec
+++ b/examples/regressions/quantifiers/repro-forall-value-binder.qedspec
@@ -1,0 +1,35 @@
+// Quantifier regression — Lean def must not strip ∀ v binder
+//
+// Expected: `qedgen codegen --lean` emits
+//   def bytes_nonneg (s : State) : Prop :=
+//     ∀ v : Nat, v ≥ 0
+//
+// Actual (pre-fix): stripped the ∀ v quantifier, emitting
+//   def bytes_nonneg (s : State) : Prop := v ≥ 0
+// where v is unbound — lake build fails:
+//   error: unknown identifier 'v'
+//
+// The strip logic was written for "∀ s : StateType, body" (where the def
+// already binds `s`) but fired on all leading ∀ forms, destroying the
+// binder for value quantifiers like "∀ v : Nat, …".
+//
+// Fix site: crates/qedgen/src/lean_gen.rs — render_properties_inner now
+// only strips "∀ s :" (the state variable already bound by the def),
+// preserving value-quantifier binders verbatim.
+
+spec ReproForallValueBinder
+program_id "11111111111111111111111111111111"
+
+type State
+  | Active of { balance : U64 }
+
+type Error | E
+
+property bytes_nonneg :
+  forall v : U8, v >= 0
+  preserved_by []
+
+handler noop : State.Active -> State.Active {
+  permissionless
+  effect { balance := balance }
+}


### PR DESCRIPTION
Implements quantifier support for `forall`/`exists` in `.qedspec` properties.

- U8/I8 quantifiers now lower to real Rust iterators (for example, `(u8::MIN..=u8::MAX).all(|v| …)`), so they no longer silently pass.
- U16+ quantifiers now emit a P1 `unchecked_quantifier` lint via `qedgen check` instead of silently returning `true`.
- Fixed Lean def emission that previously stripped `∀ v :` binders and left `v` unbound.
- Preservation proof templates now emit `sorry` for quantified properties instead of `omega`, since `omega` cannot prove universal goals and was generating non-compiling Lean.