### PR TITLE
Adversarial probe refresh: framing + 57-entry exploit corpus + 3 new probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.12.0"
+version = "2.13.0"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/src/probe.rs
+++ b/crates/qedgen/src/probe.rs
@@ -8,12 +8,16 @@
 //! (operate on the spec) by design; per-runtime spec-less predicates
 //! live in the auditor SKILL.md.
 //!
-//! v2.10 initial cut: `missing_signer`, `arbitrary_cpi`,
-//! `arithmetic_overflow_wrapping`, and `lifecycle_one_shot_violation`.
-//! Remaining categories (`cpi_param_swap`, `pda_canonical_bump`) lean
-//! more heavily on spec-less / impl-side analysis (per the manual-audit
-//! calibration); their spec-aware predicates are weak. Land alongside
-//! the auditor SKILL.md per-runtime predicates rather than here.
+//! Spec-aware categories: `missing_signer`, `arbitrary_cpi`,
+//! `arithmetic_overflow_wrapping`, `lifecycle_one_shot_violation`,
+//! `unbounded_amount_param`, `permissionless_state_writer`,
+//! `init_without_pda`. Each is a *compose-able primitive* — the
+//! auditor subagent chains them into kill-chains (see SKILL.md
+//! "Compose-with-what cookbook"). Spec-less / impl-side categories
+//! (`cpi_param_swap`, `pda_canonical_bump`, `account_type_confusion`,
+//! `close_account_redirection`, `oracle_staleness`, etc.) live in
+//! the auditor SKILL.md per-runtime predicates — they need source
+//! reading the CLI doesn't do.
 
 use anyhow::{anyhow, Result};
 use serde::Serialize;
@@ -34,6 +38,19 @@ pub enum Category {
     ArbitraryCpi,
     ArithmeticOverflowWrapping,
     LifecycleOneShotViolation,
+    /// Handler accepts an integer-shaped param used in `transfers.amount` or
+    /// in an `effects` RHS, with no `requires` clause that bounds it. Pair
+    /// with `permissionless` or `missing_signer` → drain.
+    UnboundedAmountParam,
+    /// Handler is marked `permissionless` AND mutates shared state. Anyone
+    /// can grief, fill, or contend the resource. Composes with
+    /// `unbounded_amount_param` and `arithmetic_overflow_wrapping` to amplify.
+    PermissionlessStateWriter,
+    /// Init-shape handler (transitions from initial lifecycle state) but no
+    /// writable account with `pda` seeds. Default-address state collision —
+    /// two callers can both target the same canonical address. Pair with
+    /// `missing_signer` → spoof another user's init.
+    InitWithoutPda,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -124,6 +141,7 @@ pub fn run_probe(spec_path: &Path) -> Result<ProbeOutput> {
     let spec = parse_spec_file(spec_path)?;
     let spec_models_lifecycle = !spec.lifecycle_states.is_empty()
         || spec.account_types.iter().any(|a| !a.lifecycle.is_empty());
+    let initial_state = spec.lifecycle_states.first().cloned();
     let mut findings = Vec::new();
 
     for handler in &spec.handlers {
@@ -135,6 +153,13 @@ pub fn run_probe(spec_path: &Path) -> Result<ProbeOutput> {
         }
         findings.extend(predicate_arithmetic_overflow_wrapping(handler));
         if let Some(f) = predicate_lifecycle_one_shot_violation(handler, spec_models_lifecycle) {
+            findings.push(f);
+        }
+        findings.extend(predicate_unbounded_amount_param(handler));
+        if let Some(f) = predicate_permissionless_state_writer(handler) {
+            findings.push(f);
+        }
+        if let Some(f) = predicate_init_without_pda(handler, initial_state.as_deref()) {
             findings.push(f);
         }
     }
@@ -513,6 +538,281 @@ fn predicate_lifecycle_one_shot_violation(
     })
 }
 
