### PR TITLE
v2.14.0: codegen + invariant DSL fixes from v2.13 audit eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.13.0"
+version = "2.14.0"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -141,6 +141,32 @@ pub struct ParsedLiveness {
     pub within_steps: Option<u64>,
 }
 
+/// Top-level invariant declaration.
+///
+/// Two forms:
+/// - **Expression body** (`invariant <name> : <expr>`): the predicate is
+///   real and codegen emits a real theorem / harness over it. `lean_expr`
+///   and `rust_expr` are populated.
+/// - **Description-only** (`invariant <name> "<doc>"`): a stub from the
+///   pre-v2.14 era. No predicate body, codegen emits a structured comment
+///   instead of `theorem foo : True := trivial`. `doc` is populated;
+///   `lean_expr` / `rust_expr` are `None`. The `bare_invariant` lint
+///   flags these as P3 — users should give them a body.
+#[derive(Debug, Clone)]
+pub struct ParsedInvariant {
+    pub name: String,
+    /// Description string when present (non-empty for description-only form;
+    /// may be empty when only an expression body was declared).
+    pub doc: String,
+    /// Lean form of the predicate expression. `None` for description-only.
+    pub lean_expr: Option<String>,
+    /// Rust form of the predicate expression. `None` for description-only.
+    /// v2.15 wires this into Kani / proptest invariant-checking harnesses;
+    /// v2.14 ships only the Lean theorem path.
+    #[allow(dead_code)]
+    pub rust_expr: Option<String>,
+}
+
 /// Parsed environment block (external state).
 #[derive(Debug, Clone)]
 pub struct ParsedEnvironment {
@@ -768,7 +794,7 @@ pub struct ParsedSpec {
     // Legacy fields — populated by forward bridge for backward compat.
     #[allow(dead_code)]
     pub operations: Vec<ParsedOperation>,
-    pub invariants: Vec<(String, String)>, // (name, description)
+    pub invariants: Vec<ParsedInvariant>,
     pub properties: Vec<ParsedProperty>,
     #[allow(dead_code)]
     pub has_u64_fields: bool,
@@ -1390,8 +1416,13 @@ fn generate_properties(spec: &ParsedSpec) -> Vec<(String, String, Option<String>
 
     // ── Top-level invariants ──
 
-    for (name, desc) in &spec.invariants {
-        let intent = format!("Invariant: {}", desc);
+    for inv in &spec.invariants {
+        let name = &inv.name;
+        let intent = match (&inv.lean_expr, inv.doc.is_empty()) {
+            (Some(expr), _) => format!("Invariant: {}", expr),
+            (None, false) => format!("Invariant: {}", inv.doc),
+            (None, true) => format!("Invariant: {}", name),
+        };
         let suggestion = Some(
             "This invariant stub is generated as `True` by the DSL. \
              For a meaningful conservation proof, define the predicate and prove it \

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -2144,11 +2144,26 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
                 });
             }
             TopItem::Invariant(i) => {
-                let desc = match &i.body {
-                    a::InvariantBody::Expr(e) => expr_to_lean(&e.node, Ctx::Guard, consts, &env),
-                    a::InvariantBody::Description(s) => s.clone(),
+                let parsed = match &i.body {
+                    a::InvariantBody::Expr(e) => {
+                        let lean = expr_to_lean(&e.node, Ctx::Guard, consts, &env);
+                        let rust =
+                            crate::rust_codegen_util::translate_property_to_rust(&lean, false);
+                        crate::check::ParsedInvariant {
+                            name: i.name.clone(),
+                            doc: String::new(),
+                            lean_expr: Some(lean),
+                            rust_expr: Some(rust),
+                        }
+                    }
+                    a::InvariantBody::Description(s) => crate::check::ParsedInvariant {
+                        name: i.name.clone(),
+                        doc: s.clone(),
+                        lean_expr: None,
+                        rust_expr: None,
+                    },
                 };
-                out.invariants.push((i.name.clone(), desc));
+                out.invariants.push(parsed);
             }
             TopItem::Pda(p) => {
                 let seeds: Vec<String> = p

--- a/crates/qedgen/src/codegen.rs
+++ b/crates/qedgen/src/codegen.rs
@@ -263,6 +263,19 @@ impl FrameworkSurface {
         }
     }
 
+    /// Generic "predicate violated, no specific error code" expression for
+    /// bare `requires` clauses (no `else <Error>`). Pre-v2.14 emitted
+    /// `debug_assert!` (silent no-op in release); v2.14+ emits a real
+    /// runtime check that returns this error. Each surface needs the
+    /// type-correct form for its `Result<(), _>` return shape.
+    fn generic_error_expr(&self) -> &'static str {
+        match self.target {
+            Target::Anchor => "anchor_lang::error::Error::from(ProgramError::Custom(0xFF))",
+            Target::Quasar => "ProgramError::Custom(0xFF)",
+            Target::Pinocchio => unreachable!(),
+        }
+    }
+
     fn guard_accounts_import(&self) -> &'static str {
         match self.target {
             Target::Anchor => "use crate::*;\n\n",
@@ -2664,8 +2677,9 @@ fn generate_guards(
                 // `else <Error>` for diagnostic clarity, but the check now
                 // runs either way.
                 out.push_str(&format!(
-                    "    if !({}) {{ return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }}\n",
-                    rust
+                    "    if !({}) {{ return Err({}); }}\n",
+                    rust,
+                    surface.generic_error_expr()
                 ));
             }
         }

--- a/crates/qedgen/src/codegen.rs
+++ b/crates/qedgen/src/codegen.rs
@@ -2654,7 +2654,19 @@ fn generate_guards(
                     surface.error_expr(&err_enum, err),
                 ));
             } else {
-                out.push_str(&format!("    debug_assert!({});\n", rust));
+                // Bare `requires` (no `else <ErrorCode>`). Pre-v2.14 emitted
+                // `debug_assert!`, which silently no-ops in release builds —
+                // every bare requires would skip its check in production.
+                // Emit a real runtime check with `ProgramError::Custom(0xFF)`
+                // (sentinel "predicate violated, no specific error code").
+                // The auditor's `bounty_intent_drift` predicate flags
+                // bare requires as P3 — users should still add an explicit
+                // `else <Error>` for diagnostic clarity, but the check now
+                // runs either way.
+                out.push_str(&format!(
+                    "    if !({}) {{ return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }}\n",
+                    rust
+                ));
             }
         }
 

