### PR TITLE
fix(lean_gen): emit uninterpreted helpers as `opaque … : Bool` (issue #12)

### DIFF
--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -1347,7 +1347,17 @@ fn walk_apps(
                     .iter()
                     .map(|n| infer_lean_type(&n.node, field_types, param_types))
                     .collect();
-                out.push((func.clone(), arg_types, "Prop".to_string()));
+                // Bool, not Prop. The original v2.7.1 F5 emission used
+                // `→ Prop`, which lands at codegen but breaks `lake build`
+                // — `requires` / `ensures` clauses lower to a transition
+                // function's `if`-guard, which Lean requires to be
+                // `Decidable`. `axiom foo : T → Prop` is opaque and
+                // noncomputable, so the transition fails to compile.
+                // `Bool` is auto-`Decidable` and lifts cleanly into
+                // `Prop` positions via the standard `b = true` coercion
+                // that the call-site renderer already produces. See
+                // issue #12.
+                out.push((func.clone(), arg_types, "Bool".to_string()));
             }
             for n in args {
                 walk_apps(&n.node, field_types, param_types, out, seen);

--- a/crates/qedgen/src/lean_gen.rs
+++ b/crates/qedgen/src/lean_gen.rs
@@ -399,18 +399,31 @@ fn build_guard_cond_parts(
 /// from the spec. These are functions referenced by name in guard /
 /// ensures / effect / property bodies but never defined structurally —
 /// user-facing "named but-not-fully-modeled" security check helpers.
-/// Issue #8 finding #5. Without this emission, generated Lean references
-/// an identifier Lake never sees declared.
+/// Issue #8 finding #5 (initial axiom emission), issue #12 (use
+/// `opaque` rather than `axiom` so transitions stay computable).
+///
+/// `opaque` rather than `axiom`: an `axiom`'s declared identifier is
+/// permanently noncomputable, which propagates to any `def` that
+/// references it — including the per-handler transition functions
+/// generated below. `opaque T` declares a top-level definition whose
+/// body is hidden but is computable via the type's `Inhabited`
+/// instance (`Bool` is auto-`Inhabited`, defaulting to `false`), so
+/// the `if`-guard inside a transition function compiles. Users who
+/// want to strengthen a helper into a real check replace the `opaque`
+/// declaration with a `def` in their `Proofs.lean` (or a sibling
+/// support module imported before `Spec.lean`).
 fn emit_uninterpreted_helpers(out: &mut String, helpers: &[(String, Vec<String>, String)]) {
     if helpers.is_empty() {
         return;
     }
     out.push_str(
-        "-- Uninterpreted helpers: declared axiomatically so generated\n\
-         -- proofs typecheck even though the DSL doesn't model their\n\
-         -- semantics. Treat each as an abstract property; strengthen\n\
-         -- into a concrete definition in your support module if you\n\
-         -- want to discharge it (rather than trust it).\n",
+        "-- Uninterpreted helpers: declared opaquely so generated\n\
+         -- transitions typecheck even though the DSL doesn't model\n\
+         -- their semantics. Treat each as an abstract Bool predicate;\n\
+         -- strengthen into a concrete definition in your support\n\
+         -- module if you want to discharge it (rather than trust it).\n\
+         -- `opaque` keeps the transition functions computable\n\
+         -- (axioms would force them noncomputable).\n",
     );
     for (name, arg_types, return_type) in helpers {
         let sig = if arg_types.is_empty() {
@@ -420,7 +433,7 @@ fn emit_uninterpreted_helpers(out: &mut String, helpers: &[(String, Vec<String>,
             parts.push(return_type.clone());
             parts.join(" \u{2192} ")
         };
-        out.push_str(&format!("axiom {} : {}\n", safe_name(name), sig));
+        out.push_str(&format!("opaque {} : {}\n", safe_name(name), sig));
     }
     out.push('\n');
 }
@@ -4288,31 +4301,49 @@ type State
         }
     }
 
-    // Issue #8 finding #5 regression. `requires foo(y) else E` used to
-    // emit `(foo (y))` in the guard without ever declaring `foo`, so
-    // Lake rejected with "Unknown identifier `foo`". Now `adapt` walks
-    // guard / ensures / effect-RHS / property bodies for Expr::App
-    // sites and populates `uninterpreted_helpers`; lean_gen emits an
-    // `axiom` block at the top of Spec.lean.
+    // Issue #8 finding #5 regression + issue #12 followup. `requires
+    // foo(y) else E` used to emit `(foo (y))` in the guard without
+    // ever declaring `foo`, so Lake rejected with
+    // "Unknown identifier `foo`". v2.7.1 added `axiom foo : T → Prop`
+    // emission, but `requires` lowers to a transition function's
+    // `if`-guard — `axiom … → Prop` is opaque, noncomputable, and
+    // can't satisfy `Decidable`, so `lake build` rejected with a
+    // typeclass synth failure. Issue #12 fixes that by emitting
+    // `opaque foo : T → Bool` instead — `Bool` is auto-`Decidable`
+    // and `opaque` keeps the transition computable.
     #[test]
-    fn finding_5_uninterpreted_helpers_are_axiomatized() {
+    fn finding_5_uninterpreted_helpers_are_opaque_bool() {
         let spec_src = include_str!(
             "../../../examples/regressions/issue-8/repro-05-uninterpreted-helper.qedspec"
         );
         let spec = chumsky_adapter::parse_str(spec_src).unwrap();
         let lean = render(&spec);
         assert!(
-            lean.contains("axiom foo : Nat \u{2192} Prop"),
-            "expected `axiom foo : Nat → Prop`, got:\n{}",
+            lean.contains("opaque foo : Nat \u{2192} Bool"),
+            "expected `opaque foo : Nat → Bool`, got:\n{}",
+            lean
+        );
+        // Bare `axiom` form must not regress — issue #12 specifically
+        // rejects the `axiom`/`Prop` shape because of the Decidable +
+        // computability requirements that downstream transition
+        // functions impose on `requires`-position helpers.
+        assert!(
+            !lean.contains("axiom foo"),
+            "regressed back to `axiom`-form helper (see issue #12):\n{}",
+            lean
+        );
+        assert!(
+            !lean.contains("foo : Nat \u{2192} Prop"),
+            "regressed back to `→ Prop` return (see issue #12):\n{}",
             lean
         );
         // Helper must be declared before first use (namespace position
         // matters for Lean's single-pass elaborator).
-        let axiom_pos = lean.find("axiom foo").expect("axiom present");
+        let decl_pos = lean.find("opaque foo").expect("opaque present");
         let use_pos = lean.find("foo (y)").expect("foo call present");
         assert!(
-            axiom_pos < use_pos,
-            "axiom declared after first use:\n{}",
+            decl_pos < use_pos,
+            "helper declared after first use:\n{}",
             lean
         );
     }

--- a/examples/regressions/issue-8/repro-05-uninterpreted-helper.qedspec
+++ b/examples/regressions/issue-8/repro-05-uninterpreted-helper.qedspec
@@ -1,20 +1,23 @@
 // Finding #5 — Uninterpreted helpers in requires/ensures never declared
 //
-// Generated Spec.lean never declares `foo`. lake build:
-//   error: Unknown identifier `foo`
+// History:
+//   v2.7.0: generated Spec.lean never declared `foo`; lake build failed
+//           with "Unknown identifier `foo`". (issue #8 finding #5)
+//   v2.7.1: emitted `axiom foo : Nat → Prop` — fixed the unknown-
+//           identifier failure, but `requires` lowers to a transition
+//           `if`-guard which needs `Decidable`, and `axiom … → Prop` is
+//           opaque + noncomputable. lake build still rejected.
+//   v2.7.2: emits `opaque foo : Nat → Bool` instead. `Bool` is
+//           auto-`Decidable` so the `if`-guard typechecks; `opaque`
+//           keeps the transition function computable. (issue #12)
 //
-// This directly contradicts the docstring at ast.rs:645 which promises
-// "downstream codegen declares them as uninterpreted symbols (axioms or
-// Lean defs) in the support module." Exhaustive grep across
-// crates/qedgen/src/ finds zero axiom/opaque emission for Expr::App.
+// Expected (v2.7.2+): top of generated Spec.lean contains
+//   `opaque foo : Nat → Bool`
+// and `lake build` succeeds.
 //
-// Expected: top of generated Spec.lean contains `axiom foo : Nat → Prop`.
-// Actual: no declaration → Lean rejects.
-//
-// Fix site: Expr::App renderer needs to walk the spec, collect every
-// distinct (func_name, arity, arg_types), and emit axiom declarations.
-// Simplest v1: assume Prop in boolean contexts, emit
-// `axiom foo : T1 → T2 → ... → Prop` at the top.
+// Fix sites:
+//   crates/qedgen/src/chumsky_adapter.rs::walk_apps  — collects helpers
+//   crates/qedgen/src/lean_gen.rs::emit_uninterpreted_helpers — emits
 
 spec Repro5
 program_id "11111111111111111111111111111111"


### PR DESCRIPTION
## Summary

Closes #12. v2.7.1 F5 emitted uninterpreted helpers as `axiom foo : T → Prop` — that fixed the unknown-identifier failure from issue #8 finding #5, but left the helper unusable in `requires` position. That clause lowers to a transition function's `if`-guard which Lean requires to be `Decidable`, and `axiom … → Prop` is opaque + noncomputable.

This PR emits `opaque foo : T → Bool` instead. Two changes ripple from it:

- **`Bool` instead of `Prop`** — `Bool` is auto-`Decidable`, so the `if`-guard typechecks naturally. Call-site rendering (`(foo (y))`) is unchanged; the elaborator's `Bool ⇒ Prop` coercion (`b = true`) handles `ensures` / `property` positions.
- **`opaque` instead of `axiom`** — `opaque` declares an irreducible body via the type's `Inhabited` instance (`Bool` defaults to `false`), keeping the transition function computable. `axiom` would force `noncomputable` on every transition that references the helper, which then breaks `applyOp` pattern-matching downstream.

Spec authors who want to discharge a helper rather than trust it still upgrade to a real `def` in their support module — same path as before, just one keyword different.

## Diff (~78 insertions, 34 deletions, 3 files)

| File | Change |
|---|---|
| `crates/qedgen/src/chumsky_adapter.rs` | `walk_apps` push return type `"Prop"` → `"Bool"`. One-line fix; comment expanded explaining why. |
| `crates/qedgen/src/lean_gen.rs` | `emit_uninterpreted_helpers` emits `opaque` instead of `axiom`; doc comment updated to reflect the new shape and the rationale (irreducible body via `Inhabited`, transitions stay computable). Test `finding_5_uninterpreted_helpers_are_axiomatized` → `finding_5_uninterpreted_helpers_are_opaque_bool`, with positive assertion on the new shape and negative assertions on the old `axiom` / `→ Prop` shapes to prevent regression. |
| `examples/regressions/issue-8/repro-05-uninterpreted-helper.qedspec` | Inline header doc updated to record the v2.7.0 → v2.7.1 → v2.7.2 progression. |

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 241 passed, 0 failed (including the renamed `finding_5_uninterpreted_helpers_are_opaque_bool`)
- [x] All 10 bundled `examples/{rust,sbpf}/*/formal_verification/` regen + `lake build` clean (none use App-position helpers, so the change is structurally additive for them — verified no Lean elaboration paths broke)
- [x] `examples/regressions/issue-8/repro-05-uninterpreted-helper.qedspec` end-to-end: `qedgen init` → `qedgen codegen --lean` → `lake build` succeeds (this was the original repro from issue #12; failed under v2.7.1)
- [x] Live spec from my dagon work — 13 handlers, 6 distinct App-position uninterpreted helpers in `requires` positions, 1773-line generated `Spec.lean` — also `lake build` clean post-patch (not included in this PR but a reasonable smoke test on the size of spec the change is supposed to unlock)

## Why now

Issue #12 was filed yesterday with the minimal repro and three fix-direction options. You replied that option (a) — `→ Bool` axioms — looked straightforward; I'm submitting (a) refined to `opaque … : Bool` because `axiom … : Bool` still hits the noncomputability problem (axioms-as-keyword force noncomputable, regardless of return type). Same surface API — the existing `infer_lean_type` helper continues to drive arg types — just the declaration kind moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)