+/// Spec-aware predicate: handler takes an integer-shaped parameter that
+/// flows into a `transfers.amount` slot or an `effects` value RHS, but no
+/// `requires` clause bounds the parameter. The agent should compose this
+/// finding with the rest of the handler shape:
+///
+/// - `+ permissionless` → any caller can pass `u64::MAX`, draining /
+///   bricking the system depending on what the param controls.
+/// - `+ missing_signer` → any caller can do the above + spoof identity.
+/// - `+ arithmetic_overflow_wrapping` on the same field → silent overflow
+///   to a wrong post-state (the wrap finding tells you the math is fragile;
+///   this one tells you the input is unbounded; together = exploit).
+///
+/// Detection is intentionally surface-level (substring match on the
+/// param name). False positives are acceptable — the auditor reads the
+/// impl to confirm. False negatives (missing a bounded param) are worse.
+fn predicate_unbounded_amount_param(handler: &ParsedHandler) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for (pname, ptype) in &handler.takes_params {
+        if !is_integer_type(ptype) {
+            continue;
+        }
+
+        let used_in_transfer = handler
+            .transfers
+            .iter()
+            .any(|t| t.amount.as_deref() == Some(pname.as_str()));
+        let used_in_effect = handler
+            .effects
+            .iter()
+            .any(|(_, _, value)| param_referenced(value, pname));
+        if !used_in_transfer && !used_in_effect {
+            continue;
+        }
+
+        let bounded = handler
+            .requires
+            .iter()
+            .any(|r| requires_bounds_param(&r.lean_expr, pname));
+        if bounded {
+            continue;
+        }
+
+        out.push(Finding {
+            id: stable_id(
+                &format!("{}::{}", handler.name, pname),
+                "unbounded_amount_param",
+            ),
+            category: Category::UnboundedAmountParam,
+            severity: Severity::High,
+            handler: handler.name.clone(),
+            spec_silent_on: format!(
+                "handler `{}` accepts param `{}: {}` used in transfer/effect, \
+                 but no `requires` clause bounds it",
+                handler.name, pname, ptype
+            ),
+            suppression_hint: format!(
+                "Add a bound: `requires {pname} <= <max> else <ErrorCode>` (or `> 0`, \
+                 `< state.<bound>`). If the param is intentionally unbounded \
+                 (e.g., admin governance setpoint), suppress with rationale."
+            ),
+            investigation_hint: format!(
+                "Open the impl for handler `{}`. Check whether `{}` flows into \
+                 a transfer amount, balance update, or PDA seed. Compose with \
+                 `permissionless` and `missing_signer` findings on this same \
+                 handler — the combined chain is usually the real vulnerability.",
+                handler.name, pname
+            ),
+            category_tag: "unbounded_amount_param".to_string(),
+        });
+    }
+    out
+}
+
+/// Spec-aware predicate: handler is marked `permissionless` AND has at
+/// least one `effects` clause. Permissionless writes to shared state are
+/// griefing surface — anyone can call repeatedly, fill the field, contend
+/// with the legitimate caller, or chain with another finding to escalate.
+///
+/// Composes with:
+/// - `unbounded_amount_param` → any value griefing
+/// - `arithmetic_overflow_wrapping` → cheap overflow trigger
+/// - `lifecycle_one_shot_violation` (suppressed by `permissionless` itself,
+///   but the chain still applies if the agent finds an undeclared state
+///   transition during impl review)
+fn predicate_permissionless_state_writer(handler: &ParsedHandler) -> Option<Finding> {
+    if !handler.permissionless {
+        return None;
+    }
+    if handler.effects.is_empty() {
+        return None;
+    }
+
+    let mutated_fields: Vec<&str> = handler.effects.iter().map(|(f, _, _)| f.as_str()).collect();
+
+    Some(Finding {
+        id: stable_id(&handler.name, "permissionless_state_writer"),
+        category: Category::PermissionlessStateWriter,
+        severity: Severity::High,
+        handler: handler.name.clone(),
+        spec_silent_on: format!(
+            "handler `{}` is marked `permissionless` AND mutates state fields: {}",
+            handler.name,
+            mutated_fields.join(", ")
+        ),
+        suppression_hint: "Either (a) drop `permissionless` and add `auth <actor>`, or (b) ensure \
+             the mutated fields cannot be griefed: per-actor PDAs, rate-limited \
+             via cooldown / lifecycle, or bounded by `requires`. If the design is \
+             intentional (truly public-callable like a crank), document the \
+             griefing-acceptable rationale inline in the spec."
+            .to_string(),
+        investigation_hint: format!(
+            "Open the impl for handler `{}`. The shared fields ({}) are writable \
+             by any caller. Look for: missing rate limits, missing cooldowns, \
+             unbounded amount params (compose with `unbounded_amount_param`), \
+             missing per-actor PDA derivation. The corpus entry \
+             `Frontrun the permissionless claim / crank` and Token-2022 \
+             `transfer_hook_reentrancy` are common amplifiers.",
+            handler.name,
+            mutated_fields.join(", ")
+        ),
+        category_tag: "permissionless_state_writer".to_string(),
+    })
+}
+
+/// Spec-aware predicate: init-shape handler (matches one of the canonical
+/// init-state names) but no writable account in the handler's `accounts`
+/// block declares `pda` seeds. Without a PDA, two distinct callers can
+/// both target the same canonical address; the second call either fails
+/// noisily or — worse — overwrites the first's state.
+///
+/// Composes with:
+/// - `missing_signer` → spoof another user's init by racing them or
+///   front-running with attacker-controlled signer/payer
+/// - `init_without_is_initialized` (per-runtime auditor predicate) → re-init
+///   replay if the impl doesn't guard
+///
+/// "Init-shape" is matched by `pre_status` ∈ {Uninitialized, Empty,
+/// Inactive} — the same convention `predicate_arbitrary_cpi` uses to
+/// recognize the init pattern. Specs without those states (e.g., a
+/// lifecycle that starts in `Active` because the program runs as a
+/// singleton or always-on engine) are out of scope for this probe;
+/// init-collision risk only applies to multi-instance programs.
+fn predicate_init_without_pda(
+    handler: &ParsedHandler,
+    _initial_state: Option<&str>,
+) -> Option<Finding> {
+    let pre = handler.pre_status.as_deref()?;
+    if !matches!(pre, "Uninitialized" | "Empty" | "Inactive") {
+        return None;
+    }
+
+    let writable_pda_present = handler
+        .accounts
+        .iter()
+        .any(|a| a.is_writable && a.pda_seeds.is_some());
+    if writable_pda_present {
+        return None;
+    }
+
+    Some(Finding {
+        id: stable_id(&handler.name, "init_without_pda"),
+        category: Category::InitWithoutPda,
+        severity: Severity::High,
+        handler: handler.name.clone(),
+        spec_silent_on: format!(
+            "init-shape handler `{}` (pre_status `{}`) declares no writable PDA — \
+             two callers may target the same canonical address",
+            handler.name, pre
+        ),
+        suppression_hint:
+            "Add a `pda` seed declaration to the writable account being initialized, \
+             scoped to the caller's identity (e.g., `pda [\"<resource>\", payer]`) \
+             or the resource's identity (e.g., `pda [\"<resource>\", <id>]`). \
+             Without per-caller / per-resource scoping, `init_without_is_initialized` \
+             becomes reachable across callers."
+                .to_string(),
+        investigation_hint: format!(
+            "Open the impl for handler `{}`. Check Anchor `#[account(init, ..., \
+             seeds = [...])]` on the writable account. If `seeds` is missing or \
+             doesn't include the caller pubkey / resource id, this is a real \
+             account-collision vulnerability. Compose with `missing_signer` for \
+             the full takeover chain.",
+            handler.name
+        ),
+        category_tag: "init_without_pda".to_string(),
+    })
+}
+
+/// True for the integer-typed DSL types `qedgen probe` reasons about.
+/// Matches what `unbounded_amount_param` cares about: scalar quantities
+/// that flow into transfer amounts or arithmetic effects.
+fn is_integer_type(ty: &str) -> bool {
+    matches!(
+        ty,
+        "U8" | "U16" | "U32" | "U64" | "U128" | "I8" | "I16" | "I32" | "I64" | "I128" | "Nat"
+    )
+}
+
+/// Substring match on word-boundary references to `param` in `value`.
+/// Surface-level: catches `param`, `state.x + param`, `wrapping_add(param)`,
+/// `param * 2`. Misses obfuscated forms — that's OK; the auditor is the
+/// real backstop.
+fn param_referenced(value: &str, param: &str) -> bool {
+    let bytes = value.as_bytes();
+    let pbytes = param.as_bytes();
+    let plen = pbytes.len();
+    if plen == 0 || bytes.len() < plen {
+        return false;
+    }
+    let is_ident_byte = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    for i in 0..=bytes.len().saturating_sub(plen) {
+        if &bytes[i..i + plen] != pbytes {
+            continue;
+        }
+        let prev_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+        let next_ok = i + plen == bytes.len() || !is_ident_byte(bytes[i + plen]);
+        if prev_ok && next_ok {
+            return true;
+        }
+    }
+    false
+}
+
+/// True when `expr` looks like an *upper* bound on `param`. Lower-only
+/// bounds (`amount > 0`) don't suppress the finding — those don't
+/// constrain the dangerous side (`u64::MAX`) of an amount param flowing
+/// into a transfer. We accept either form:
+///
+/// - LHS-bounded: `param < X`, `param <= X`, `param ≤ X`
+/// - RHS-bounded: `X > param`, `X >= param`, `X ≥ param`
+///
+/// Equality (`param == X`) also suppresses — fixed value, no overflow
+/// surface. Lower-only forms (`param > 0`, `param >= 1`) do NOT suppress.
+fn requires_bounds_param(expr: &str, param: &str) -> bool {
+    if !param_referenced(expr, param) {
+        return false;
+    }
+
+    // Equality / inequality fix the param exactly or constrain it from
+    // above implicitly. Cheap escape hatch.
+    if expr.contains("==") || expr.contains("!=") || expr.contains('\u{2260}') {
+        return true;
+    }
+
+    // Tokenize-ish: split on whitespace and look for a (lhs, op, rhs)
+    // triple where the param is on the bounded side of an inequality.
+    // Multi-conjunct expressions (`a > 0 && a < MAX`) are scanned for
+    // any bound that satisfies the upper-bound shape.
+    let normalized = expr
+        .replace('\u{2264}', "<=")
+        .replace('\u{2265}', ">=")
+        .replace("&&", " ")
+        .replace("||", " ")
+        .replace(" and ", " ")
+        .replace(" or ", " ");
+    let tokens: Vec<&str> = normalized.split_whitespace().collect();
+
+    let upper_ops = ["<", "<="];
+    let lower_ops = [">", ">="];
+
+    // Sliding window of length 3.
+    for w in tokens.windows(3) {
+        let (lhs, op, rhs) = (w[0], w[1], w[2]);
+        // LHS-bounded upper: `param <[=] _`
+        if lhs == param && upper_ops.contains(&op) {
+            return true;
+        }
+        // RHS-bounded upper: `_ >[=] param`
+        if rhs == param && lower_ops.contains(&op) {
+            return true;
+        }
+    }
+    false
+}
+
 fn stable_id(handler: &str, category: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(handler.as_bytes());
@@ -525,6 +825,7 @@ fn stable_id(handler: &str, category: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chumsky_adapter::parse_str;
 
     fn make_handler(name: &str, who: Option<&str>, permissionless: bool) -> ParsedHandler {
         ParsedHandler {
@@ -739,5 +1040,174 @@ mod tests {
         assert_eq!(a.len(), 8);
         let c = stable_id("withdraw", "arbitrary_cpi");
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn unbounded_amount_param_fires_on_lower_only_bound() {
+        // `requires amount > 0` is a lower bound; doesn't constrain the
+        // u64::MAX side. Probe must fire so the auditor escalates.
+        let src = r#"spec T
+state { pool : U64 }
+handler deposit (amount : U64) {
+  permissionless
+  requires amount > 0 else InvalidAmount
+  effect { pool += amount }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        let findings = predicate_unbounded_amount_param(h);
+        assert_eq!(findings.len(), 1, "expected one finding: {findings:#?}");
+        assert_eq!(findings[0].category_tag, "unbounded_amount_param");
+    }
+
+    #[test]
+    fn unbounded_amount_param_suppressed_by_upper_bound() {
+        // `requires amount <= state.cap` is a real upper bound — suppress.
+        let src = r#"spec T
+state { pool : U64, cap : U64 }
+handler deposit (amount : U64) {
+  permissionless
+  requires amount <= state.cap else CapExceeded
+  effect { pool += amount }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        let findings = predicate_unbounded_amount_param(h);
+        assert!(
+            findings.is_empty(),
+            "upper bound should suppress: {findings:#?}"
+        );
+    }
+
+    #[test]
+    fn unbounded_amount_param_suppressed_by_rhs_form() {
+        // `requires state.cap >= amount` — RHS-bounded upper bound.
+        let src = r#"spec T
+state { pool : U64, cap : U64 }
+handler deposit (amount : U64) {
+  permissionless
+  requires state.cap >= amount else CapExceeded
+  effect { pool += amount }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        let findings = predicate_unbounded_amount_param(h);
+        assert!(
+            findings.is_empty(),
+            "RHS-bounded upper should suppress: {findings:#?}"
+        );
+    }
+
+    #[test]
+    fn permissionless_state_writer_fires_on_permissionless_with_effect() {
+        let src = r#"spec T
+state { counter : U64 }
+handler crank {
+  permissionless
+  effect { counter += 1 }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        let f = predicate_permissionless_state_writer(h).expect("expected finding");
+        assert_eq!(f.category_tag, "permissionless_state_writer");
+    }
+
+    #[test]
+    fn permissionless_state_writer_suppressed_when_authd() {
+        // Has auth — no permissionless flag — no finding.
+        let src = r#"spec T
+state { counter : U64 }
+handler crank {
+  auth admin
+  accounts { admin : signer }
+  effect { counter += 1 }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        assert!(predicate_permissionless_state_writer(h).is_none());
+    }
+
+    #[test]
+    fn permissionless_state_writer_suppressed_when_no_effects() {
+        // Permissionless read-only handler — no shared state to grief.
+        let src = r#"spec T
+state { counter : U64 }
+handler ping {
+  permissionless
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        assert!(predicate_permissionless_state_writer(h).is_none());
+    }
+
+    #[test]
+    fn init_without_pda_fires_on_init_handler_no_pda() {
+        // pre_status `Uninitialized` matches the init shape; the
+        // writable account has no pda seeds — collision risk.
+        let src = r#"spec T
+type State
+  | Uninitialized
+  | Active of { owner : Pubkey, balance : U64 }
+
+handler initialize : State.Uninitialized -> State.Active {
+  auth payer
+  accounts {
+    payer : signer, writable
+    target : writable
+  }
+  effect { balance := 0 }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        let f = predicate_init_without_pda(h, Some("Uninitialized")).expect("expected finding");
+        assert_eq!(f.category_tag, "init_without_pda");
+    }
+
+    #[test]
+    fn init_without_pda_suppressed_when_pda_present() {
+        let src = r#"spec T
+type State
+  | Uninitialized
+  | Active of { owner : Pubkey, balance : U64 }
+
+handler initialize : State.Uninitialized -> State.Active {
+  auth payer
+  accounts {
+    payer : signer, writable
+    target : writable, pda ["target", payer]
+  }
+  effect { balance := 0 }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        assert!(predicate_init_without_pda(h, Some("Uninitialized")).is_none());
+    }
+
+    #[test]
+    fn init_without_pda_suppressed_when_lifecycle_starts_in_active() {
+        // Spec doesn't have an Uninitialized / Empty / Inactive state —
+        // not init-shape, no collision risk to flag.
+        let src = r#"spec T
+type State
+  | Active of { owner : Pubkey, count : U64 }
+  | Frozen
+
+handler add (i : U8) : State.Active -> State.Active {
+  auth admin
+  accounts { admin : signer }
+  effect { count += 1 }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = &spec.handlers[0];
+        assert!(predicate_init_without_pda(h, Some("Active")).is_none());
     }
 }

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.12.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.12.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.12.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.12.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
 
 [workspace]

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.12.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
 
 [workspace]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Agent skill for spec-driven verification of Solana programs — .qedspec specs generate proptest harnesses, Kani BMC harnesses, Lean 4 proofs, Anchor and Quasar agent-fill scaffolds, deploy-safety ratchets, and CI workflows.",
   "keywords": [
     "agent-skill",

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -410,6 +410,90 @@ the runtime would otherwise enforce.
   `*account.lamports.borrow_mut()` outside a close path.
 - Corpus: OtterSec "King of the SOL" post.
 
+### `init_config_field_unanchored` — CRITICAL (DAMM-v2 shape)
+Spec-less only. The **write-side companion** to
+`field_chain_missing_root_anchor`. An init handler accepts a
+`Pubkey` (or address-shaped arg) and stores it directly into the
+config / state account that downstream handlers later trust as a
+"stored authority field." Because the stored value originated
+from caller-supplied bytes — not from a canonical PDA derivation
+or an authenticated signer — every later handler that trusts the
+field is trusting attacker input.
+
+The classic chain: `initialize` is permissionless (or the signer
+isn't the canonical authority), attacker frontruns the legitimate
+init with their own ATA / pubkey, the program persists it, and
+subsequent fee / yield / withdraw handlers send funds to the
+attacker-controlled address.
+
+- **Anchor:** look at every `init` (or `init_if_needed`) handler.
+  For each `Pubkey` / address parameter and each `vault_config.X =
+  caller_supplied_X` assignment in the body: is `caller_supplied_X`
+  bound to a `Signer<'info>` (the caller authenticated as that
+  authority)? Is it the result of a `find_program_address` call
+  with canonical seeds? If neither, the field is unanchored on the
+  write side. Pair with permissionless init (no `Signer` constraint
+  matched against pre-existing trusted state) for the full
+  frontrun chain.
+- **Native:** same pattern; trace each `state.field = <input>`
+  back to the handler's account list. If the input is from
+  `accounts[i].key()` without a signer check or PDA-derivation
+  proof, the write is unanchored.
+- Companion to `field_chain_missing_root_anchor`: that category
+  catches *read-side* trust of unanchored fields; this one catches
+  the *write* that planted the unanchored value to begin with.
+  Both can ship in the same program (DAMM-v2 OOD eval found
+  exactly this pair).
+- Corpus: `damm-v2-fee-routing` Apr 2026 OOD eval — `creator_quote_ata`
+  taken as init param, stored in `vault_config`, later trusted in
+  `route_fees` as the canonical fee destination.
+
+### `bounty_intent_drift` — varies (HIGH when intent is a security invariant)
+Spec-less only. The handler / program ships with stated intent
+(bounty description, README, docstring, comment, mode flag) that
+the implementation **doesn't enforce**. Not a structural primitive
+— a *gap between declared and implemented behavior*. Severity
+follows whether the stated invariant was a security claim or a
+UX nicety.
+
+Three common shapes:
+
+1. **Constant defined, never read.** `MIN_PAYOUT_LAMPORTS_DEFAULT
+   = 1_000`, but no handler references it. The minimum-payout
+   guarantee exists in the constants module and nowhere else.
+2. **Stored field written at init, never read in handlers.**
+   `vault_config.y0_total_allocation` set in `initialize`, never
+   referenced in `route_fees` / `claim_fee`. The locked/unlocked
+   scaling logic is stubbed.
+3. **Mode/discriminator param accepted but downstream-equivalent.**
+   Bounty says "quote-only fees"; `initialize` accepts
+   `collect_fee_mode: u8` and persists it; `route_fees` doesn't
+   branch on the value. `BothToken` (mode 0) silently passes,
+   despite the bounty's quote-only claim.
+
+The auditor walks:
+- The bounty description / README / handler docstrings for
+  stated invariants (text-search for "must", "always", "only",
+  rate / window / cap claims).
+- `cargo check --message-format=json` for `dead_code` warnings on
+  constants / fields.
+- Stored config fields' read-side: `grep` for the field name
+  across all handlers; if zero readers, flag it.
+- Mode parameters: trace the param into the body; if no `match` /
+  `if` branches on the value, the mode is decorative.
+
+Severity:
+- **HIGH** when the stated invariant is a security claim (slippage
+  bound, quote-only, rate cap, time window).
+- **MEDIUM** when it's an economic claim that doesn't immediately
+  translate to fund loss but could (rounding direction, fee
+  discount).
+- **LOW** when it's UX (event payloads with stale fields, etc.).
+
+Corpus: `damm-v2-fee-routing` Apr 2026 — quote-only intent
+unenforced, 24h crank entirely absent, `y0_total_allocation`
+stored-and-never-read.
+
 ### `transfer_hook_reentrancy` — HIGH (Token-2022 only)
 Token-2022 transfer hooks can call back into the calling program
 during a transfer. Handler that updates state across a transfer
@@ -444,6 +528,8 @@ exhaustive; use as a thinking primer, not a checklist.
 | permissionless marker | + | unbounded amount param | = | griefing / draining via repeated calls (HIGH) |
 | permissionless init | + | unchecked authority field on init | = | attacker bakes their own pubkey as `mint_authority` / `withdraw_authority` / `admin` at init time → privileged CPI authority on every later operation (CRIT) |
 | field_chain_missing_root_anchor | + | typed-but-unanchored CPI authority field | = | forge a fake collateral chain that the validator accepts as internally-consistent → invoke privileged CPI (mint, withdraw) under the real authority (CRIT, Cashio shape) |
+| init_config_field_unanchored | + | permissionless_state_writer init | = | frontrun legitimate init, bake attacker pubkey as stored "creator" / "authority" field, capture every fee/yield/withdraw routed through it (CRIT, DAMM-v2 OOD shape) |
+| bounty_intent_drift (mode flag accepted but unbranched) | + | permissionless caller | = | invoke the "forbidden" mode the bounty claimed it didn't allow, every time (HIGH→CRIT depending on what the mode controls) |
 | lamport_write_demotion | + | rent-exempt PDA | = | silent rent extraction, downstream rent failure (MED→HIGH) |
 | saturating_by_design (`+=!`) | + | amount-shaped field | = | silent value loss, no error path (MED→HIGH) |
 

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -267,15 +267,49 @@ shape; downstream reads trust the spoof.
 
 ### `missing_owner_check` — CRITICAL
 Spec-less only — handler reads or trusts data from an account
-whose `owner` field is not validated against the expected program.
-A token account from program X is interchangeable with one from
-program Y until the owner is checked.
+whose **runtime `owner` field** (the program that owns the account
+on Solana) is not validated against the expected program. A token
+account from program X is interchangeable with one from program Y
+until the owner is checked.
 - **Anchor:** raw `AccountInfo<'info>` field used as a token account
   source/destination without an owner=Token-Program constraint. Anchor
   `Account<TokenAccount>` enforces this; raw AccountInfo doesn't.
 - **Native:** any `account.data.borrow()` or struct deserialize
   without first verifying `account.owner == &expected_program_id`.
-- Corpus: Cashio fake-account chain.
+- Corpus: typed-account-with-untyped-owner pattern (Neodyme).
+
+### `field_chain_missing_root_anchor` — CRITICAL (Cashio shape)
+Spec-less only. **Distinct from `missing_owner_check`** — Anchor's
+typed wrappers (`Account<T>`) close the runtime-owner question for
+an incoming account, but **the *fields* on that typed account
+remain untrusted at the field level**. A `Pubkey` field stored on
+`Account<Bank>` was written by the program, but a key passed in
+the handler's accounts struct claiming "I am that bank's
+crate_token" is just bytes the caller supplied, unless the
+validator pins it back to the bank's stored value.
+
+A fresh auditor walking the catalog from `missing_owner_check`
+will see "Anchor types this account, owner check enforced — no
+finding" and move on. That's correct for the owner check, wrong
+for field-level forgery. The Cashio exploit is exactly this gap.
+
+- **Anchor:** for every `Validate::validate()` (or per-handler
+  validation block) and for each passed-in account A and field F
+  on a stored state account S: trust is *anchored* iff F is
+  referenced (`A.key() == s.f`, `S.f == A.something`). If A is
+  only checked against another passed-in account B
+  (`A.key() == B.field`), the chain is *internally consistent*
+  but **not anchored** — attacker forges A and B together.
+  Pattern to grep for: chains of `assert_keys_eq!` /
+  `==` / `has_one` that thread through passed-in accounts without
+  ever touching a stored-state field on a PDA-owned `Account<T>`.
+- **Native:** same shape; walk every `key()` / `pubkey ==`
+  comparison. If neither side is `<trusted-state>.<field>`, the
+  comparison only proves consistency, not anchoring.
+- Corpus: Cashio fake-account chain — the canonical example
+  (`crate_token` / `crate_mint` / `crate_collateral_tokens` form
+  an internally-consistent chain that's never anchored to
+  `bank.crate_token` / `bank.crate_mint`). $52.8M in 2022.
 
 ### `close_account_redirection` — HIGH
 Anchor `close = <destination>` field, or manual close via lamport
@@ -408,6 +442,8 @@ exhaustive; use as a thinking primer, not a checklist.
 | discriminator_collision | + | shared deserializer between handlers | = | cross-type spoof → privileged action (HIGH) |
 | transfer_hook_reentrancy | + | mid-transfer state read | = | classic reentrancy (Solana-native, HIGH→CRIT) |
 | permissionless marker | + | unbounded amount param | = | griefing / draining via repeated calls (HIGH) |
+| permissionless init | + | unchecked authority field on init | = | attacker bakes their own pubkey as `mint_authority` / `withdraw_authority` / `admin` at init time → privileged CPI authority on every later operation (CRIT) |
+| field_chain_missing_root_anchor | + | typed-but-unanchored CPI authority field | = | forge a fake collateral chain that the validator accepts as internally-consistent → invoke privileged CPI (mint, withdraw) under the real authority (CRIT, Cashio shape) |
 | lamport_write_demotion | + | rent-exempt PDA | = | silent rent extraction, downstream rent failure (MED→HIGH) |
 | saturating_by_design (`+=!`) | + | amount-shaped field | = | silent value loss, no error path (MED→HIGH) |
 

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -47,6 +47,40 @@ just string analysis, no type resolution required for most predicates.
   unavailable. sBPF predicates ignore LSP entirely (rust-analyzer
   doesn't index `.s` files).
 
+## Adversarial mindset
+
+Approach every program assuming there's a bug. The spec is a hypothesis
+the user wants to disprove; the implementation is a translator that may
+have introduced bugs on top. A linear walk through the catalog surfaces
+generic taxonomy hits — those alone are not enough. **The bear-hug
+demands you find something the user missed**, and that requires
+composing primitives the way an attacker would, not running a checklist.
+
+Working assumptions when auditing:
+
+- **The author tested the happy path.** Bugs hide in unhappy paths:
+  integer edges, lifecycle skips, account confusion, CPI return-value
+  trust, PDA seed reuse, missing rent-exemption, sysvar substitution.
+- **Frameworks have escape hatches.** Anchor's typed wrappers
+  (`Account<T>`, `Signer`, `Program<T>`, `Sysvar<T>`) close many
+  primitives by construction. Any `AccountInfo` / `UncheckedAccount`
+  field is an explicit opt-out and a gap to investigate. Native Rust
+  handlers carry no defaults — every check is the author's
+  responsibility, missing or present.
+- **Composition beats taxonomy.** A "small" finding (write-without-read,
+  saturating-by-design, missing freshness check) chains into a critical
+  when paired with another small finding. The user pays for kill-chains.
+  Always ask "compose with what?"
+- **Refresh assumptions every audit.** Stale heuristics produce stale
+  findings. Read `exploits.md` (57 entries: named incidents, generic
+  primitives, DeFi-shape attacks, audit-firm patterns) before writing
+  the report. For each entry, ask "could the same shape happen here?"
+  Investigate even if the category isn't in the spec-aware probe output.
+
+If you finish an audit and your worst finding is a generic
+"`AccountInfo` should be `Account`" without a kill-chain, you've
+auditied wrong. Go back to the corpus and compose.
+
 ## How it works
 
 1. **Detect mode and runtime.**
@@ -66,9 +100,43 @@ just string analysis, no type resolution required for most predicates.
 3. **Investigate.** For each (handler, category):
    - Open the handler's source with Read.
    - Apply the per-runtime predicate from the catalog below.
+   - Walk the relevant `exploits.md` entries for the same primitive —
+     for each one, ask "could this shape happen here?"
    - Classify: real-vulnerability / spec-gap / suppressed.
 
-4. **Scaffold silently** (per the tactile-tooling principle — no consent
+4. **Escalate every real-vuln finding before writing it up.** This is
+   where the bear-hug lives — finding the kill-chain, not just the
+   primitive. For each finding classified as "real vulnerability",
+   answer two questions before drafting the report entry:
+
+   **a) Standalone severity.** What's the worst an attacker can do
+   with *just this primitive*, no chains? Concrete state / dollar
+   impact, not a category label.
+
+   **b) Compose-with-what.** List 1–3 other findings or known
+   primitives in this codebase that compose with this one. What's the
+   worst-case kill-chain? **If a small finding chains into a critical,
+   the severity is the chain's ceiling, not the primitive's.** Some
+   common compositions (the cookbook below has more):
+
+   - Missing signer + arbitrary CPI = full account takeover (CRIT).
+   - Numeric overflow + lifecycle violation = state corruption (CRIT).
+   - Account-type confusion + missing owner check = forged-data trust (CRIT).
+   - Frontrunnable swap + oracle staleness = sandwich + MEV (HIGH).
+   - Close-account redirection + missing signer check on close = drain
+     entire PDA's rent + state (CRIT).
+   - Saturating-by-design on amount-shaped field + permissionless caller
+     = silent value loss with no error path (HIGH).
+   - Non-canonical PDA bump + signer-derived seeds = signer
+     impersonation (CRIT).
+   - Init-without-is-initialized + close-without-zero-discriminator =
+     account replay (HIGH).
+
+   If a primitive doesn't compose with anything reachable in this
+   codebase, write that down: "stand-alone, no chain identified,
+   severity X." Don't stop at category; the user pays for kill-chains.
+
+5. **Scaffold silently** (per the tactile-tooling principle — no consent
    prompts in the middle of the named operation):
    - In spec-less mode, sketch a `.qedspec` from observed handlers via
      `qedgen spec --idl <path>` (Anchor with IDL) or by writing a
@@ -80,10 +148,12 @@ just string analysis, no type resolution required for most predicates.
      opt-in heavy artifacts that the user invokes explicitly via
      `qedgen codegen`.
 
-5. **Return a vulnerability-first digest.** Real findings first
+6. **Return a vulnerability-first digest.** Real findings first
    (CRIT → HIGH → MED), then spec-gap suggestions, then suppressed
-   items. Footer lists scaffolded artifacts so the user can see what
-   was created.
+   items. Each entry shows kill-chain (or stand-alone tag) and
+   composes-with hint so the user can verify the chain reasoning.
+   Footer lists scaffolded artifacts so the user can see what was
+   created.
 
 ## Category catalog
 
@@ -106,53 +176,6 @@ Spec-less per-runtime:
   signer is enforced downstream by the callee program. Not a finding.
 - **sBPF:** look for the bytes-comparison pattern that checks the signer
   flag in the AccountInfo header.
-
-### `unconstrained_account_info` — HIGH (Anchor; spec-less)
-Anchor's `/// CHECK:` annotation is the framework's escape hatch for
-`AccountInfo<'info>` accounts that the user has manually verified.
-**The annotation alone is not justification** — it must be paired with
-a real `constraint = ...` / `address = ...` / `has_one = ...` clause
-that semantically pins the account.
-
-Investigate:
-- Each `/// CHECK:` site in `#[derive(Accounts)]` structs.
-- For each, confirm there's an accompanying constraint that makes the
-  comment's "I take responsibility" stance verifiable.
-- Particularly suspect: `AccountInfo` accounts used as `close = X`
-  recipient, transfer destination, or PDA seed input. These are
-  passive-recipient roles that look harmless but redirect value when
-  the caller controls the account.
-
-Real-world hit: escrow Issue #18 (2026-04-26) — `Exchange.initializer:
-AccountInfo<'info>` with `/// CHECK:` and `close = initializer` on the
-escrow account, but no `has_one = initializer` constraint. Caller
-passed any writable account; rent went there.
-
-### `unchecked_account_against_state` — HIGH (Anchor; spec-less)
-Handler has a writable account whose name semantically matches a
-state-stored Pubkey field, but the impl doesn't bind them. Without
-the binding, the caller can pass any account that satisfies the
-mechanical type constraint, defeating the spec's intent.
-
-Investigate per-handler:
-- Read the `#[derive(Accounts)]` struct for `mut` accounts of token
-  / account types.
-- Cross-reference each against the program's State struct (typically
-  `#[account] pub struct StateName { ... }`) for Pubkey fields with
-  similar names.
-- For each suspicious pair, look for a binding: `address = state.X`,
-  `constraint = account.key() == state.X`, `has_one = X`, or `seeds`
-  derivation that incorporates `state.X`.
-- Absence of any binding on a writable account that could redirect
-  value (token transfers, close-rent, account closure) is the
-  finding.
-
-Real-world hit: escrow Issue #17 (2026-04-26) —
-`Exchange.initializer_receive_token_account: Account<'info, TokenAccount>`
-with no constraint, despite escrow state storing
-`initializer_token_account: Pubkey` at initialize time. Taker passed
-attacker-controlled accounts, routed taker→initializer transfer to
-themselves, drained escrow.
 
 ### `arbitrary_cpi` — HIGH
 Spec-aware: handler has a writable `token`-typed account but spec
@@ -226,9 +249,193 @@ Spec-less only.
   via helpers (e.g., `check_pool_authority_address(...)?` returning a
   bump seed) is also canonical — recognize the indirection.
 
+### `account_type_confusion` — CRITICAL (Wormhole shape)
+Spec-less only — a "well-known" account (sysvar, token program,
+mint, mint-authority, vault) is typed as `AccountInfo<'info>` /
+`UncheckedAccount` instead of its strongly-typed wrapper. Attacker
+substitutes a forged account whose data layout mimics the expected
+shape; downstream reads trust the spoof.
+- **Anchor:** `AccountInfo<'info>` / `UncheckedAccount<'info>` for
+  any of: `Mint`, `Token` (token account), `Sysvar<T>`, `Program<T>`,
+  or a strongly-typed user-defined `Account<MyState>`. Each one is a
+  finding *unless* there's an explicit downstream key/owner check.
+- **Native:** AccountInfo passed for a sysvar / mint / token
+  program without an `==` check on the well-known program ID, or for
+  a user account without an `is_initialized` discriminator check.
+- Corpus: Wormhole sysvar spoof (`exploits.md` named-incident #1),
+  Cashio mint trust chain.
+
+### `missing_owner_check` — CRITICAL
+Spec-less only — handler reads or trusts data from an account
+whose `owner` field is not validated against the expected program.
+A token account from program X is interchangeable with one from
+program Y until the owner is checked.
+- **Anchor:** raw `AccountInfo<'info>` field used as a token account
+  source/destination without an owner=Token-Program constraint. Anchor
+  `Account<TokenAccount>` enforces this; raw AccountInfo doesn't.
+- **Native:** any `account.data.borrow()` or struct deserialize
+  without first verifying `account.owner == &expected_program_id`.
+- Corpus: Cashio fake-account chain.
+
+### `close_account_redirection` — HIGH
+Anchor `close = <destination>` field, or manual close via lamport
+transfer to a destination, where the destination is signer-controlled
+and not validated against an expected wallet (creator, treasury, etc.).
+- **Anchor:** `#[account(mut, close = receiver)]` where `receiver`
+  is `AccountInfo` or `UncheckedAccount` with no constraint.
+- **Native:** manual `**from.try_borrow_mut_lamports()? -= x;
+  **to.try_borrow_mut_lamports()? += x;` with no destination check.
+- Pair with `missing_signer` or `permissionless` marker → drain rent
+  from any closable PDA. Corpus: "Account close redirected to
+  attacker" pattern.
+
+### `discriminator_collision` — HIGH
+Two account types with the same first-8-bytes discriminator (Anchor
+default). Attacker submits an account of type A where type B is
+expected; deserialize succeeds; reads return attacker-controlled
+state.
+- **Anchor:** look for explicit `#[account(zero_copy)]` types or
+  user-named discriminators that overlap. Default Anchor discriminator
+  is `sha256("account:<TypeName>")[..8]` — generic names risk
+  collision (`State`, `Vault`, `Pool` shared across crates linked in).
+- **Native:** explicit discriminator bytes; check for the same
+  collision shape.
+- Pair with `missing_owner_check` → forged-data trust.
+
+### `pda_seed_collision` — HIGH
+PDA seeds insufficient to discriminate between different domains —
+e.g., user-vault PDA seeded with `["vault"]` instead of
+`["vault", user.key()]` lets one user's vault occupy another's.
+- **Anchor:** `seeds = [...]` lacking the user-pubkey or
+  resource-id-shaped seed; static seeds across handler families.
+- **Native:** `find_program_address(&[seeds], &id)` with seeds
+  that don't include caller-distinguishing data.
+- Pair with `missing_signer` → take over another user's account.
+
+### `unvalidated_remaining_accounts` — HIGH
+Handler iterates `ctx.remaining_accounts` (or
+`accounts.iter().skip(N)`) without validating type / owner / key.
+Attacker passes a malicious account that satisfies the iteration but
+not the implicit type assumption.
+- **Anchor:** `for acc in ctx.remaining_accounts.iter()` without
+  immediate `Account::try_from` (which checks discriminator+owner)
+  or explicit checks.
+- **Native:** any per-iteration `account_info_iter.next()` without
+  type/owner validation.
+
+### `account_not_reloaded_after_cpi` — HIGH
+Handler invokes a CPI that may mutate a passed-in account, then
+reads that account's state without `account.reload()` (Anchor) /
+re-deserialize (native). Stale read decisions trust pre-CPI values
+that the CPI just changed.
+- **Anchor:** `token::transfer(...)?;` followed by reads from the
+  involved token account without `account.reload()?`.
+- **Native:** repeated `unpack` of the same account before/after
+  `invoke_signed`.
+
+### `init_without_is_initialized` — HIGH
+Init-style handler that doesn't check whether the target account
+has already been initialized. Re-init replays state, wipes existing
+balance/votes/whatever.
+- **Anchor:** `init` constraint requires the account to NOT exist
+  (`payer = ...` allocates fresh). `init_if_needed` opts out of this
+  protection — every use is a finding *unless* the body explicitly
+  guards on a discriminator/sentinel field.
+- **Native:** missing `if account.is_initialized` check at the top
+  of init handlers; or the init handler accepts an existing account
+  and overwrites in place.
+- Corpus: "Init-without-is-initialized" pattern.
+
+### `oracle_staleness` — HIGH (DeFi-specific)
+Spec-less only — handler reads a price/rate-shaped field from an
+oracle account without verifying freshness (timestamp window) or
+confidence (deviation bound).
+- **Anchor / Native:** `pyth::load_price_feed(...)` followed by
+  immediate use without `get_price_no_older_than` or equivalent.
+  Switchboard: `AggregatorAccountData::get_result()` without a
+  staleness check on `latest_confirmed_round.round_open_timestamp`.
+- Corpus: Mango / Solend / Nirvana / Loopscale oracle exploits.
+
+### `frontrunnable_no_slippage` — HIGH (DeFi-specific)
+Permissionless swap-shape handler accepts no `min_amount_out` /
+`max_amount_in` parameter, or accepts one but never asserts on it.
+Sandwich-bot bait.
+- **Spec-aware:** handler effects modify two amount-shaped fields in
+  opposite directions but no `requires` clause references the
+  resulting ratio.
+- **Anchor / Native:** `swap`-shape handler signature with no
+  `min_*` parameter, or with one that's ignored in the body.
+- Corpus: "Sandwich / MEV against AMM swap" pattern.
+
+### `lamport_write_demotion` — MEDIUM
+Direct lamport mutation via `**account.try_borrow_mut_lamports()? +=
+x;` instead of `system_program::transfer(...)`. Demotes an executable
+or rent-exempt account silently, can also bypass ownership checks
+the runtime would otherwise enforce.
+- **Native / Anchor (rare):** any direct mutation of
+  `*account.lamports.borrow_mut()` outside a close path.
+- Corpus: OtterSec "King of the SOL" post.
+
+### `transfer_hook_reentrancy` — HIGH (Token-2022 only)
+Token-2022 transfer hooks can call back into the calling program
+during a transfer. Handler that updates state across a transfer
+boundary without the new state visible to the hook is reentrancy-
+vulnerable.
+- **Anchor / Native:** Token-2022 transfer (`transfer_checked` with
+  `mint = TOKEN_2022_PROGRAM_ID`) where program state is mutated
+  *after* the transfer with the pre-transfer state still trusted.
+- Corpus: "Reentrancy via Token-2022 transfer hook" — first
+  Solana-native reentrancy class.
+
+## Compose-with-what cookbook
+
+The bear-hug lives in chains. Walk this cookbook when a finding
+looks "small" — a chain promotes it to the ceiling severity. Not
+exhaustive; use as a thinking primer, not a checklist.
+
+| Primitive A | + | Primitive B | = | Chain ceiling |
+|---|---|---|---|---|
+| missing_signer | + | arbitrary_cpi | = | full account takeover via CPI authority forgery (CRIT) |
+| missing_signer | + | close_account_redirection | = | drain rent + state from any closable PDA (CRIT) |
+| account_type_confusion | + | missing_owner_check | = | forged-data trust → arbitrary state read (CRIT) |
+| pda_seed_collision | + | missing_signer | = | take over another user's account (CRIT) |
+| non_canonical_bump | + | signer-derived seeds | = | signer impersonation, sign for any address (CRIT) |
+| oracle_staleness | + | frontrunnable_no_slippage | = | sandwich-amplified single-block extraction (HIGH→CRIT) |
+| arithmetic_overflow_wrapping | + | lifecycle_one_shot_violation | = | state corruption past intended ceiling (CRIT) |
+| init_without_is_initialized | + | close_without_zero_discriminator | = | account replay, double-spend rent / votes (HIGH) |
+| account_not_reloaded_after_cpi | + | mid-handler trust on stale balance | = | CPI return-value trust → fund loss (HIGH) |
+| unvalidated_remaining_accounts | + | iterator-driven state mutation | = | injected accounts mutate authorized state (HIGH) |
+| discriminator_collision | + | shared deserializer between handlers | = | cross-type spoof → privileged action (HIGH) |
+| transfer_hook_reentrancy | + | mid-transfer state read | = | classic reentrancy (Solana-native, HIGH→CRIT) |
+| permissionless marker | + | unbounded amount param | = | griefing / draining via repeated calls (HIGH) |
+| lamport_write_demotion | + | rent-exempt PDA | = | silent rent extraction, downstream rent failure (MED→HIGH) |
+| saturating_by_design (`+=!`) | + | amount-shaped field | = | silent value loss, no error path (MED→HIGH) |
+
 ## Classification rules
 
-Each finding lands in one of three buckets:
+Each finding lands in one of three buckets, then gets a severity
+keyed off attacker capability — not category label.
+
+### Severity grading (attacker-capability rubric)
+
+Use the chain's ceiling, not the primitive's:
+
+- **CRITICAL** — direct fund loss, total state takeover, unbounded
+  mint, or permanent denial-of-service to all users. Attacker
+  capability: any user, any tx, repeatable. No special preconditions.
+- **HIGH** — conditional fund loss (requires victim action, specific
+  market state, or favorable timing), griefing of all users, or
+  partial state takeover. Attacker capability: any user, but bounded
+  by economic preconditions, victim cooperation, or competition.
+- **MEDIUM** — exploit possible but bounded by attacker's own
+  economic stake or narrow precondition; partial DoS; data leak that
+  doesn't immediately translate to fund loss.
+- **LOW** — surface anomaly that doesn't compose into a real attack.
+  Surface as informational. **A LOW that composes to CRIT is reported
+  as CRIT** — never let a chain's ceiling escape.
+
+If you can't articulate a concrete attacker capability for the
+severity you assigned, downgrade.
 
 ### Real vulnerability
 The impl genuinely has the bug. Action: surface as a finding with
@@ -260,6 +467,8 @@ finding doesn't re-surface on the next run.
 **Location:** `programs/<crate>/src/<file>:<line>`
 **Mode:** spec-less (no .qedspec at audit time)
 **Runtime:** Anchor
+**Standalone severity:** HIGH (chain promotes to CRIT)
+**Kill-chain:** <category> + <other primitive in this codebase> = <impact>
 
 ### Vulnerable code
 
@@ -269,7 +478,15 @@ finding doesn't re-surface on the next run.
 
 ### Attack scenario
 
-<concrete narrative>
+<concrete narrative — name the attacker action, the chained primitive,
+and the resulting state / fund delta. If stand-alone, say "stand-alone,
+no chain identified" explicitly so reviewers know it was checked.>
+
+### Composes with
+
+- <other finding in this audit, or known primitive in the codebase>
+  → <amplified impact>
+- <other> → <amplified impact>
 
 ### Proposed fix (impl)
 
@@ -282,6 +499,10 @@ finding doesn't re-surface on the next run.
 ​```
 <minimal .qedspec edit that would have caught this in spec-aware mode>
 ​```
+
+### Corpus reference
+
+`exploits.md` § <named incident or pattern> — same shape.
 ```
 
 ### Digest (returned to orchestrator)

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -505,6 +505,126 @@ vulnerable.
 - Corpus: "Reentrancy via Token-2022 transfer hook" — first
   Solana-native reentrancy class.
 
+## Quasar / qedgen-codegen runtime
+
+When the runtime is **qedgen-codegen** (detected by `quasar-lang`
+dep or `#[qed(verified)]` markers), the program is split into
+codegen-owned and user-owned files. This changes how the catalog
+applies:
+
+- **Codegen-owned** (`Cargo.toml`, `state.rs`, `errors.rs`,
+  `events.rs`, `instructions/<h>/guards.rs`, the `lib.rs` Anchor
+  wrapping, `formal_verification/Spec.lean`,
+  `tests/{kani,proptest}.rs`): auditing these is auditing the
+  codegen, not the program. Bugs here are spec-gap or
+  qedgen-bug, not user-vulnerability.
+- **User-owned handler bodies** (`instructions/<handler>/<handler>.rs`,
+  the files qedgen prints "already exists — skipping (user-owned)"):
+  this is the real attack surface. Hand-written Rust that may or
+  may not honor the spec.
+
+Most existing categories collapse on qedgen-codegen because the
+codegen mechanizes them by construction:
+
+- `missing_signer`, `missing_owner_check`, `account_type_confusion`,
+  `field_chain_missing_root_anchor`, `pda_canonical_bump`,
+  `pda_seed_collision`, `discriminator_collision`,
+  `init_without_is_initialized`: codegen mechanizes these from
+  the spec's `auth` / `accounts` / `pda` / lifecycle declarations.
+  Apply at the spec-aware probe level only; per-handler-body
+  re-check is rarely productive unless the user added hand-written
+  divergence.
+- `arbitrary_cpi`, `cpi_param_swap`, `account_not_reloaded_after_cpi`,
+  `transfer_hook_reentrancy`: codegen owns the CPI block (driven
+  by `transfers { }` or `call Interface.handler(...)`); user-owned
+  bodies typically don't write `invoke` / `invoke_signed`. If the
+  user *adds* hand-written CPI to a body, that's
+  `spec_impl_drift_user_owned` (below).
+
+Categories that **still apply** at the user-owned handler-body
+level: `arithmetic_overflow_wrapping`,
+`lifecycle_one_shot_violation`, `bounty_intent_drift`,
+`frontrunnable_no_slippage`, `oracle_staleness` — bodies write
+math, mutate state, accept params, and read external data, all
+of which can drift from the spec.
+
+Plus four qedgen-codegen-specific categories below.
+
+### `spec_impl_drift_user_owned` — HIGH (Quasar)
+User-owned handler body deviates from the spec's `effect` block.
+Three flavors:
+
+1. **Body does *more*:** writes a state field the spec doesn't
+   model. The Lean / Kani / proptest artifacts are blind to the
+   extra write — formal verification stays "green" while the
+   actual state machine has an unmodeled side-channel.
+2. **Body does *less*:** omits a field-write the spec declares.
+   Codegen, Lean, Kani all honor the spec's broken view; the
+   program runs with a stale field that callers trust.
+3. **Body does *differently*:** uses unchecked arithmetic where
+   spec says `+=` (checked), or saturating where spec says
+   wrapping. Semantics drift.
+
+Detection: cross-reference each spec `effect` field against the
+user-owned handler body's assignments. Look for `s.field = ...` /
+`*field += ...` / `state.field = ...` patterns that aren't in the
+spec's effect block (extra), or spec effects that have no
+corresponding body assignment (missing).
+
+Severity: HIGH because the formal-verification artifacts become
+stale silently — `lake build` green ≠ "program correct."
+
+### `generated_guard_bypass` — CRITICAL (Quasar)
+User-owned handler body skips the codegen-emitted
+`guards::<handler>(self, ...)?;` call (or comments it out, or
+narrows it to a subset). The codegen ships with the guard call
+at the top of the user-owned scaffold; an agent or human can
+drop it.
+
+- **Detect:** `grep -L "guards::<handler-name>"
+  programs/*/src/instructions/<handler>/<handler>.rs`. Every
+  user-owned body must invoke its corresponding generated guard.
+- Pair with `arbitrary_cpi` or `arithmetic_overflow_wrapping` →
+  the body now does whatever, with no spec-derived
+  authorization.
+
+### `stored_field_never_written` — CRITICAL (Quasar)
+The spec's state struct (or sum-type variant) declares a field
+that **no handler `effect` block writes**, but other handler
+guards or effect RHSes read it. Distinct from
+`init_config_field_unanchored` (which is *written from
+unauthenticated input*) — this field is *not written at all*,
+so reads always return the type's zero / default.
+
+- **Detect:** for each field F in `type State | ... of { F : T,
+  ... }`, walk every handler's `effect` block and check whether
+  any `F := ...` / `F += ...` assignment exists. If zero, but F
+  is read in any guard / effect RHS / property, flag as
+  CRIT/HIGH.
+- Severity: CRIT if the read controls authorization (an unwritten
+  `creator` / `authority` Pubkey defaults to `0x00` — anyone
+  signing as the zero address would pass, depending on guard
+  shape). HIGH if it's economic but not authorization. MEDIUM if
+  it's only event payload / read-only.
+- Surfaced by Quasar OOD eval — multisig's `create_vault` doesn't
+  write `vault.creator` despite the spec declaring it; downstream
+  guards read it.
+
+### `qed_hash_drift_or_forgery` — HIGH (Quasar)
+The `#[qed(verified, hash = "...", spec_hash = "...")]` proc-macro
+content-pin can drift (the body changed, the hash didn't update —
+`qedgen check --frozen` catches it) or be forged (a malicious
+rebuilder edits the hash to match a tampered body). Auditor must
+run `qedgen check --frozen --spec <spec>` before trusting the
+verification claim.
+
+- **Detect:** `qedgen check --frozen` on the spec — if the
+  proc-macro hash doesn't match the canonical token-string of
+  the body, drift. If the build pipeline doesn't include the
+  frozen check, forgery is undetectable to downstream consumers.
+- Severity: HIGH if forged (verification claim is a lie); MED if
+  drift (out-of-date but caught at the next CI run).
+
 ## Compose-with-what cookbook
 
 The bear-hug lives in chains. Walk this cookbook when a finding
@@ -530,6 +650,8 @@ exhaustive; use as a thinking primer, not a checklist.
 | field_chain_missing_root_anchor | + | typed-but-unanchored CPI authority field | = | forge a fake collateral chain that the validator accepts as internally-consistent → invoke privileged CPI (mint, withdraw) under the real authority (CRIT, Cashio shape) |
 | init_config_field_unanchored | + | permissionless_state_writer init | = | frontrun legitimate init, bake attacker pubkey as stored "creator" / "authority" field, capture every fee/yield/withdraw routed through it (CRIT, DAMM-v2 OOD shape) |
 | bounty_intent_drift (mode flag accepted but unbranched) | + | permissionless caller | = | invoke the "forbidden" mode the bounty claimed it didn't allow, every time (HIGH→CRIT depending on what the mode controls) |
+| bounty_intent_drift (spec docstring claims behavior the spec body doesn't enforce) | + | qedgen-codegen mechanization | = | formal-verification artifacts (Lean / Kani / proptest) faithfully translate the broken spec — `lake build` green proves the broken behavior, **giving false confidence that the program is correct** (HIGH-CRIT depending on what the docstring claimed) |
+| spec_impl_drift_user_owned (body writes a state field the spec doesn't model) | + | downstream guard reads that field | = | unmodeled side-channel that formal verification is blind to (HIGH) |
 | lamport_write_demotion | + | rent-exempt PDA | = | silent rent extraction, downstream rent failure (MED→HIGH) |
 | saturating_by_design (`+=!`) | + | amount-shaped field | = | silent value loss, no error path (MED→HIGH) |
 

--- a/skills/qedgen-auditor/exploits.md
+++ b/skills/qedgen-auditor/exploits.md
@@ -1,0 +1,1032 @@
+# Solana exploit corpus
+
+Reference for the qedgen auditor. Walk this list when auditing — for each entry, ask "could the same shape happen here?" Each entry is a hunting heuristic, not a blanket check. If the same source-line shape appears, the *primitive* is present; the auditor's job is to determine whether the surrounding context closes or opens it.
+
+The corpus is organized by category:
+
+1. **Named incidents** — public exploits with attributable losses, ordered roughly by impact.
+2. **Generic primitives** — patterns that show up across audits, with or without a famous incident attached.
+3. **DeFi-shape attacks** — economic / cross-program patterns portable to Solana from Ethereum lineage.
+4. **Audit-firm patterns** — recurring findings from Neodyme, OtterSec, Sec3, Halborn, Asymmetric, Offside.
+
+---
+
+## 1. Named incidents
+
+## Wormhole sysvar-instructions spoof (2022, $326M)
+
+**Root cause:** verify_signatures used `load_instruction_at` (deprecated) which did not check that the input account was the real `sysvar::instructions` account; attacker passed a fake sysvar that looked like a successful prior secp256k1 verification.
+
+**Attack flow:**
+1. Construct an account whose data mimics the layout the instruction-introspection sysvar produces after a successful Ed25519/secp256k1 verify.
+2. Pass that fake account in the position the program expected the real sysvar.
+3. `verify_signatures` reads the fake "previous" verification, marks the guardian set as approved.
+4. Call `complete_wrapped` to mint 120k wETH on Solana with no Ethereum-side lock.
+
+**Grep for:**
+- `load_instruction_at(` (deprecated; use `load_instruction_at_checked`)
+- Any read of `Sysvar::Instructions` data without `solana_program::sysvar::instructions::ID` equality check
+- Anchor: `AccountInfo<'info>` for the instructions sysvar instead of `Sysvar<'info, Instructions>`
+- More generally: any "well-known" account (token program, system program, rent, clock) typed as `AccountInfo` rather than its strongly-typed wrapper
+
+**Composes with:** missing program-id check on CPI target; account type confusion (treating any AccountInfo as a sysvar).
+
+---
+
+## Cashio fake-account chain (2022, $52.8M)
+
+**Root cause:** no "trusted root" — the `mint` field on the arrow account was never validated against the real Saber LP mint. Attacker forged the entire chain (arrow → crate_collateral_tokens → mint) with worthless underlying.
+
+**Attack flow:**
+1. Create a fake `arrow` account with a mint pointer to attacker-controlled tokens.
+2. Create a fake `crate_collateral_tokens` account that points to the fake arrow.
+3. Pass the fake chain into `print_cash`, which trusts the leaf and walks up.
+4. Mint 2B CASH against zero real collateral; dump.
+
+**Grep for:**
+- Account-A reads pubkey field from Account-B without verifying B's owner *and* B's contents pin back to a known-good root
+- Multi-account validation chains where each link is checked locally but no link is anchored to a hardcoded program-id, mint, or PDA derivation
+- Any `account.data.field` used as authority or routing key without `account.owner == &expected::ID`
+
+**Composes with:** missing owner check (forgery cheap); type confusion (forgery undetectable); arbitrary CPI (forgery directs the swap path).
+
+---
+
+## Mango Markets oracle manipulation (2022, $114M)
+
+**Root cause:** thin spot oracle for low-liquidity governance token (MNGO); single-block price ramp via cross-trading from one attacker account to another, leveraging artificially-inflated MNGO as collateral against real assets.
+
+**Attack flow:**
+1. Open offsetting long+short positions in MNGO-PERP from two attacker accounts ($10M USDC seed).
+2. Pump MNGO spot price 2¢ → 91¢ in ~10 minutes with low-liquidity buys.
+3. Long-side account's collateral value balloons; borrow ~$114M of real assets (USDC, BTC, ETH, SOL, mSOL) against it.
+4. Walk away — short side gets liquidated, but the borrows already left.
+
+**Grep for:**
+- Oracle reads with no TWAP / no min-confidence-interval check
+- Single-source price feeds (one Pyth product, no Switchboard cross-check)
+- Collateral valuation that uses spot price without liquidity-adjusted haircut on thin markets
+- `borrow_value = collateral_value * ltv` patterns where `collateral_value` is a single oracle read
+
+**Composes with:** thin spot market = manipulable input; cross-margin pools = single-account-can-drain-all; no per-asset borrow caps = no circuit breaker.
+
+---
+
+## Crema Finance fake tick account (2022, $8.8M)
+
+**Root cause:** CLMM accepted attacker-supplied "tick" account without owner check or PDA derivation check; tick stored in-band fee-growth values that the program trusted.
+
+**Attack flow:**
+1. Flash-loan from Solend.
+2. Create a fake `tick_array` account with crafted `fee_growth_outside` values.
+3. Open and immediately close a position that "earns" the crafted fees on swap fees.
+4. Collect inflated fees, repay flash loan, profit.
+
+**Grep for:**
+- Tick / order / position accounts passed via `AccountInfo` without `seeds = [b"tick", pool, tick_index]` Anchor constraint
+- Manual PDA derivation that compares only one of (program_id, owner, address) — must check all three
+- Accounts that store accounting state (fee growth, cumulative index) with no owner check
+
+**Composes with:** flash-loan amplifier (attacker doesn't need capital); CLMM in-band accounting (the lie compounds with each tick crossed).
+
+---
+
+## Saber / SPL token-swap rounding (2022, ~$700M at risk; Neodyme found pre-exploit)
+
+**Root cause:** stable-swap rounding rounded *toward* the LP, then *also* toward the LP on the reverse swap; attacker round-trips draining one token per instruction.
+
+**Attack flow:**
+1. Swap A→B with input that triggers round-up favoring user.
+2. Swap B→A with input that triggers round-up favoring user.
+3. Net: one extra token per round-trip, fee-free at Solana's flat 5000 lamport tx cost.
+4. Pack 100s of swap instructions per tx; drain pool over hours.
+
+**Grep for:**
+- Bidirectional pair functions (deposit/withdraw, mint/redeem, swap A↔B) using the *same* rounding direction on both sides
+- `try_round_u64`, `.round()`, `ceil_div` used without asymmetric direction (favor protocol on intake, user on payout — never both same)
+- `(a / c) * b` pattern (divide-then-multiply loses precision); should be `(a * b) / c` with overflow check
+
+**Composes with:** Solana's flat-fee model (off-by-one is profitable, unlike Ethereum); deep liquidity (many round-trips before pool empties).
+
+---
+
+## Solend USDH oracle manipulation (2022, $1.26M)
+
+**Root cause:** USDH price feed sourced from a single Saber pool; attacker write-locked the pool account in the same slot as the oracle update to prevent arbitrage and inflate the read.
+
+**Attack flow:**
+1. Predict the slot the oracle will sample USDH price.
+2. Send a tx in that slot that write-locks the Saber USDH/USDC pool while pumping price.
+3. Oracle reads inflated price ($1 → $15).
+4. Deposit USDH as collateral, borrow $1.26M of real assets, walk.
+
+**Grep for:**
+- Oracle wrapper reading from a DEX pool reserve as the price source
+- No min-liquidity threshold before accepting an oracle read
+- No "max move per slot" rate limiter on collateral revaluation
+- Any oracle that reads from an account the user can write-lock in the same tx
+
+**Composes with:** single-source oracle (no cross-check); per-slot transaction ordering (write-lock blocks arbs); permissionless borrow against single-asset.
+
+---
+
+## Nirvana flash-loan oracle pump (2022, $3.5M)
+
+**Root cause:** ANA price oracle read from internal bonding curve which itself responded to flash-loan-sized buys.
+
+**Attack flow:**
+1. Borrow $10M USDC flash loan from Solend.
+2. Mint ANA via Nirvana's bonding curve, pumping its internal price.
+3. Use the inflated ANA holdings as collateral to drain the treasury at the new price.
+4. Repay flash loan, keep delta.
+
+**Grep for:**
+- Treasury / redemption logic that prices its own token via its own AMM/bonding curve in the same tx
+- Mint and redeem in the same instruction without TWAP between
+- "Use my mint price as my collateral price" loop
+
+**Composes with:** flash-loan availability (zero capital requirement); same-tx price+borrow (no cooldown).
+
+---
+
+## Loopscale RateX collateral mispricing (2025, $5.8M)
+
+**Root cause:** isolated lending market priced RateX PT tokens from a single point-in-time pool read with no TWAP; attacker manipulated the source pool to overstate collateral.
+
+**Attack flow:**
+1. Identify which market uses the manipulable RateX-PT pool as its price source.
+2. Trade against that pool to push the spot price upward in one block.
+3. Deposit PT tokens at inflated valuation, borrow USDC/SOL up to the inflated cap.
+4. Walk; the rest of the market is collateralized in real assets.
+
+**Grep for:**
+- New / niche / illiquid token added as collateral with the same oracle pattern as blue-chip
+- Per-market collateral pricing where the function pulls a fresh read each call (no TWAP, no Pyth confidence band)
+- "Genesis vault" or "isolated pool" that shares a price oracle with an attacker-influenceable venue
+
+**Composes with:** young protocol (small liquidity buffer); permissionless market-add (governance can list a manipulable token); single-block price + borrow.
+
+---
+
+## Jet Protocol C-ratio close-account bypass (2022, $25M near-miss; private disclosure)
+
+**Root cause:** position-array iteration broke the loop when it encountered `Pubkey::default()` as a sentinel for "closed account"; attacker placed real positions *after* the closed slot so they were skipped during collateralization check.
+
+**Attack flow:**
+1. Open a benign position to fill array slot 0.
+2. Close it — slot now reads `Pubkey::default()`.
+3. Open a real liability position in slot 1+.
+4. Borrow against zero counted liabilities (loop short-circuits at slot 0).
+
+**Grep for:**
+- `for position in positions { if position.key == Pubkey::default() { break; } }` patterns
+- Sentinel-terminated arrays where account closure inserts the sentinel mid-array
+- Any "skip on null-pubkey" loop in a solvency / collateral check
+
+**Composes with:** account-close primitive (creates the sentinel); permissionless position-open (creates the array hole).
+
+---
+
+## Raydium admin-key trojan (2022, $4.4M)
+
+**Root cause:** `withdraw_pnl` instruction guarded only by a single hot-wallet authority; key was exfiltrated by malware on the operator's machine.
+
+**Attack flow:**
+1. Compromise operator workstation, exfiltrate authority keypair.
+2. Sign `withdraw_pnl` to drain LP-owner accumulated fees.
+3. Drain 8 constant-product pools before authority can be revoked.
+
+**Grep for:**
+- Privileged operations gated by a single Ed25519 signer (not a multisig PDA / Squads multisig)
+- `set_authority`, `withdraw_admin`, `claim_protocol_fees` whose only check is `signer.key == config.authority`
+- Hardcoded admin pubkeys that require off-chain key custody to remain safe
+
+**Composes with:** custodial supply-chain risk (npm, dev machine); no time-lock on admin actions; no rate-limit on protocol-fee draws.
+
+---
+
+## Cypher economic-loop exploit (2023, $1M)
+
+**Root cause:** flash-loan-amplified self-trading exploited an SVT pricing economic loop (rebate / margin accounting that didn't account for sandwich self-trading).
+
+**Attack flow:**
+1. Borrow flash liquidity.
+2. Repeatedly buy/sell SVT tokens against the protocol's own margin accounting.
+3. Each round increases the attacker's "credited" P&L without changing real cash.
+4. Withdraw the credited amount in real assets.
+
+**Grep for:**
+- Margin/PnL accounting that updates from same-tx self-trade fills
+- No "is this trade against yourself" check on `take_perp_fund_settlement` or equivalent
+- Any economic feedback loop where `account_value += f(account_value)` without a settlement boundary
+
+**Composes with:** flash loan; permissionless market-make; self-cross allowed.
+
+---
+
+## Drift durable-nonce admin-takeover (2026-04, $285M)
+
+**Root cause:** governance multisig signed durable-nonce-anchored transactions that were submitted weeks later. Attackers spent months building social trust as a fake quant firm, captured signatures intended for one purpose, then replayed them with attacker-controlled durable-nonce accounts to execute admin transfer.
+
+**Attack flow:**
+1. Social-engineer access; create 4 durable-nonce accounts (2 from real council members, 2 from attacker).
+2. Capture council signatures on a benign-looking governance op anchored to attacker's nonce.
+3. Wait. The transactions don't expire because the nonce doesn't expire.
+4. Submit when context shifts (after a real test withdrawal); transfer admin authority to attacker.
+5. Whitelist a fake collateral token, deposit 500M of it, borrow $285M.
+
+**Grep for:**
+- Multisig flows that don't pin a recent blockhash (durable-nonce-anchored signing)
+- Admin-transfer / `set_authority` instructions that don't enforce a ceremony or time-lock
+- Permissionless `add_collateral_type` / market-config changes that admin can do unilaterally and instantly
+
+**Composes with:** social engineering (signatures captured under one pretext, replayed under another); durable-nonce + Solana's signature-validity model = arbitrary delay; instant admin reconfig (no time-lock buffer).
+
+---
+
+## Slope wallet Sentry key leak (2022, $6M, 9,231 wallets)
+
+**Root cause:** mobile wallet pointed Sentry SDK at self-hosted endpoint, transmitted private-key material in error logs.
+
+**Attack flow:**
+1. Attacker observes leaked secrets at the Sentry endpoint (or compromises Sentry host).
+2. Reconstructs private keys for affected users.
+3. Drains their Solana wallets in bulk.
+
+**Grep for:**
+- Mobile / desktop wallet code where any secret-bearing object passes through a logging / telemetry SDK without redaction
+- Sentry, LogRocket, Datadog with no `beforeSend` scrubber
+- React Native: error boundaries that serialize entire app state
+
+**Composes with:** off-chain — listed because Solana program audits frequently include a companion SDK whose telemetry leaks PDA seeds, derivation paths, or unsigned tx payloads.
+
+---
+
+## @solana/web3.js supply-chain backdoor (2024-12, ~$130-160k)
+
+**Root cause:** spear-phish on npm publish-credential holder; v1.95.6 / 1.95.7 shipped with `addToQueue` exfiltrating private keys via fake CloudFlare headers.
+
+**Attack flow:**
+1. Phish credentials + 2FA from a maintainer.
+2. Publish a backdoored patch version.
+3. Auto-upgraders pull the new version into bots, dApps, and key-handling services.
+4. Backdoor exfiltrates raw keys handled in-process.
+
+**Grep for:**
+- `package.json` dependency on `@solana/web3.js` without a pinned version + integrity hash
+- Bots / signers that hold raw `Keypair` in memory at version-resolution time
+- CI that runs `npm install` against floating versions before an audit gate
+
+**Composes with:** raw-key custody (anything routing trades or cosigning); npm dependency floats; no SBOM / pinning.
+
+---
+
+## 2. Generic primitives (with or without a public incident)
+
+## Missing signer check on privileged instruction (pattern)
+
+**Root cause:** authorization compared `account.key == config.authority` but never `account.is_signer == true`.
+
+**Attack flow:**
+1. Find the privileged ix (admin-mint, set-authority, drain-fees).
+2. Pass the *real* authority pubkey as a non-signing `AccountInfo`.
+3. Equality check passes; signature isn't required.
+4. Execute privileged op.
+
+**Grep for:**
+- `Account<'info, T>` for an authority field instead of `Signer<'info>`
+- Manual: `if ctx.accounts.authority.key != &state.authority` with no following `is_signer` test
+- Anchor constraint missing `#[account(signer)]` or the `Signer` type
+
+**Composes with:** missing owner check (substitute fake `state` so the equality check picks attacker's key); permissionless ix (no other gating).
+
+---
+
+## Missing owner check on user-supplied state (pattern)
+
+**Root cause:** program reads fields from an `AccountInfo` whose `owner` field is never compared to `program::ID`.
+
+**Attack flow:**
+1. Create an account owned by a different program (or system program), populate it with crafted bytes.
+2. Pass it where the target program expects its own state.
+3. Crafted fields (admin pubkey, balance, mint reference) are trusted.
+
+**Grep for:**
+- `try_from_slice(&account.data.borrow())` without a preceding `account.owner == &crate::ID` check
+- Bare `AccountInfo<'info>` for state-bearing accounts that should be `Account<'info, T>`
+- `unpack_unchecked` / `unpack_from_slice` without owner gate
+
+**Composes with:** type confusion (any owned account works); fake-mint chain (Cashio); arbitrary CPI (the fake state names a fake CPI target).
+
+---
+
+## PDA seed concatenation collision
+
+**Root cause:** PDAs derived from concatenated seeds without separators — `[b"vault", user.key, "rewards"]` collides with `[b"vault", user.key + "rewards"]`-shaped variants when seeds are user-controlled or variable-length.
+
+**Attack flow:**
+1. Identify a PDA derivation with a variable-length user-controlled seed.
+2. Construct two distinct logical inputs that hash to the same PDA bytes.
+3. The "wrong" PDA gets reused — DoS, fund redirection, or auth bypass depending on context.
+
+**Grep for:**
+- `find_program_address(&[b"prefix", user_input.as_bytes(), b"suffix"], ...)` where `user_input` is variable-length
+- Seeds list where one seed is `&str` / `Vec<u8>` of unbounded length
+- No `[user.key().as_ref()]` (fixed-length) or no separator byte between variable seeds
+
+**Composes with:** missing PDA-derivation verification (just trusts the address); permissionless account creation (lets attacker pre-mine the colliding PDA).
+
+---
+
+## Non-canonical bump seed acceptance
+
+**Root cause:** program accepts a user-supplied bump and calls `create_program_address` instead of `find_program_address`; multiple valid PDAs exist for a given seed set, attacker chooses a non-canonical one.
+
+**Attack flow:**
+1. Brute-force a non-canonical bump that produces a different PDA for the same logical seeds.
+2. Initialize that PDA via the program, claiming the "non-canonical user vault" slot.
+3. Use the bump in subsequent calls to bypass deduplication that assumed canonical bump.
+
+**Grep for:**
+- `Pubkey::create_program_address(&[..., &[bump]], program_id)` with `bump` from instruction data
+- Anchor: `seeds = [...]` without the matching `bump = stored_bump` once the account is initialized
+- No persisted bump in the PDA's own state for re-validation
+
+**Composes with:** PDA sharing (one logical user → multiple PDAs → balance fragmentation); type confusion.
+
+---
+
+## Account type confusion / type cosplay
+
+**Root cause:** struct deserialization without a leading discriminator; multiple account types with overlapping byte layouts; `User` account passed where `Config` expected.
+
+**Attack flow:**
+1. Identify two account structs in the same program with similar layouts (e.g. first field is `Pubkey`).
+2. Create the cheaper type (`User`) with attacker pubkey in its first field.
+3. Pass it as the privileged type (`Config`) — first-field equality check reads attacker pubkey as admin.
+
+**Grep for:**
+- Manual `borsh::try_from_slice(...)` with no leading discriminator/version field
+- Anchor: shared discriminator across versions of an account migrated via realloc
+- Any `unpack_unchecked` that doesn't check a leading `account_type: u8` tag
+
+**Composes with:** missing owner check (any program-owned account works); realloc-without-zero (residual data from prior type leaks).
+
+---
+
+## Init-without-is-initialized / `init_if_needed` reuse
+
+**Root cause:** `init_if_needed` re-runs initialization when the account has zero lamports OR is owned by system program — does not detect a *previously-closed-and-reopened* account.
+
+**Attack flow:**
+1. Use the program normally to create an account, then close it (lamports → 0, owner → system).
+2. Call the same `init_if_needed` instruction again — Anchor sees an "uninitialized" account.
+3. Re-initialize with attacker-friendly fields.
+
+**Grep for:**
+- `#[account(init_if_needed, ...)]` on accounts that hold authority, balance, or PDA-derived state
+- Init handlers without an `if account.is_initialized { return Err(...); }` early-return
+- Custom init code with no boolean / discriminator guard
+
+**Composes with:** close-then-reinit primitive (account closure must zero-out and bump owner correctly); type confusion (re-init under a new struct).
+
+---
+
+## Account close without data zeroing / discriminator zap
+
+**Root cause:** transferring lamports out of an account but not zeroing data or invalidating its discriminator — re-funded in the same tx, account "lives" with old data and old owner.
+
+**Attack flow:**
+1. Call the program's close-account instruction; it transfers lamports to attacker.
+2. In the same tx, call a benign instruction that funds the closed account back to rent-exempt.
+3. Garbage collection skips it; old data + old owner persist.
+4. Replay the privileged operation against the "deleted" account.
+
+**Grep for:**
+- `**account.lamports.borrow_mut() = 0` without `account.assign(&system_program::ID)` and without zeroing data
+- Custom close logic that doesn't use Anchor's `close = recipient` macro
+- Any close path missing a discriminator-write to a "closed" sentinel value
+
+**Composes with:** `init_if_needed` (the resurrected account is mistaken for fresh); permissionless funding (anyone can re-rent-exempt).
+
+---
+
+## Close-account redirected to attacker (rent extraction)
+
+**Root cause:** close-account instruction takes the destination account from the user without checking it equals the original payer / a designated recipient.
+
+**Attack flow:**
+1. Find the program's close ix.
+2. Pass `destination = attacker_wallet`.
+3. Rent lamports — sometimes meaningful sums on dust-token-account-spam accounts — go to attacker.
+
+**Grep for:**
+- `close = recipient` with `recipient` not constrained to `payer` or PDA-derived
+- Manual `**dst.lamports.borrow_mut() += account.lamports();` with `dst` from instruction args
+- Bot / sweep tools that close many small accounts; the rent-extractor pattern is well-known to MEV searchers
+
+**Composes with:** PDA-as-rent-vault (PDA-owned rent goes to attacker if PDA-signed); permissionless close (no signer check on the close authority).
+
+---
+
+## Duplicate mutable accounts (aliasing)
+
+**Root cause:** instruction takes two `mut` accounts that the caller can pass as the *same* account; in-memory writes interleave; final write-back from one struct clobbers the other.
+
+**Attack flow:**
+1. Identify an ix taking `from: Account<T>, to: Account<T>` both mutable.
+2. Pass the same pubkey for both.
+3. `from.balance -= amount; to.balance += amount;` ends with `to.balance == original + amount` (no debit), or the order matters and money is created.
+
+**Grep for:**
+- Multiple `mut` parameters of the same account type with no `from.key() != to.key()` constraint
+- Anchor: missing `#[account(mut, constraint = a.key() != b.key())]`
+- Token transfers within the same program where source == destination is not rejected
+
+**Composes with:** missing solvency check (the inflated balance is then borrowed against); arithmetic overflow (the double-write masks the wrong value).
+
+---
+
+## Arbitrary CPI to user-supplied program
+
+**Root cause:** `invoke` / `invoke_signed` is called with a program account read from the instruction's account list, with no `program.key == &expected::ID` check.
+
+**Attack flow:**
+1. Pass attacker's program in the `token_program` slot.
+2. Program calls `invoke_signed` with PDA seeds, transferring authority to attacker's program.
+3. Attacker's program ignores the transfer, signs whatever it wants, returns Ok.
+4. Caller's PDA-signed slot is now blank — attacker uses it to drain.
+
+**Grep for:**
+- `invoke_signed(&ix, &accounts, &[seeds])` where the program account in `accounts` is not asserted equal to a hardcoded ID
+- Anchor: `Program<'info, T>` with `T = AccountInfo` instead of `T = Token` / `T = System`
+- Any CPI helper that reads program ID from an account field rather than a const
+
+**Composes with:** missing owner check (the spoofed program also lies about state); PDA signing (the leaked authority is reusable).
+
+---
+
+## Sysvar substitution (Clock, Rent, Instructions)
+
+**Root cause:** sysvar-bearing accounts typed as `AccountInfo` and read directly, with no equality check against the well-known sysvar ID.
+
+**Attack flow:**
+1. Identify `clock_account.data` read for slot/timestamp gating (vesting, cooldown, deadlines).
+2. Pass an attacker-controlled account whose bytes encode the desired `unix_timestamp`.
+3. Vesting unlocks; cooldown skipped; deadline bypassed.
+
+**Grep for:**
+- `Clock::from_account_info(account)` with `account` not equality-checked to `sysvar::clock::ID`
+- `Sysvar::Rent` / `Sysvar::Instructions` typed as raw `AccountInfo`
+- Anchor: `clock: AccountInfo<'info>` instead of `clock: Sysvar<'info, Clock>`
+
+**Composes with:** vesting / time-lock bypass; instruction-introspection bypass (Wormhole shape).
+
+---
+
+## `remaining_accounts` unvalidated
+
+**Root cause:** program iterates `ctx.remaining_accounts` (or equivalent) and trusts each entry without owner / type / address checks.
+
+**Attack flow:**
+1. Find an instruction that pays out per-account (e.g. reward distribution, batch settle).
+2. Pass attacker's accounts in the `remaining_accounts` slot.
+3. Each iteration credits attacker accounts that should not have been eligible.
+
+**Grep for:**
+- `for account in ctx.remaining_accounts` without owner / discriminator / membership check inside the loop
+- Anchor: `remaining_accounts: &[AccountInfo<'info>]` consumed without per-element validation
+- Reward / claim / settle instructions taking variadic accounts
+
+**Composes with:** missing owner check (any account works); permissionless claim (no allowlist).
+
+---
+
+## PDA sharing across authority domains
+
+**Root cause:** one PDA serves as signing authority for multiple distinct vaults / mints; signing for one purpose accidentally authorizes the other.
+
+**Attack flow:**
+1. Find two CPI sites in the program both signed by the same PDA seeds.
+2. Construct an instruction that triggers signing for the "weak" purpose (e.g. fee payout).
+3. The PDA's signature on the inner CPI authorizes operations against the unrelated "strong" vault because the program counter-signs both.
+
+**Grep for:**
+- Same PDA seeds (`seeds = [b"authority", pool.key().as_ref()]`) used as signer for two different mints / vaults
+- A single program-wide "master authority" PDA
+- CPI sites where `with_signer(&[&seeds])` reuses the same seeds across different account contexts
+
+**Composes with:** arbitrary CPI (PDA signs whatever attacker hands it); missing per-resource gating.
+
+---
+
+## Insecure / permissionless initialization
+
+**Root cause:** global config / state initializer is callable by anyone; whoever calls it first gets to set protocol parameters (admin pubkey, fee rates, oracle addresses).
+
+**Attack flow:**
+1. Watch the deploy. Race the legitimate team's init transaction.
+2. Win the race with priority fees.
+3. Set `admin = attacker`, `oracle = attacker_oracle`, `fee_recipient = attacker`.
+
+**Grep for:**
+- `pub fn initialize(ctx: Context<Initialize>, admin: Pubkey, ...)` with no signer constraint matching `crate::ID`'s upgrade authority
+- Anchor: no `#[account(constraint = signer.key() == bpf_loader_upgradeable::get_program_data_address(&crate::ID).?)]` flow
+- Singleton config PDA with no race-protection (deploy-time multisig initializer)
+
+**Composes with:** mainnet deploy without atomic init in the deploy script; admin-only operations (game over after init).
+
+---
+
+## Account-not-reloaded after CPI
+
+**Root cause:** program reads token-account balance, performs a CPI that mutates that balance, then continues to use the in-memory copy from before the CPI.
+
+**Attack flow:**
+1. Trigger the path where program does `let bal = token_account.amount; cpi_transfer(...); use(bal);`.
+2. The post-CPI logic operates on stale `bal`.
+3. Result: double-credit, wrong-fee, mis-accounting.
+
+**Grep for:**
+- `let amount = ctx.accounts.token.amount;` followed by a CPI that writes to `ctx.accounts.token`
+- Missing `ctx.accounts.token.reload()?;` after CPI
+- Pattern: read → CPI → use stale-read value in arithmetic
+
+**Composes with:** rounding (reload-stale + favorable rounding compounds); flash-loan amplification (stale snapshot used as repayment proof).
+
+---
+
+## Integer overflow / underflow
+
+**Root cause:** unchecked `+`/`-`/`*` in release mode silently wraps on BPF; checked-math omitted.
+
+**Attack flow:**
+1. Find a balance update: `position.borrowed += amount;` or `pool.shares = total * x / y;`.
+2. Craft input so the operation wraps (e.g. `amount = u64::MAX`).
+3. Wrapped value passes downstream solvency check; real liability is enormous.
+
+**Grep for:**
+- `+`, `-`, `*` on `u64` / `u128` balance/amount fields without `.checked_*` / `.saturating_*`
+- Missing `overflow-checks = true` in `Cargo.toml` `[profile.release]` (note: this only triggers panics, not safe handling)
+- `as u64` casts from larger integer types without prior bounds check
+
+**Composes with:** missing solvency assertion (overflow → wrong totals → false-pass solvency); rounding (compounding error).
+
+---
+
+## Loss of precision / wrong rounding direction
+
+**Root cause:** divide-then-multiply (`(a / c) * b`), or rounding *toward the user* on payout and *toward the user* on intake; or mismatched rounding in a pair of bidirectional operations.
+
+**Attack flow:**
+1. Find a swap / mint-redeem pair using `try_round_u64` / `ceil_div` consistently.
+2. Round-trip small amounts repeatedly.
+3. Each round-trip leaks 1 unit; Solana flat fees make this profitable.
+
+**Grep for:**
+- `(numerator / denominator) * factor`
+- Pair of fns where `f(x)` and `f_inverse(y)` both use the same `round_up` / `round_down`
+- `try_round_u64` in any payout fn (should be floor on payout, ceil on intake)
+
+**Composes with:** flash-loan-funded round-tripping; bidirectional pool functions; flat-fee transaction model.
+
+---
+
+## Sentinel / null-key array short-circuit
+
+**Root cause:** iteration `for x in arr { if x == DEFAULT { break; } }` used as a "stop scanning" pattern, without recognizing that closures / closes leave a `DEFAULT` mid-array.
+
+**Attack flow:** see Jet pattern above.
+
+**Grep for:**
+- `Pubkey::default()` used as an in-array sentinel
+- `if ... == 0 { break; }` in solvency / collateralization loops
+- Position arrays that don't compact on close
+
+**Composes with:** account-close primitive; permissionless position-open.
+
+---
+
+## Frontrunning / no slippage check on permissionless calls
+
+**Root cause:** permissionless instruction (swap, claim, liquidate) has no `min_out` / `max_in` parameter, or accepts one that defaults to zero.
+
+**Attack flow:**
+1. User submits a swap with no `min_amount_out`.
+2. Searcher front-runs with a sandwich; user receives way less than expected.
+3. Searcher back-runs to capture the spread.
+
+**Grep for:**
+- `pub fn swap(amount_in: u64)` — no `minimum_amount_out`
+- `liquidate_position(...)` with no liquidator-supplied price band check
+- Any user-facing op where the user-controlled max-deviation parameter is missing or unconstrained
+
+**Composes with:** thin AMM (sandwich is cheap); no batched / commit-reveal protection.
+
+---
+
+## Lamport-transfer write-demotion / executable-account / rent-exempt freeze
+
+**Root cause:** program transfers lamports to an account whose nature can change post-deploy: feature gate makes it write-demoted, account becomes executable, or rent-exemption check fails silently. Transfer reverts but program logic assumed success.
+
+**Attack flow:** see OtterSec's "King of the SOL" — attacker becomes the destination, then triggers a state change (feature activation, deployment) that makes their account untransferable, freezing the "throne" forever.
+
+**Grep for:**
+- `**recipient.lamports.borrow_mut() += amount;` where `recipient` is `AccountInfo<'info>` (not a constrained PDA / token account)
+- `system_program::transfer` to user-supplied destinations without account-type assertions
+- Logic that reads `account.lamports()` *after* a transfer attempt as proof-of-success without `?`-propagating the transfer error
+
+**Composes with:** future feature gate (you can't grep this — it's a runtime-evolution risk); `set_lamports` patterns.
+
+---
+
+## Missing rent-exemption check on init
+
+**Root cause:** account initialization doesn't enforce rent-exemption; account drops below minimum and gets garbage-collected mid-protocol-operation.
+
+**Attack flow:**
+1. Initialize with the bare minimum lamports (or attacker funds intentionally low).
+2. Operation proceeds; account is purged at slot boundary.
+3. Subsequent reads see a zeroed account; reinitialization possible.
+
+**Grep for:**
+- `system_instruction::create_account(..., lamports, ...)` with `lamports` from user input
+- Manual init paths missing `Rent::get()?.minimum_balance(size)`
+- Anchor with `space` set but `payer` unconstrained on lamport amount
+
+**Composes with:** init-without-is-initialized; account close redirection.
+
+---
+
+## Permissionless account-add via remaining_accounts (governance hijack-lite)
+
+**Root cause:** "extend allowlist" / "register strategy" instruction takes accounts from `remaining_accounts` or instruction args without governance gating.
+
+**Attack flow:**
+1. Find the registry-add op.
+2. Add attacker-controlled "strategy" / "vault" / "collateral" account to the registry.
+3. Use the now-allowlisted account in normal program flows that trust the registry.
+
+**Grep for:**
+- `register_*`, `add_*`, `whitelist_*` instructions with no `signer == governance` or `is_admin` check
+- "Allowlist" structures that grow via instruction args, not via a sealed governance flow
+
+**Composes with:** Drift-shape admin takeover; oracle pump (attacker registers attacker's token as collateral).
+
+---
+
+## 3. DeFi-shape attacks portable to Solana
+
+## Sandwich / MEV against AMM swap
+
+**Root cause:** AMM swap instruction is permissionless with predictable price-impact, no commit-reveal, no per-slot fair-ordering.
+
+**Attack flow:**
+1. Searcher monitors mempool / Jito bundles for victim swap.
+2. Sends front-run swap pumping price.
+3. Victim's swap fills at worse price.
+4. Back-run dumps; profit = victim's slippage.
+
+**Grep for:**
+- AMM `swap` with no commit-reveal or batch settlement
+- No oracle-guard ("revert if pool price diverges from oracle by > X bps")
+- No `expected_price_after` parameter
+
+**Composes with:** missing slippage check (user has no defense); Jito bundle access (deterministic ordering for searcher).
+
+---
+
+## Oracle staleness exploit
+
+**Root cause:** lending / margin protocol reads a price feed without checking its `publish_time` / `valid_slot`; reads a price from minutes ago.
+
+**Attack flow:**
+1. Wait for a price spike that the oracle hasn't yet propagated (or stops updating).
+2. Liquidate / borrow against the stale price snapshot.
+3. Real price catches up; protocol is insolvent.
+
+**Grep for:**
+- `price_feed.aggregate.price` reads with no `slot - last_update <= MAX_STALENESS` check
+- Pyth: missing `get_price_no_older_than(MAX_AGE)` (using `get_price_unchecked` instead)
+- Switchboard: no `min_update_slot_delay` enforcement
+
+**Composes with:** congestion (oracles fall behind); single-source feed (no fallback); aggressive LTV (small staleness window = big impact).
+
+---
+
+## TWAP gameable in single block
+
+**Root cause:** "TWAP" computed from `(price_old + price_new) / 2` over a window so short (a few slots) that a flash-loan-funded pump moves both samples inside one tx-bundle.
+
+**Attack flow:**
+1. Borrow flash loan.
+2. Pump pool price; wait the few slots required for the second sample.
+3. Both samples are at the inflated price; "TWAP" sees a high average.
+4. Borrow against inflated TWAP; repay flash loan; walk.
+
+**Grep for:**
+- TWAP windows shorter than the bundle / leader-slot span (Solana: <=4 slots = ~1.6s = bundle-spannable)
+- Cumulative-price oracles that update on every interaction (interaction-pumping moves the cumulative)
+- TWAP based on internal pool reserves rather than an external oracle
+
+**Composes with:** flash loan; thin pool; permissionless interaction (pumping is free).
+
+---
+
+## Reentrancy via Token-2022 transfer hook
+
+**Root cause:** transfer hook calls back into the calling program (or a related program) before the original program finishes its state update. Solana's CPI graph rules prevent A→B→A but allow A→B→C→A under specific structures, and same-mint same-tx transfers via hook can re-enter.
+
+**Attack flow:**
+1. Attacker registers a transfer hook on a mint they control (or trick protocol into accepting it as collateral).
+2. Protocol's withdraw flow does `transfer; update_state;`.
+3. Hook fires during `transfer`, calls the protocol's withdraw again before `update_state`.
+4. Double-withdraw against single accounting update.
+
+**Grep for:**
+- Token-2022 mints (extensions) accepted with no allowlist
+- Withdraw / claim / settle flows with `transfer → state-update` ordering (should be reversed: CEI)
+- No reentrancy guard (no per-tx "in_progress" flag) on multi-step state machines
+
+**Composes with:** type confusion (Token-2022 with hooks treated as plain SPL); CPI depth (hook depth + caller's depth nearing 4-deep limit forces revert without surfacing root cause).
+
+---
+
+## Flash-loan-amplified governance attack (Mango shape)
+
+**Root cause:** governance vote weight = real-time token balance (or staked balance with no time-lock); flash loan grants temporary majority.
+
+**Attack flow:**
+1. Borrow flash loan in governance token.
+2. Stake / hold in same tx.
+3. Submit and pass governance proposal that authorizes treasury withdrawal.
+4. Withdraw, repay flash loan, walk.
+
+**Grep for:**
+- Governance vote-weight reads spot balance (not historical / vote-locked)
+- Staking with zero unlock period
+- `propose + vote + execute` collapsible into one tx
+
+**Composes with:** flash loan; thin governance-token market (cheap dump risk on backside); same-block proposal-execute.
+
+---
+
+## Cross-margin pool single-account drain
+
+**Root cause:** all assets share one liquidity pool / one liability ledger; a single account with manipulable collateral can borrow against all assets, not just its asset class.
+
+**Attack flow:** see Mango. Inflated collateral X borrows real assets A, B, C.
+
+**Grep for:**
+- Single `Pool` / `Vault` struct holding all collateral types together
+- No isolated-market / per-asset borrow caps
+- LTV applied symmetrically to thin and deep markets
+
+**Composes with:** thin governance-token oracle; permissionless add-collateral.
+
+---
+
+## Liquidation rounding / dust accumulation
+
+**Root cause:** liquidation flow rounds *toward the liquidator* on every step, leaving sub-rounding-unit "dust" that's claimable repeatedly.
+
+**Attack flow:**
+1. Find positions just above liquidation threshold.
+2. Liquidate the smallest possible chunk; rounding gives 1-unit favor each time.
+3. Repeat; over time drains more than the position's actual delinquency.
+
+**Grep for:**
+- Liquidation `repay_amount * factor / total` with consistent `ceil_div`
+- No "minimum repayment" to prevent dust attacks
+- `liquidator_premium` calculated on a separately-rounded base than `debt_repaid`
+
+**Composes with:** Solana flat fee (many small liquidations); permissionless liquidator role.
+
+---
+
+## Fee-on-transfer / transfer-fee unaccounting
+
+**Root cause:** protocol assumes `transfer(amount) → recipient.balance += amount`; for Token-2022 transfer-fee mints, recipient gets `amount - fee`, but program's accounting recorded `+amount`.
+
+**Attack flow:**
+1. Use a transfer-fee Token-2022 mint as deposit token.
+2. Deposit `100`; pool actually receives `99` but ledger says `+100`.
+3. Withdraw `100`; pool sends `100` but only had `99`. Now insolvent.
+4. Repeat across users; insolvency compounds.
+
+**Grep for:**
+- `token_2022::transfer` followed by `state.balance += amount` (no `get_account_data_size_after_extension` or post-transfer balance read)
+- Protocols that gate by mint via `Mint` (legacy) but allow Token-2022 mints in the same path
+- Any user-supplied mint passed through deposit flow with no `mint.extensions` enumeration check
+
+**Composes with:** transfer hook (re-entrancy + fee-on-transfer compound); permissionless mint-add.
+
+---
+
+## Frontrun the permissionless `claim` / `crank`
+
+**Root cause:** rewards / fee-claim instruction iterates "all eligible users" and pays each; instruction is permissionless and pays gas to crankers; an attacker times the crank to capture rewards into a freshly-created LP.
+
+**Attack flow:**
+1. Watch for the next reward-distribution slot.
+2. Right before the crank fires, deposit a large position.
+3. Crank distributes proportional to current snapshot; attacker captures.
+4. Withdraw immediately after.
+
+**Grep for:**
+- Reward distribution that snapshots holdings *at crank time*, not via vote-locked / time-weighted shares
+- `claim_rewards` permissionless with no minimum-deposit-age
+- LP shares with no warmup period
+
+**Composes with:** flash loan (deposit + withdraw within 1 tx if crank is also same-tx-callable); permissionless crank.
+
+---
+
+## 4. Audit-firm patterns
+
+## Authority transfer missing nominate-accept (Halborn-recurring)
+
+**Root cause:** `set_authority` writes the new authority directly with no two-step nominate→accept handshake; one-shot fat-finger or compromised key writes a wrong / attacker pubkey.
+
+**Attack flow (operational, not exploit per se):**
+1. Compromised admin key calls `set_authority(new_authority = attacker)`.
+2. Single tx; no chance to revoke.
+3. Subsequent admin ops are now attacker-gated.
+
+**Grep for:**
+- `set_authority` / `transfer_admin` writing to a single field in one ix
+- Missing `pending_authority` field on the state struct
+- No `accept_authority` ix that the new pubkey must call before the swap finalizes
+
+**Composes with:** no time-lock; single-key admin custody; off-chain key-management mistakes.
+
+---
+
+## Unsafe Rust / `unsafe` block (multiple firms)
+
+**Root cause:** program uses `unsafe { ... }` to deref raw pointers, transmute, or cast — bypasses Rust's memory safety; one mistake → UB → exploitable.
+
+**Attack flow:**
+1. Identify the `unsafe` block, usually around `slice::from_raw_parts` for zero-copy account data.
+2. Find an input whose length / alignment violates the unsafe contract.
+3. Out-of-bounds read leaks adjacent account memory; out-of-bounds write corrupts adjacent state.
+
+**Grep for:**
+- `unsafe { ... }` keyword anywhere in program code
+- `slice::from_raw_parts` / `transmute` / `*const T as *mut T`
+- `bytemuck::from_bytes_unchecked` (the unchecked variant skips alignment / size check)
+
+**Composes with:** zero-copy account layouts (typically the reason for `unsafe`); missing length validation.
+
+---
+
+## Bidirectional rounding on stable-swap pair (Sec3)
+
+**Root cause:** `liquidity_to_collateral` and `collateral_to_liquidity` (or `mint`/`redeem`) round in the same direction on both legs; round-trip is profitable.
+
+**Attack flow / grep / composes:** see Saber entry above. This is the Sec3-named taxonomic version.
+
+---
+
+## CPI without program-id check on Token CPI (Asymmetric Research-recurring)
+
+**Root cause:** Anchor `Program<'info, Token>` enforces program-id, but if the program field is bare `AccountInfo<'info>` and the CPI is built manually, the check is skipped.
+
+**Attack flow:** see "arbitrary CPI" above. This is the Anchor-specific version that frequently slips past audits because Anchor *usually* enforces it.
+
+**Grep for:**
+- `token_program: AccountInfo<'info>` (should be `Program<'info, Token>`)
+- Manual `solana_program::program::invoke(&ix, &accounts)` where `ix.program_id` comes from `accounts[N].key`
+- Custom CPI helpers that take `program_id: &Pubkey` from caller
+
+---
+
+## Sysvar typed as AccountInfo (OtterSec / Wormhole post-mortem)
+
+**Root cause:** see Wormhole entry. Generalized form: any well-known account (token program, ATA program, system program, BPF loader, sysvars) that's typed as untyped `AccountInfo`.
+
+**Grep for:**
+- `clock: AccountInfo<'info>` / `rent: AccountInfo<'info>` / `instructions: AccountInfo<'info>`
+- `system_program: AccountInfo<'info>` (use `Program<'info, System>`)
+- `associated_token_program: AccountInfo<'info>` (use `Program<'info, AssociatedToken>`)
+
+---
+
+## Insecure deserialization (unpack_unchecked) (Neodyme + sec3)
+
+**Root cause:** `unpack_unchecked` skips the SPL Token "is_initialized" check; an uninitialized token account is treated as a real one.
+
+**Attack flow:**
+1. Pass a freshly-allocated, never-initialized SPL token account (zero-filled).
+2. `unpack_unchecked` returns a zero-mint-zero-owner-zero-amount struct.
+3. Some downstream check ("if amount > X" → false, no revert) lets the flow continue.
+4. Subsequent ops trust the spoofed account.
+
+**Grep for:**
+- `spl_token::state::Account::unpack_unchecked(`
+- `Mint::unpack_unchecked(`
+- Any explicit `_unchecked` deserialization helper
+
+**Composes with:** missing owner check; type confusion (the zero-discriminator account masquerades as another type).
+
+---
+
+## Authority not stored in PDA seeds (Offside / Sec3)
+
+**Root cause:** vault PDA derived from `[b"vault", mint.key().as_ref()]` instead of `[b"vault", mint.key().as_ref(), authority.key().as_ref()]`; one global vault per mint, not one per (mint, user) pair, so any user's withdrawal sigs work against the global pool.
+
+**Attack flow:**
+1. Identify a per-mint vault PDA used as recipient of user deposits.
+2. Note that withdrawal signs the PDA with the same seeds, regardless of caller.
+3. Caller A deposits; caller B withdraws against the same PDA.
+
+**Grep for:**
+- `seeds = [b"<purpose>", mint.key().as_ref()]` — no per-user seed
+- Vault PDAs with no `user.key().as_ref()` or `authority.key().as_ref()`
+- Single global `treasury_vault` PDA used as the destination/source for per-user flows
+
+**Composes with:** missing balance accounting (the protocol "knows" individual balances but the on-chain account is shared); permissionless deposit + permissionless withdraw.
+
+---
+
+## Realloc + zero_init = false data leak (Helius checklist)
+
+**Root cause:** `realloc(new_size, false)` after a smaller-then-larger sequence within one tx leaves stale prior-data bytes readable in the freshly-grown region.
+
+**Attack flow:**
+1. Trigger a flow that reallocates the account to size N, then back to size M < N, then to size N again with `zero_init = false`.
+2. Bytes from the prior-larger phase are still there.
+3. If those bytes contained a sensitive field (encryption key, PDA seed, internal flag), they're now in the new layout's read range.
+
+**Grep for:**
+- `account.realloc(new_size, false)`
+- Any size-shrink-then-grow within the same instruction
+- Custom resize helpers without explicit zero-fill
+
+**Composes with:** type confusion (the leaked region is interpreted as a new struct); discriminator collision.
+
+---
+
+## Token-account close to wrong destination (Anchor `close = `)
+
+**Root cause:** `close = recipient` constraint where `recipient` is unconstrained; user closes token account, redirects rent + remaining-token sweep to attacker.
+
+**Attack flow:** see "close redirected" above. Anchor-specific because the macro hides the rent-redirect mechanism.
+
+**Grep for:**
+- `#[account(mut, close = some_account)]` where `some_account` is `AccountInfo` / `UncheckedAccount`
+- Missing constraint pinning `close` recipient to `payer` / a specific PDA
+
+---
+
+## Sandwich-the-init: pre-init account spoof
+
+**Root cause:** initializer creates account by PDA derivation, but the program logic that *uses* the PDA later doesn't check it was created by the same program (it checks address matches, not provenance).
+
+**Attack flow:**
+1. Create an account at the expected PDA address (yes — anyone can transfer lamports there) before the legitimate init runs.
+2. Force a state-bearing instruction that pre-touches the account with attacker-favorable data (if possible via system-program create-with-seed).
+3. Real init may fail (account exists), DoS'ing the protocol; or, if init is `init_if_needed`, attacker's data is preserved.
+
+**Grep for:**
+- PDA accounts that the program reads but doesn't verify were created via its own init path
+- `init_if_needed` on accounts whose pre-init state is consequential
+- No `seeds_with_bump` constraint on read paths
+
+**Composes with:** insecure init; init-if-needed reuse; permissionless creation.
+
+---
+
+## Trusted upstream binary not pinned
+
+**Root cause:** program calls into an external program (oracle, AMM, vault) via known program-id, but never verifies the *deployed binary* matches what was audited; an upgrade by the upstream's authority changes semantics under the caller's feet.
+
+**Attack flow:** non-exploit risk, but real:
+1. Caller integrates with `Program X v1` — semantics: `swap(min_out)` reverts on slippage.
+2. Upstream upgrades to v2 — semantics: silently fills at any price.
+3. Caller's slippage protection is now nullified.
+
+**Grep for:**
+- Hardcoded program-ids without binary-hash verification
+- No `qed::cpi { binary_hash = ... }` (or framework equivalent)
+- Calls to upgradeable programs with no on-chain immutability check
+
+**Composes with:** arbitrary CPI risk evolves over time; upgrade-authority compromise upstream becomes attacker capability downstream.
+
+---
+
+## Permissionless instruction without rate-limit / circuit-breaker
+
+**Root cause:** sensitive ops (mint, claim, settle) lack a per-slot / per-block / per-account rate limit; one tx = unlimited damage.
+
+**Attack flow:**
+1. Find any "drain pool / reward / fee" path.
+2. Pack maximum-allowed instructions per tx (Solana: ~30-40 within compute budget).
+3. Drain in one transaction; revert is impossible because individual instructions all succeed.
+
+**Grep for:**
+- No per-account / per-slot counter checked before mutating critical state
+- No `last_action_slot` field on user accounts for sensitive ops
+- No protocol-wide TVL / withdraw-per-window cap
+
+**Composes with:** every other primitive — the rate limit is the last line of defense even when the primitive bug exists.


### PR DESCRIPTION
## Summary

Expand the qedgen auditor from a category-checklist runner into a composition-aware bug hunter — the bear-hug demands novel-vuln discovery, which is composition reasoning, not longer taxonomy.

### 1. Adversarial framing in SKILL.md

- New "**Adversarial mindset**" section: working assumptions (frameworks have escape hatches; composition beats taxonomy; refresh per audit).
- Explicit **escalation step** in the workflow: for every real-vuln finding, the auditor must name the standalone severity AND the compose-with-what kill-chain before writing the report. Severity is the chain's ceiling, not the primitive's.
- Per-finding output now requires `Standalone severity`, `Kill-chain`, `Composes with`, and `Corpus reference` fields.
- **Severity rubric** keyed off attacker capability (CRIT/HIGH/MED/LOW), not category label.
- **Compose-with-what cookbook** — 15 named chains (missing_signer + arbitrary_cpi = takeover, oracle_staleness + frontrunnable_no_slippage = sandwich-amplified, etc.) so the auditor doesn't miss obvious amplifications.

### 2. `exploits.md` corpus (57 entries)

Reference shipped with the skill at `skills/qedgen-auditor/exploits.md`. Walked at every audit; for each entry, ask "could the same shape happen here?"

- **Named incidents (15)**: Wormhole ($326M), Cashio ($52.8M), Mango ($114M), Crema ($8.8M), Saber, Solend, Nirvana, Loopscale (April 2025), Jet, Raydium, Cypher, Drift (April 2026, $285M), Slope, web3.js backdoor (Dec 2024).
- **Generic primitives (20)**: missing signer/owner/type checks, PDA seed collision, non-canonical bumps, account-type confusion, init-without-is-initialized, close-redirection, duplicate accounts, arbitrary CPI, sysvar substitution, unvalidated remaining_accounts, account-not-reloaded after CPI, integer overflow, precision loss, sentinel short-circuit, frontrunning, lamport demotion, missing rent-exemption.
- **DeFi-shape (8)**: sandwich/MEV, oracle staleness, gameable TWAP, Token-2022 transfer-hook reentrancy, flash-loan governance, cross-margin drain, liquidation rounding, fee-on-transfer.
- **Audit-firm patterns (10)**: nominate-accept transfer, unsafe Rust, bidirectional rounding, CPI without program-id, sysvar typed as AccountInfo, unpack_unchecked, authority not in PDA seeds, realloc data leak, close= redirect, sandwich-the-init.

Each entry has root-cause primitive, attack flow (3-5 steps), concrete grep patterns, and "composes with" chains.

### 3. Three new spec-aware probe categories

`qedgen probe --json` now emits compose-able primitives the auditor chains:

- **`unbounded_amount_param`** — handler accepts integer param used in transfer/effect with no upper-bound `requires`. Detects the drain shape that lower-only bounds (`amount > 0`) miss. Predicate: scans `requires` for explicit `<` / `<=` / `>=` (RHS form) / `==` against the param.
- **`permissionless_state_writer`** — `permissionless` + state effect. Griefing surface; almost always amplifies via another primitive.
- **`init_without_pda`** — init-shape handler (`pre_status` ∈ {Uninitialized, Empty, Inactive}) with no writable PDA-seeded account. Default-address collision.

### Smoke evidence — real shapes surfacing

```
escrow::initialize          → 2× unbounded_amount_param (deposit, receive)
lending::init_pool          → unbounded_amount_param
lending::deposit            → unbounded_amount_param + permissionless_state_writer
                              ← canonical drain chain
lending::borrow             → 2× unbounded_amount_param
lending::liquidate          → permissionless_state_writer
multisig::propose           → permissionless_state_writer
multisig::execute           → permissionless_state_writer
multisig::cancel_proposal   → permissionless_state_writer
```

The drain chain on `lending::deposit` is exactly the kind of composition the previous auditor (1/15 novel on the v2.6.1 eval) couldn't surface.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --release -- -D warnings`
- [x] `cargo test --release` — 469 unit tests pass (+9 new probe tests covering upper-vs-lower-bound, permissionless suppression rules, init-without-pda init-shape detection)
- [x] `cargo test --test codegen_smoke -- --ignored` — 4 smoke tests pass
- [x] Manual probe sweep against escrow / lending / multisig / percolator — findings are real shapes, no false-positive flood

## Out of scope (deferred)

- Spec-less / impl-side categories from the corpus (`account_type_confusion`, `close_account_redirection`, `oracle_staleness`, etc.) live in the SKILL.md per-runtime catalog — they need source reading the CLI doesn't do, by design (`feedback_audit_as_subagent.md`).
- Pre-launch real-program eval against a serious mainnet program (the bear-hug success bar per `feedback_audit_bear_hug.md`) — this PR is the toolkit upgrade; the eval is the next thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)