--- a/crates/qedgen/src/lean_gen.rs
+++ b/crates/qedgen/src/lean_gen.rs
@@ -158,12 +158,9 @@ fn render_single_account(spec: &ParsedSpec) -> String {
     render_cpi_theorems(&mut out, &ops_refs, &spec.state_fields, "State", spec);
 
     // Invariants
-    for (inv_name, _desc) in &spec.invariants {
-        out.push_str(&format!(
-            "/-- Invariant: {}. -/\ntheorem {} : True := trivial\n\n",
-            inv_name, inv_name
-        ));
-    }
+    let state_field_set: std::collections::HashSet<&str> =
+        spec.state_fields.iter().map(|(n, _)| n.as_str()).collect();
+    render_invariants_theorem_form(&mut out, &spec.invariants, &state_field_set, "State");
 
     // Operation inductive + applyOp
     render_operation_inductive(&mut out, &ops_refs, "State");
@@ -288,13 +285,14 @@ fn render_multi_account(spec: &ParsedSpec) -> String {
         render_operation_inductive(&mut out, &ops, &state_name);
     }
 
-    // Invariants
-    for (inv_name, _desc) in &spec.invariants {
-        out.push_str(&format!(
-            "/-- Invariant: {}. -/\ntheorem {} : True := trivial\n\n",
-            inv_name, inv_name
-        ));
-    }
+    // Invariants — multi-account specs need richer translation than v2.14
+    // ships (the body may reference per-account variant types like
+    // `Loan.Active` that need lowering to `LoanState` + status filter).
+    // Emit structured comments for now; v2.15 picks up multi-account
+    // invariant lowering.
+    let dummy: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    render_invariants_as_comments(&mut out, &spec.invariants);
+    let _ = dummy;
 
     // Properties — for multi-account, reference the state type from the first account
     // that has matching fields. Properties using `state.X` bind to the account whose
@@ -826,6 +824,93 @@ fn render_cpi_theorems(
                 ));
             }
         }
+    }
+}
+
+/// Render `theorem <name> ...` for each declared invariant — single-account
+/// path. For multi-account specs, use `render_invariants_as_comments`
+/// (v2.14 doesn't yet lower variant-typed binders like `Loan.Active`).
+///
+/// Two paths inside this function:
+///
+/// - **Expression body** (`invariant <name> : <expr>`): the parsed
+///   `lean_expr` is the predicate. Emit a real theorem statement,
+///   prefix bare state-field references with `s.`, and close with
+///   `:= by sorry` (the user is expected to supply or fill the proof,
+///   matching the v2.8 G3 ensures-as-axiom precedent — `sorry` here
+///   is a tracked obligation, not a tautology).
+/// - **Description-only**: the spec declared the name but no body.
+///   Emit a structured comment describing the obligation; do not emit
+///   a theorem. Pre-v2.14 emitted `theorem <name> : True := trivial`,
+///   which was tautological by design (no goal to prove). The
+///   structured comment is the honest replacement; `bare_invariant`
+///   lint flags these for the spec author to fix.
+fn render_invariants_theorem_form(
+    out: &mut String,
+    invariants: &[crate::check::ParsedInvariant],
+    field_set: &std::collections::HashSet<&str>,
+    state_type: &str,
+) {
+    for inv in invariants {
+        match &inv.lean_expr {
+            Some(lean) => {
+                let prefixed = prefix_state_fields(lean, field_set);
+                out.push_str(&format!(
+                    "/-- Invariant: {}{} -/\n",
+                    inv.name,
+                    if inv.doc.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" — {}", inv.doc)
+                    }
+                ));
+                out.push_str(&format!(
+                    "theorem {} (s : {}) : {} := by sorry\n\n",
+                    inv.name, state_type, prefixed
+                ));
+            }
+            None => {
+                out.push_str(&format!(
+                    "-- INVARIANT OBLIGATION (declared, no predicate body): {}\n",
+                    inv.name
+                ));
+                if !inv.doc.is_empty() {
+                    out.push_str(&format!("--   description: {}\n", inv.doc));
+                }
+                out.push_str("-- The spec declared this name but didn't supply a predicate body\n");
+                out.push_str(
+                    "-- (`invariant <name> : <expr>`). The codegen has no goal to lower —\n",
+                );
+                out.push_str("-- pre-v2.14 emitted `theorem <name> : True := trivial`, which\n");
+                out.push_str("-- was tautological. To verify this invariant, give it a body in\n");
+                out.push_str("-- the spec.\n\n");
+            }
+        }
+    }
+}
+
+/// Render invariants as structured comments only (no theorems). Used for
+/// multi-account specs in v2.14 — the body translation needs to lower
+/// variant-typed binders (`Loan.Active`) into Lean's typed-state +
+/// status-filter form, which v2.14 doesn't yet implement. Pre-v2.14
+/// emitted `theorem <name> : True := trivial` (tautological); structured
+/// comments are the honest stop-gap until v2.15 picks up the richer
+/// translation.
+fn render_invariants_as_comments(out: &mut String, invariants: &[crate::check::ParsedInvariant]) {
+    for inv in invariants {
+        out.push_str(&format!(
+            "-- INVARIANT OBLIGATION (declared, multi-account translation deferred): {}\n",
+            inv.name
+        ));
+        if let Some(lean) = &inv.lean_expr {
+            out.push_str(&format!("--   predicate body: {}\n", lean));
+        }
+        if !inv.doc.is_empty() {
+            out.push_str(&format!("--   description: {}\n", inv.doc));
+        }
+        out.push_str("-- v2.14 emits this as a comment; multi-account invariant\n");
+        out.push_str("-- bodies (e.g. `forall l : Loan.Active, ...`) need lowering\n");
+        out.push_str("-- to typed-state-with-status-filter form. v2.15 picks it up.\n\n");
     }
 }
 

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.14.0" }
 
 [workspace]

--- a/examples/rust/escrow/formal_verification/Spec.lean
+++ b/examples/rust/escrow/formal_verification/Spec.lean
@@ -130,8 +130,13 @@ theorem cancel_transfer_correct (from_pk to_pk authority_pk : Pubkey) :
   unfold build_cancel_transfer targetsProgram accountAt hasDiscriminator
   exact ⟨rfl, rfl, rfl, rfl, rfl⟩
 
-/-- Invariant: conservation. -/
-theorem conservation : True := trivial
+-- INVARIANT OBLIGATION (declared, no predicate body): conservation
+--   description: total tokens preserved across initialize, exchange, cancel
+-- The spec declared this name but didn't supply a predicate body
+-- (`invariant <name> : <expr>`). The codegen has no goal to lower —
+-- pre-v2.14 emitted `theorem <name> : True := trivial`, which
+-- was tautological. To verify this invariant, give it a body in
+-- the spec.
 
 inductive Operation where
   | «initialize» (deposit_amount : Nat) (receive_amount : Nat)

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.14.0" }
 
 [workspace]

--- a/examples/rust/lending/formal_verification/Spec.lean
+++ b/examples/rust/lending/formal_verification/Spec.lean
@@ -172,8 +172,11 @@ def applyLoanOp (s : LoanState) (signer : Pubkey) : LoanOperation → Option Loa
   | .repay => repayTransition s signer
   | .liquidate => liquidateTransition s signer
 
-/-- Invariant: collateral_backing. -/
-theorem collateral_backing : True := trivial
+-- INVARIANT OBLIGATION (declared, multi-account translation deferred): collateral_backing
+--   predicate body: ∀ l : Loan.Active, l.collateral > 0
+-- v2.14 emits this as a comment; multi-account invariant
+-- bodies (e.g. `forall l : Loan.Active, ...`) need lowering
+-- to typed-state-with-status-filter form. v2.15 picks it up.
 
 def pool_solvency (s : PoolState) : Prop := s.total_deposits ≥ s.total_borrows
 

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.14.0" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.14.0" }
 
 [workspace]

--- a/examples/rust/multisig/programs/src/guards.rs
+++ b/examples/rust/multisig/programs/src/guards.rs
@@ -135,9 +135,9 @@ pub fn remove_member<'info>(ctx: &mut RemoveMember<'info>) -> Result<(), Program
     // lifecycle: require status == Active
     if ctx.vault.status != Status::Active as u8 { return Err(ProgramError::from(crate::errors::MultisigError::InvalidLifecycle)); }
     // requires: s.member_count > s.threshold
-    debug_assert!(ctx.vault.member_count > ctx.vault.threshold);
+    if !(ctx.vault.member_count > ctx.vault.threshold) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: s.approval_count = 0 ∧ s.rejection_count = 0
-    debug_assert!((ctx.vault.approval_count == 0) && (ctx.vault.rejection_count == 0));
+    if !((ctx.vault.approval_count == 0) && (ctx.vault.rejection_count == 0)) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     Ok(())
 }
 

--- a/examples/rust/multisig/programs/src/guards.rs
+++ b/examples/rust/multisig/programs/src/guards.rs
@@ -135,9 +135,9 @@ pub fn remove_member<'info>(ctx: &mut RemoveMember<'info>) -> Result<(), Program
     // lifecycle: require status == Active
     if ctx.vault.status != Status::Active as u8 { return Err(ProgramError::from(crate::errors::MultisigError::InvalidLifecycle)); }
     // requires: s.member_count > s.threshold
-    if !(ctx.vault.member_count > ctx.vault.threshold) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(ctx.vault.member_count > ctx.vault.threshold) { return Err(ProgramError::Custom(0xFF)); }
     // requires: s.approval_count = 0 ∧ s.rejection_count = 0
-    if !((ctx.vault.approval_count == 0) && (ctx.vault.rejection_count == 0)) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !((ctx.vault.approval_count == 0) && (ctx.vault.rejection_count == 0)) { return Err(ProgramError::Custom(0xFF)); }
     Ok(())
 }
 

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.13.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.14.0" }
 
 [workspace]

--- a/examples/rust/percolator/programs/src/guards.rs
+++ b/examples/rust/percolator/programs/src/guards.rs
@@ -43,11 +43,11 @@ pub fn reclaim_empty_account<'info>(ctx: &mut ReclaimEmptyAccount<'info>, i: usi
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: s.accounts[i].capital = 0
-    if !(ctx.vault.accounts[(i) as usize].capital.get() == 0) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(ctx.vault.accounts[(i) as usize].capital.get() == 0) { return Err(ProgramError::Custom(0xFF)); }
     // requires: s.accounts[i].reserved_pnl = 0
-    if !(ctx.vault.accounts[(i) as usize].reserved_pnl.get() == 0) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(ctx.vault.accounts[(i) as usize].reserved_pnl.get() == 0) { return Err(ProgramError::Custom(0xFF)); }
     // requires: s.accounts[i].fee_credits = 0
-    if !(ctx.vault.accounts[(i) as usize].fee_credits.get() == 0) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(ctx.vault.accounts[(i) as usize].fee_credits.get() == 0) { return Err(ProgramError::Custom(0xFF)); }
     Ok(())
 }
 
@@ -135,9 +135,9 @@ pub fn execute_trade<'info>(ctx: &mut ExecuteTrade<'info>, a: usize, b: usize, s
     // requires: s.accounts[b].active = 1
     if !(ctx.vault.accounts[(b) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: a ≠ b
-    if !(a != b) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(a != b) { return Err(ProgramError::Custom(0xFF)); }
     // requires: (((size_q) * ((((exec_price) : Int)))) / (1000000)) ≤ (((100000000000000000000) : Int))
-    if !(mul_div_floor_u128(((size_q) as u128), ((exec_price) as u128), ((1000000) as u128)) <= 100000000000000000000) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(mul_div_floor_u128(((size_q) as u128), ((exec_price) as u128), ((1000000) as u128)) <= 100000000000000000000) { return Err(ProgramError::Custom(0xFF)); }
     Ok(())
 }
 
@@ -149,7 +149,7 @@ pub fn liquidate_case_0<'info>(ctx: &mut LiquidateCase0<'info>, i: usize) -> Res
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int))
-    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)) { return Err(ProgramError::Custom(0xFF)); }
     // requires: 0 = 1
     if !(false) { return Err(ProgramError::from(PercolatorError::AccountHealthy)); }
     Ok(())
@@ -163,9 +163,9 @@ pub fn liquidate_case_1<'info>(ctx: &mut LiquidateCase1<'info>, i: usize) -> Res
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int)))
-    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl + (((s.I) : Int)) ≥ (((0) : Int))
-    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128)) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128)) { return Err(ProgramError::Custom(0xFF)); }
     Ok(())
 }
 
@@ -177,9 +177,9 @@ pub fn liquidate_otherwise<'info>(ctx: &mut LiquidateOtherwise<'info>, i: usize)
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int)))
-    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl + (((s.I) : Int)) ≥ (((0) : Int)))
-    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128))) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
+    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
     // requires: 0 = 1
     if !(false) { return Err(ProgramError::from(PercolatorError::BankruptPosition)); }
     Ok(())

--- a/examples/rust/percolator/programs/src/guards.rs
+++ b/examples/rust/percolator/programs/src/guards.rs
@@ -43,11 +43,11 @@ pub fn reclaim_empty_account<'info>(ctx: &mut ReclaimEmptyAccount<'info>, i: usi
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: s.accounts[i].capital = 0
-    debug_assert!(ctx.vault.accounts[(i) as usize].capital.get() == 0);
+    if !(ctx.vault.accounts[(i) as usize].capital.get() == 0) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: s.accounts[i].reserved_pnl = 0
-    debug_assert!(ctx.vault.accounts[(i) as usize].reserved_pnl.get() == 0);
+    if !(ctx.vault.accounts[(i) as usize].reserved_pnl.get() == 0) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: s.accounts[i].fee_credits = 0
-    debug_assert!(ctx.vault.accounts[(i) as usize].fee_credits.get() == 0);
+    if !(ctx.vault.accounts[(i) as usize].fee_credits.get() == 0) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     Ok(())
 }
 
@@ -135,9 +135,9 @@ pub fn execute_trade<'info>(ctx: &mut ExecuteTrade<'info>, a: usize, b: usize, s
     // requires: s.accounts[b].active = 1
     if !(ctx.vault.accounts[(b) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: a ≠ b
-    debug_assert!(a != b);
+    if !(a != b) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: (((size_q) * ((((exec_price) : Int)))) / (1000000)) ≤ (((100000000000000000000) : Int))
-    debug_assert!(mul_div_floor_u128(((size_q) as u128), ((exec_price) as u128), ((1000000) as u128)) <= 100000000000000000000);
+    if !(mul_div_floor_u128(((size_q) as u128), ((exec_price) as u128), ((1000000) as u128)) <= 100000000000000000000) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     Ok(())
 }
 
@@ -149,7 +149,7 @@ pub fn liquidate_case_0<'info>(ctx: &mut LiquidateCase0<'info>, i: usize) -> Res
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int))
-    debug_assert!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128));
+    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: 0 = 1
     if !(false) { return Err(ProgramError::from(PercolatorError::AccountHealthy)); }
     Ok(())
@@ -163,9 +163,9 @@ pub fn liquidate_case_1<'info>(ctx: &mut LiquidateCase1<'info>, i: usize) -> Res
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int)))
-    debug_assert!(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)));
+    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl + (((s.I) : Int)) ≥ (((0) : Int))
-    debug_assert!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128));
+    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128)) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     Ok(())
 }
 
@@ -177,9 +177,9 @@ pub fn liquidate_otherwise<'info>(ctx: &mut LiquidateOtherwise<'info>, i: usize)
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int)))
-    debug_assert!(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)));
+    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl + (((s.I) : Int)) ≥ (((0) : Int)))
-    debug_assert!(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128)));
+    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128))) { return Err(solana_program::program_error::ProgramError::Custom(0xFF).into()); }
     // requires: 0 = 1
     if !(false) { return Err(ProgramError::from(PercolatorError::BankruptPosition)); }
     Ok(())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Agent skill for spec-driven verification of Solana programs — .qedspec specs generate proptest harnesses, Kani BMC harnesses, Lean 4 proofs, Anchor and Quasar agent-fill scaffolds, deploy-safety ratchets, and CI workflows.",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
## Summary

Two fixes from the v2.13 Quasar audit eval. Both eliminate v2.12-style "stop lying" anti-patterns that the auditor surfaced in our own shipping examples.

### 1. Codegen — bare `requires` emits real runtime check

`requires <expr>` clauses without `else <Error>` were emitted as `debug_assert!(...)` — silently no-op in release builds. The check would run in tests, fail to fire in production. Two `requires` on `multisig::remove_member` and five on percolator handlers were affected.

Fix in `codegen.rs`: emit `if !(expr) { return Err(ProgramError::Custom(0xFF).into()); }` when no error name is supplied. Users still get specific errors via `else <Error>`; either way, the check runs.

Same anti-pattern as `theorem foo : True := trivial` in Lean — silent acceptance of an obligation that's not actually checked.

### 2. Invariant DSL — preserve predicate body, emit real theorems

The DSL grammar already supported `invariant <name> : <expr>` (since pre-v2.10), but the chumsky adapter collapsed both expression-form and description-string-form into a `(name, String)` tuple, losing the predicate. Codegen then emitted `theorem <name> : True := trivial` for both. The lending spec's `invariant collateral_backing : forall l : Loan.Active, l.collateral > 0` was vacuous.

Fix:

- **New `ParsedInvariant` struct** in `check.rs` — preserves `name`, `doc`, `lean_expr: Option<String>`, `rust_expr: Option<String>`. Adapter no longer collapses.
- **Single-account specs** (escrow, multisig): when `lean_expr` is `Some`, emit a real theorem with state-field prefixing and `:= by sorry` (tracked obligation, same precedent as v2.8 G3 ensures-as-axiom). When `None`, emit a structured comment naming the obligation.
- **Multi-account specs** (lending, percolator): emit structured comments inlining the predicate body — variant-typed binders (`forall l : Loan.Active, ...`) need lowering to typed-state + status-filter form. v2.15 picks up the richer translation.

This closes the last surviving instance of the v2.12 "stop lying" principle. No more `theorem foo : True := trivial` in shipping examples.

## Out of scope

Two findings from the Quasar audit eval still need fixes — both require DSL/codegen extensions beyond v2.14's scope, queued for v2.15:

- **Multisig `propose` doesn't reset `voted[]` bitmap** — needs Map-clear effect form (`voted := zero_map` or similar). The bug shape is real (each member who votes is permanently locked out of future proposals).
- **Multisig `create_vault` doesn't write `creator`/`bump`** — needs codegen auto-fill from the `pda ["vault", creator]` declaration, OR spec-state-vs-account-binding name disambiguation.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --release -- -D warnings`
- [x] `cargo test --release` — 469 unit tests pass
- [x] `cargo test --test codegen_smoke -- --ignored` — 4 smoke tests pass
- [x] `lake build` clean on all four shipping Rust examples
- [x] `qedgen check --regen-drift` clean
- [x] Manual verification: lending's `collateral_backing` invariant now produces a structured-comment record of the obligation (not `True := trivial`); escrow's description-only `conservation` produces a comment flagging the missing body

🤖 Generated with [Claude Code](https://claude.com/claude-code)