### PR TITLE
fix(proptest_gen + adapter): make standalone proptest compile for larger brownfield specs

### DIFF
--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -973,9 +973,13 @@ fn render_rust_binary_with_coercion(
     let rk = rust_infer_kind(opts.env, &rhs.node);
     let l = expr_to_rust(&lhs.node, ctx, consts, opts);
     let r = expr_to_rust(&rhs.node, ctx, consts, opts);
+    // When widening Nat → Int we must cast BOTH sides to the same wide
+    // type. Pre-fix only the Nat side was cast, leaving comparisons like
+    // `i64 >= i128` that don't typecheck. Symmetric widening to i128 keeps
+    // operands aligned without losing precision on either side.
     match (lk, rk) {
-        (Kind::Nat, Kind::Int) => (format!("(({}) as i128)", l), r),
-        (Kind::Int, Kind::Nat) => (l, format!("(({}) as i128)", r)),
+        (Kind::Nat, Kind::Int) => (format!("(({}) as i128)", l), format!("(({}) as i128)", r)),
+        (Kind::Int, Kind::Nat) => (format!("(({}) as i128)", l), format!("(({}) as i128)", r)),
         _ => (l, r),
     }
 }

--- a/crates/qedgen/src/codegen.rs
+++ b/crates/qedgen/src/codegen.rs
@@ -2311,7 +2311,7 @@ fn precompute_body_hash(scaffold_source: &str) -> Option<String> {
 /// fixed-point helpers in `src/math.rs`. Used to gate the `use crate::math::*;`
 /// import in `guards.rs` so legacy programs whose user-owned `lib.rs` doesn't
 /// declare `pub mod math;` keep compiling.
-fn guards_use_math_helpers(spec: &ParsedSpec) -> bool {
+pub(crate) fn guards_use_math_helpers(spec: &ParsedSpec) -> bool {
     let mut any = false;
     let probe = |s: &str| s.contains("mul_div_floor_u128") || s.contains("mul_div_ceil_u128");
     for h in &spec.handlers {
@@ -2322,6 +2322,14 @@ fn guards_use_math_helpers(spec: &ParsedSpec) -> bool {
             any = true;
         }
         if h.ensures.iter().any(|e| probe(&e.rust_expr)) {
+            any = true;
+        }
+        // Handler-level `let bindings: (lean_expr, rust_expr)` also lower to
+        // `let X = mul_div_floor_u128(...)` in the emitted Rust handler body.
+        // Without this, specs that compute fee math via a `let` (a common
+        // pattern for splitting amounts before the effect block) wouldn't
+        // pick up the math.rs import / inline helpers.
+        if h.let_bindings.iter().any(|(_, _, r)| probe(r)) {
             any = true;
         }
     }

--- a/crates/qedgen/src/codegen.rs
+++ b/crates/qedgen/src/codegen.rs
@@ -1858,8 +1858,12 @@ fn mechanize_effect(
         return None;
     }
 
-    let rhs = crate::rust_codegen_util::resolve_value(value, handler, spec);
+    // Anchor / Quasar handler bodies bind state as `self.<acct>.<field>`,
+    // so a bare state-field RHS (e.g. `bid_buyer := state.rfp_buyer` after
+    // upstream strips `state.`) needs to resolve to `self.<acct>.rfp_buyer`.
     let acct = &state_acct.name;
+    let acct_binder = format!("self.{}.", acct);
+    let rhs = crate::rust_codegen_util::resolve_value(value, handler, spec, Some(&acct_binder));
     // Cast index expressions in the LHS path to `usize`. `render_effect`
     // emits the field as `voted[member_index]` (Lean-friendly); on the
     // Rust side, indexing `[u8; N]` with `u8`/`u16`/Fin fails — Rust

--- a/crates/qedgen/src/proptest_gen.rs
+++ b/crates/qedgen/src/proptest_gen.rs
@@ -404,6 +404,36 @@ pub fn generate(spec_path: &Path, output_path: &Path) -> Result<()> {
     );
     out.push_str("use proptest::prelude::*;\n\n");
 
+    // ── Math helpers ─────────────────────────────────────────────────────
+    // The brownfield workflow runs `qedgen codegen --proptest` against an
+    // existing program crate, without `--all`. In that case `src/math.rs`
+    // is never generated, so any `mul_div_floor_u128` / `mul_div_ceil_u128`
+    // calls emitted by chumsky_adapter::expr_to_rust have no definition in
+    // scope. Inline the helpers ONLY when the spec actually uses them —
+    // otherwise we'd ship two sources of truth for every spec that
+    // doesn't need them, with the silent-divergence risk that implies for
+    // any future change to the canonical helper.
+    //
+    // Detection reuses `codegen::guards_use_math_helpers` so this gate
+    // tracks the same predicate as the `--all` math.rs emission.
+    if crate::codegen::guards_use_math_helpers(&spec) {
+        out.push_str(
+            "#[allow(dead_code)]\n\
+#[inline]\n\
+fn mul_div_floor_u128(a: u128, b: u128, d: u128) -> u128 {\n\
+    if d == 0 { return 0; }\n\
+    a.saturating_mul(b) / d\n\
+}\n\n\
+#[allow(dead_code)]\n\
+#[inline]\n\
+fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {\n\
+    if d == 0 { return 0; }\n\
+    let prod = a.saturating_mul(b);\n\
+    if prod % d == 0 { prod / d } else { (prod / d).saturating_add(1) }\n\
+}\n\n",
+        );
+    }
+
     // ── Constants ────────────────────────────────────────────────────────
     rust_codegen_util::emit_constants(&mut out, &spec.constants);
 

--- a/crates/qedgen/src/proptest_gen.rs
+++ b/crates/qedgen/src/proptest_gen.rs
@@ -402,6 +402,34 @@ pub fn generate(spec_path: &Path, output_path: &Path) -> Result<()> {
     out.push_str(
         "// ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----\n\n",
     );
+
+    // rustc's default `recursion_limit = 128` is enough for small specs
+    // but not for proptest's deeply nested `TupleValueTree<...>`
+    // instantiations when `arb_state()` composes a State with many
+    // (≳40) fields — layout/normalize queries overflow at typecheck:
+    //
+    //   error: queries overflow the depth limit!
+    //     = help: consider increasing the recursion limit by adding a
+    //       `#![recursion_limit = "256"]` attribute to your crate
+    //
+    // Gate the override emission on field count so small specs (escrow:
+    // 3 fields, lending: 6, multisig: 5) keep the rustc default and only
+    // larger specs pay the higher ceiling. 32 is a comfortable threshold
+    // — well below the empirical 99-field State that needs ≥256.
+    //
+    // Value 512 = 2× rustc's suggested 256, empirically validated against
+    // a 99-field flat State. Specs that genuinely need more will fail
+    // with the same clear diagnostic and can override locally.
+    let total_field_count: usize = rust_codegen_util::mutable_fields(&spec.state_fields).len()
+        + spec
+            .account_types
+            .iter()
+            .map(|a| rust_codegen_util::mutable_fields(&a.fields).len())
+            .sum::<usize>();
+    if total_field_count > 32 {
+        out.push_str("#![recursion_limit = \"512\"]\n\n");
+    }
+
     out.push_str("use proptest::prelude::*;\n\n");
 
     // ── Math helpers ─────────────────────────────────────────────────────

--- a/crates/qedgen/src/proptest_gen.rs
+++ b/crates/qedgen/src/proptest_gen.rs
@@ -1284,29 +1284,46 @@ fn emit_sequence_test_for(
                     map_type(t, spec).map(|rust_type| format!("0{rt}..={rt}::MAX", rt = rust_type))
                 })
                 .collect::<Result<Vec<_>>>()?;
-            out.push_str(&format!("        ({}).prop_map(|", strategies.join(", ")));
+            let names: Vec<&str> = op.takes_params.iter().map(|(n, _)| n.as_str()).collect();
+            // proptest's `Strategy` trait is implemented for tuples up to
+            // arity 12 only. Handlers with >12 args (Anchor handlers
+            // commonly hit this — RfpCreate-style init handlers in
+            // brownfield specs are typical) overflow that bound and emit
+            // E0599 "method `prop_map` exists but trait bounds not
+            // satisfied". Chunk strategies into sub-tuples of ≤12 and
+            // destructure with a nested pattern so any arity stays
+            // well-formed.
+            const MAX_PROPTEST_TUPLE_ARITY: usize = 12;
             if op.takes_params.len() == 1 {
-                out.push_str("v| ");
-                out.push_str(&format!("Op::{}(v)", pascal));
+                out.push_str(&format!(
+                    "        ({}).prop_map(|v| Op::{}(v)),\n",
+                    strategies[0], pascal
+                ));
+            } else if op.takes_params.len() <= MAX_PROPTEST_TUPLE_ARITY {
+                out.push_str(&format!(
+                    "        ({}).prop_map(|({})| Op::{}({})),\n",
+                    strategies.join(", "),
+                    names.join(", "),
+                    pascal,
+                    names.join(", ")
+                ));
             } else {
-                out.push('(');
-                for (i, (pname, _)) in op.takes_params.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(", ");
-                    }
-                    out.push_str(pname);
-                }
-                out.push_str(")| ");
-                out.push_str(&format!("Op::{}(", pascal));
-                for (i, (pname, _)) in op.takes_params.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(", ");
-                    }
-                    out.push_str(pname);
-                }
-                out.push(')');
+                let strat_chunks: Vec<String> = strategies
+                    .chunks(MAX_PROPTEST_TUPLE_ARITY)
+                    .map(|c| format!("({})", c.join(", ")))
+                    .collect();
+                let pat_chunks: Vec<String> = names
+                    .chunks(MAX_PROPTEST_TUPLE_ARITY)
+                    .map(|c| format!("({})", c.join(", ")))
+                    .collect();
+                out.push_str(&format!(
+                    "        ({}).prop_map(|({})| Op::{}({})),\n",
+                    strat_chunks.join(", "),
+                    pat_chunks.join(", "),
+                    pascal,
+                    names.join(", ")
+                ));
             }
-            out.push_str("),\n");
         }
     }
     out.push_str("    ]\n");

--- a/crates/qedgen/src/proptest_gen.rs
+++ b/crates/qedgen/src/proptest_gen.rs
@@ -148,6 +148,81 @@ fn strategy_for_field(
     })
 }
 
+/// Render a type-aware default value for a state field used to seed the
+/// initial `State { ... }` literal in init-handler preservation tests and
+/// in `state_machine_sequence`.
+///
+/// Pre-fix every field was initialized to `0`, which broke array fields:
+///
+///     error[E0308]: mismatched types
+///       | rfp_milestone_amounts: 0,
+///       |                        ^ expected `[u64; 8]`, found integer
+///
+/// `Map[N] T` lowers to `[T; N]` in the State struct — so its default has
+/// to be `[<inner-default>; N]`, not `0`. For non-primitive `T` (records
+/// like `Account`, or unit-variant sums) we need `Default::default()`
+/// since the record may not be numeric. Records are detected against
+/// `spec.records`; when matched, we emit `<RecordName>::default()`
+/// (relies on `#[derive(Default)]` on the record struct) and `[ ... ; N]`
+/// for arrays-of-records.
+///
+/// Returns `None` when no sensible default can be derived (e.g. a sum
+/// type with payload variants); the caller should skip the seed-init for
+/// that field and rely on `cargo` to surface the missing field, which
+/// gives a clearer diagnostic than emitting wrong-type code.
+fn default_value_for_field(dsl_type: &str, spec: &ParsedSpec) -> Option<String> {
+    let dsl_type = dsl_type.trim();
+    // Map[BOUND] T → [<default of T>; N]
+    if let Some(rest) = dsl_type.strip_prefix("Map") {
+        let rest = rest.trim_start();
+        if let Some(rest) = rest.strip_prefix('[') {
+            if let Some(close) = rest.find(']') {
+                let bound_src = rest[..close].trim();
+                let inner_src = rest[close + 1..].trim();
+                if let Ok(n) = resolve_map_bound_local(bound_src, &spec.constants) {
+                    let inner_default = default_value_for_field(inner_src, spec)?;
+                    return Some(format!("[{}; {}]", inner_default, n));
+                }
+            }
+        }
+        return None;
+    }
+    // Type alias → recurse on rhs
+    if let Some((_, rhs)) = spec.type_aliases.iter().find(|(n, _)| n == dsl_type) {
+        return default_value_for_field(rhs, spec);
+    }
+    // Record type → <Name>::default() (the matching `emit_record_structs`
+    // call below derives `Default` on every emitted record struct, so
+    // this resolves at the seed-state literal).
+    if spec.records.iter().any(|r| r.name == dsl_type) {
+        return Some(format!("{}::default()", dsl_type));
+    }
+    // Sum types with payload variants don't have a meaningful zero default
+    // — return None so the caller skips the field and rustc surfaces an
+    // E0063 missing-field at the seed-state literal, pointing at the
+    // exact line that needs attention. Unit-variant sums fall through to
+    // the primitive path below since `emit_unit_enum_sums` derives
+    // Default only when explicitly requested (which it isn't today).
+    if spec
+        .sum_types
+        .iter()
+        .any(|s| s.name == dsl_type && s.variants.iter().any(|v| !v.fields.is_empty()))
+    {
+        return None;
+    }
+    // Fin[N] → 0usize (modeled as usize index)
+    if dsl_type.starts_with("Fin[") {
+        return Some("0".to_string());
+    }
+    // Pubkey → [0u8; 32] when not filtered (rare — usually filtered upstream
+    // by mutable_fields, but a Map[N] Pubkey makes its way through).
+    if dsl_type == "Pubkey" {
+        return Some("[0u8; 32]".to_string());
+    }
+    // Primitive numeric types → 0
+    Some("0".to_string())
+}
+
 /// Local copy of codegen::resolve_map_bound (private there) — same rule: bound
 /// is either a numeric literal or a declared spec constant.
 fn resolve_map_bound_local(bound: &str, constants: &[(String, String)]) -> Result<String> {
@@ -420,7 +495,17 @@ fn emit_account_section(
     // v2.7 G1 finishes what v2.6.2 S3 started: the struct decls were emitted
     // but the strategy lookup bailed into `0u64..=u64::MAX` for record-typed
     // fields. emit_record_prop_composes + strategy_for_field below fix that.
-    rust_codegen_util::emit_record_structs(out, spec, "Debug, Clone, Copy", |t| map_type(t, spec))?;
+    // `Default` is required by the seed-state init path (commit 3:
+    // `default_value_for_field` emits `<RecordName>::default()` for
+    // record-typed array elements like `[Account; 1024]`). All record
+    // fields in current bundled specs are primitives or fixed-size arrays
+    // of primitives, both of which derive Default automatically; specs
+    // with non-Default field types would surface as a compile error at
+    // the record struct itself, with a clearer pointer than the cascading
+    // E0599 we'd get from `<Name>::default()`.
+    rust_codegen_util::emit_record_structs(out, spec, "Debug, Clone, Copy, Default", |t| {
+        map_type(t, spec)
+    })?;
     rust_codegen_util::emit_unit_enum_sums(out, spec, "Debug, Clone, Copy, PartialEq, Eq")?;
     rust_codegen_util::emit_lifecycle_status_enum(out, spec, "Debug, Clone, Copy, PartialEq, Eq");
     emit_record_prop_composes(out, spec)?;
@@ -787,8 +872,22 @@ fn emit_preservation_tests_for(
 
             if is_init {
                 out.push_str("        let mut s = State {\n");
-                for (fname, _) in mutable_fields {
-                    out.push_str(&format!("            {}: 0,\n", fname));
+                for (fname, ftype) in mutable_fields {
+                    if let Some(default) = default_value_for_field(ftype, spec) {
+                        out.push_str(&format!("            {}: {},\n", fname, default));
+                    }
+                    // No sensible default: skip — emitting a wrong-type
+                    // value would mask the issue. The struct-init E0063
+                    // diagnostic will point the user at the missing
+                    // field.
+                }
+                // The `status` discriminator is added by emit_state_struct
+                // when has_lifecycle (≥2 states); seed it to the spec's
+                // declared initial state, not a hardcoded "Uninitialized".
+                if rust_codegen_util::has_lifecycle(spec) {
+                    if let Some(initial) = rust_codegen_util::initial_lifecycle_state(spec) {
+                        out.push_str(&format!("            status: Status::{},\n", initial));
+                    }
                 }
                 out.push_str("        };\n");
             } else {
@@ -928,8 +1027,15 @@ fn emit_invariant_preservation_tests_for(
 
             if is_init {
                 out.push_str("        let mut s = State {\n");
-                for (fname, _) in mutable_fields {
-                    out.push_str(&format!("            {}: 0,\n", fname));
+                for (fname, ftype) in mutable_fields {
+                    if let Some(default) = default_value_for_field(ftype, spec) {
+                        out.push_str(&format!("            {}: {},\n", fname, default));
+                    }
+                }
+                if rust_codegen_util::has_lifecycle(spec) {
+                    if let Some(initial) = rust_codegen_util::initial_lifecycle_state(spec) {
+                        out.push_str(&format!("            status: Status::{},\n", initial));
+                    }
                 }
                 out.push_str("        };\n");
             } else {
@@ -1269,10 +1375,20 @@ fn emit_sequence_test_for(
         seq_len
     ));
 
-    // Start from a valid initial state (zeroed — represents Uninitialized)
+    // Start from a valid initial state. Type-aware defaults: arrays get
+    // [<inner>; N], records get <Name>::default(), primitives get 0. The
+    // status discriminator (if has_lifecycle) seeds to the spec's first
+    // declared lifecycle state.
     out.push_str("        let mut s = State {\n");
-    for (fname, _) in mutable_fields {
-        out.push_str(&format!("            {}: 0,\n", fname));
+    for (fname, ftype) in mutable_fields {
+        if let Some(default) = default_value_for_field(ftype, spec) {
+            out.push_str(&format!("            {}: {},\n", fname, default));
+        }
+    }
+    if rust_codegen_util::has_lifecycle(spec) {
+        if let Some(initial) = rust_codegen_util::initial_lifecycle_state(spec) {
+            out.push_str(&format!("            status: Status::{},\n", initial));
+        }
     }
     out.push_str("        };\n");
 

--- a/crates/qedgen/src/rust_codegen_util.rs
+++ b/crates/qedgen/src/rust_codegen_util.rs
@@ -310,15 +310,58 @@ fn is_ident_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
-/// Resolve an effect value to a Rust expression (param name, constant, or literal).
-pub fn resolve_value(value: &str, op: &ParsedHandler, spec: &ParsedSpec) -> String {
+/// Resolve an effect value to a Rust expression: handler param name,
+/// declared constant, state field (rebound to `<state_binder>X` when
+/// provided), or pass-through literal.
+///
+/// Why state fields need a binder: by the time effect-value rendering
+/// reaches this fn, upstream effect-RHS rendering has already stripped
+/// the `state.` prefix (see chumsky_adapter::render_effect — it unwraps
+/// `Expr::FieldAccess { base: state, .. }` to the bare field name so each
+/// backend can apply its own state binder). Different targets bind state
+/// differently:
+///
+///   - proptest fn body binds state as `s` (`fn op(s: &mut State, ...)`)
+///   - Anchor handler body accesses state via `self.<acct>.<field>`
+///   - Lean / Kani may bind differently again
+///
+/// Without a target-aware binder, a bare `X` for a state field becomes
+/// E0425 "cannot find value `X` in this scope" at compile time. Each
+/// caller passes the binder appropriate to its emission target; pass
+/// `None` to keep the legacy pass-through behavior (bare identifier).
+pub fn resolve_value(
+    value: &str,
+    op: &ParsedHandler,
+    spec: &ParsedSpec,
+    state_binder: Option<&str>,
+) -> String {
     if op.takes_params.iter().any(|(n, _)| n == value) {
         value.to_string()
     } else if let Some((_, const_val)) = spec.constants.iter().find(|(n, _)| n == value) {
         const_val.clone()
+    } else if let Some(binder) = state_binder {
+        if is_state_field(value, spec) {
+            format!("{}{}", binder, value)
+        } else {
+            value.to_string()
+        }
     } else {
         value.to_string()
     }
+}
+
+/// True when the bare identifier names a state field in the flat
+/// `state_fields` list or any `account_types[*].fields` (multi-account).
+fn is_state_field(name: &str, spec: &ParsedSpec) -> bool {
+    if spec.state_fields.iter().any(|(n, _)| n == name) {
+        return true;
+    }
+    for acct in &spec.account_types {
+        if acct.fields.iter().any(|(n, _)| n == name) {
+            return true;
+        }
+    }
+    false
 }
 
 // ============================================================================
@@ -385,7 +428,11 @@ pub fn emit_one_effect(
     value: &str,
     indent: &str,
 ) {
-    let rust_value = resolve_value(value, op, spec);
+    // proptest / kani body binds state as `s` — pass that binder so a
+    // bare state-field RHS (e.g. `bid_buyer := state.rfp_buyer` after
+    // upstream strips `state.`) renders as `s.rfp_buyer`. (PR #45 fix #2,
+    // generalized to all callers via emit_one_effect rather than per-arm.)
+    let rust_value = resolve_value(value, op, spec, Some("s."));
     match op_kind {
         "set" => {
             out.push_str(&format!("{indent}s.{field} = {rust_value};\n"));
@@ -938,6 +985,10 @@ pub fn emit_transition_fn(
         }
         out.push_str("    }\n");
     } else {
+        // PR #45 fix #2: `emit_one_effect` resolves state-field idents
+        // via `resolve_value(..., Some("s."))` so a bare state-field RHS
+        // (e.g. `bid_buyer := state.rfp_buyer` after upstream strips
+        // `state.`) renders as `s.rfp_buyer` in the proptest body.
         for (field, op_kind, value) in &op.effects {
             if field_type_is_pubkey(field, op, spec) {
                 continue;

--- a/examples/rust/escrow-split/formal_verification/Spec.lean
+++ b/examples/rust/escrow-split/formal_verification/Spec.lean
@@ -49,8 +49,13 @@ theorem exchange_Token_transfer_call_1_post_0 (s : State) : s.initializer_amount
 /-- Token.transfer.ensures @ `initialize` call #0 (stance 1: axiomatized via sorry; v3.0 will close via imported callee proofs). -/
 theorem initialize_Token_transfer_call_0_post_0 (s : State) (deposit_amount : Nat) (receive_amount : Nat) : deposit_amount > 0 := by sorry
 
-/-- Invariant: conservation. -/
-theorem conservation : True := trivial
+-- INVARIANT OBLIGATION (declared, no predicate body): conservation
+--   description: total tokens preserved across initialize, exchange, cancel
+-- The spec declared this name but didn't supply a predicate body
+-- (`invariant <name> : <expr>`). The codegen has no goal to lower —
+-- pre-v2.14 emitted `theorem <name> : True := trivial`, which
+-- was tautological. To verify this invariant, give it a body in
+-- the spec.
 
 inductive Operation where
   | cancel

--- a/examples/rust/lending/tests/proptest.rs
+++ b/examples/rust/lending/tests/proptest.rs
@@ -104,6 +104,7 @@ proptest! {
             total_deposits: 0,
             total_borrows: 0,
             interest_rate: 0,
+            status: Status::Uninitialized,
         };
         if init_pool(&mut s, rate) {
             prop_assert!(pool_solvency(&s),
@@ -209,6 +210,7 @@ proptest! {
             total_deposits: 0,
             total_borrows: 0,
             interest_rate: 0,
+            status: Status::Uninitialized,
         };
         let mut lifecycle = Lifecycle::Uninitialized;
         let mut initialized = false;

--- a/examples/rust/multisig/programs/tests/proptest.rs
+++ b/examples/rust/multisig/programs/tests/proptest.rs
@@ -197,10 +197,11 @@ proptest! {
         let mut s = State {
             threshold: 0,
             member_count: 0,
-            members: 0,
-            voted: 0,
+            members: [[0u8; 32]; 32],
+            voted: [0; 32],
             approval_count: 0,
             rejection_count: 0,
+            status: Status::Uninitialized,
         };
         if create_vault(&mut s, threshold, member_count) {
             prop_assert!(threshold_bounded(&s),
@@ -315,10 +316,11 @@ proptest! {
         let mut s = State {
             threshold: 0,
             member_count: 0,
-            members: 0,
-            voted: 0,
+            members: [[0u8; 32]; 32],
+            voted: [0; 32],
             approval_count: 0,
             rejection_count: 0,
+            status: Status::Uninitialized,
         };
         if create_vault(&mut s, threshold, member_count) {
             prop_assert!(votes_bounded(&s),
@@ -563,10 +565,11 @@ proptest! {
         let mut s = State {
             threshold: 0,
             member_count: 0,
-            members: 0,
-            voted: 0,
+            members: [[0u8; 32]; 32],
+            voted: [0; 32],
             approval_count: 0,
             rejection_count: 0,
+            status: Status::Uninitialized,
         };
         let mut lifecycle = Lifecycle::Uninitialized;
         let mut initialized = false;

--- a/examples/rust/multisig/tests/proptest.rs
+++ b/examples/rust/multisig/tests/proptest.rs
@@ -197,10 +197,11 @@ proptest! {
         let mut s = State {
             threshold: 0,
             member_count: 0,
-            members: 0,
-            voted: 0,
+            members: [[0u8; 32]; 32],
+            voted: [0; 32],
             approval_count: 0,
             rejection_count: 0,
+            status: Status::Uninitialized,
         };
         if create_vault(&mut s, threshold, member_count) {
             prop_assert!(threshold_bounded(&s),
@@ -315,10 +316,11 @@ proptest! {
         let mut s = State {
             threshold: 0,
             member_count: 0,
-            members: 0,
-            voted: 0,
+            members: [[0u8; 32]; 32],
+            voted: [0; 32],
             approval_count: 0,
             rejection_count: 0,
+            status: Status::Uninitialized,
         };
         if create_vault(&mut s, threshold, member_count) {
             prop_assert!(votes_bounded(&s),
@@ -563,10 +565,11 @@ proptest! {
         let mut s = State {
             threshold: 0,
             member_count: 0,
-            members: 0,
-            voted: 0,
+            members: [[0u8; 32]; 32],
+            voted: [0; 32],
             approval_count: 0,
             rejection_count: 0,
+            status: Status::Uninitialized,
         };
         let mut lifecycle = Lifecycle::Uninitialized;
         let mut initialized = false;

--- a/examples/rust/percolator/programs/src/guards.rs
+++ b/examples/rust/percolator/programs/src/guards.rs
@@ -19,7 +19,7 @@ pub fn add_user<'info>(ctx: &mut AddUser<'info>, i: usize) -> Result<(), Program
     // requires: s.accounts[i].active = 0
     if !(ctx.vault.accounts[(i) as usize].active == 0) { return Err(ProgramError::from(PercolatorError::SlotAlreadyActive)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int))
-    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)) { return Err(ProgramError::from(PercolatorError::AccountUnderwater)); }
+    if !(((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) >= ((0) as i128)) { return Err(ProgramError::from(PercolatorError::AccountUnderwater)); }
     Ok(())
 }
 
@@ -31,7 +31,7 @@ pub fn add_lp<'info>(ctx: &mut AddLp<'info>, i: usize) -> Result<(), ProgramErro
     // requires: s.accounts[i].active = 0
     if !(ctx.vault.accounts[(i) as usize].active == 0) { return Err(ProgramError::from(PercolatorError::SlotAlreadyActive)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int))
-    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)) { return Err(ProgramError::from(PercolatorError::AccountUnderwater)); }
+    if !(((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) >= ((0) as i128)) { return Err(ProgramError::from(PercolatorError::AccountUnderwater)); }
     Ok(())
 }
 
@@ -85,7 +85,7 @@ pub fn withdraw<'info>(ctx: &mut Withdraw<'info>, i: usize, amount: u128) -> Res
     // requires: s.accounts[i].capital ≥ amount
     if !(ctx.vault.accounts[(i) as usize].capital.get() >= amount) { return Err(ProgramError::from(PercolatorError::InsufficientFunds)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((amount) : Int))
-    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((amount) as i128)) { return Err(ProgramError::from(PercolatorError::InsufficientFunds)); }
+    if !(((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) >= ((amount) as i128)) { return Err(ProgramError::from(PercolatorError::InsufficientFunds)); }
     Ok(())
 }
 
@@ -149,7 +149,7 @@ pub fn liquidate_case_0<'info>(ctx: &mut LiquidateCase0<'info>, i: usize) -> Res
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int))
-    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128)) { return Err(ProgramError::Custom(0xFF)); }
+    if !(((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) >= ((0) as i128)) { return Err(ProgramError::Custom(0xFF)); }
     // requires: 0 = 1
     if !(false) { return Err(ProgramError::from(PercolatorError::AccountHealthy)); }
     Ok(())
@@ -163,9 +163,9 @@ pub fn liquidate_case_1<'info>(ctx: &mut LiquidateCase1<'info>, i: usize) -> Res
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int)))
-    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
+    if !(!(((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
     // requires: (((s.accounts[i].capital) : Int)) + s.accounts[i].pnl + (((s.I) : Int)) ≥ (((0) : Int))
-    if !(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128)) { return Err(ProgramError::Custom(0xFF)); }
+    if !(((((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) + ((ctx.vault.I.get()) as i128)) as i128) >= ((0) as i128)) { return Err(ProgramError::Custom(0xFF)); }
     Ok(())
 }
 
@@ -177,9 +177,9 @@ pub fn liquidate_otherwise<'info>(ctx: &mut LiquidateOtherwise<'info>, i: usize)
     // requires: s.accounts[i].active = 1
     if !(ctx.vault.accounts[(i) as usize].active == 1) { return Err(ProgramError::from(PercolatorError::SlotInactive)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl ≥ (((0) : Int)))
-    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
+    if !(!(((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
     // requires: ¬((((s.accounts[i].capital) : Int)) + s.accounts[i].pnl + (((s.I) : Int)) ≥ (((0) : Int)))
-    if !(!(((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ctx.vault.accounts[(i) as usize].pnl.get() + ((ctx.vault.I.get()) as i128) >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
+    if !(!(((((((ctx.vault.accounts[(i) as usize].capital.get()) as i128) + ((ctx.vault.accounts[(i) as usize].pnl.get()) as i128)) as i128) + ((ctx.vault.I.get()) as i128)) as i128) >= ((0) as i128))) { return Err(ProgramError::Custom(0xFF)); }
     // requires: 0 = 1
     if !(false) { return Err(ProgramError::from(PercolatorError::BankruptPosition)); }
     Ok(())

--- a/examples/rust/percolator/tests/kani.rs
+++ b/examples/rust/percolator/tests/kani.rs
@@ -82,7 +82,7 @@ fn account_solvent_at(s: &State, i: usize) -> bool {
 // ============================================================================
 
 fn add_user(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -94,7 +94,7 @@ fn add_user(s: &mut State, i: usize) -> bool {
 }
 
 fn add_lp(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -154,7 +154,7 @@ fn deposit(s: &mut State, i: usize, amount: u128) -> bool {
 }
 
 fn withdraw(s: &mut State, i: usize, amount: u128) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((amount) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((amount) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -245,7 +245,7 @@ fn execute_trade(s: &mut State, a: usize, b: usize, size_q: i128, exec_price: u6
 }
 
 fn liquidate_case_0(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128)) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128)) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -256,7 +256,7 @@ fn liquidate_case_0(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_case_1(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl + ((s.I) as i128) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -268,7 +268,7 @@ fn liquidate_case_1(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_otherwise(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl + ((s.I) as i128) >= ((0) as i128))) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -330,7 +330,7 @@ fn verify_add_user_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     let i: usize = kani::any();
-    kani::assume(!((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))));
+    kani::assume(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))));
     assert!(!add_user(&mut s, i),
         "add_user must reject when guard is violated");
 }
@@ -348,7 +348,7 @@ fn verify_add_lp_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     let i: usize = kani::any();
-    kani::assume(!((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))));
+    kani::assume(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))));
     assert!(!add_lp(&mut s, i),
         "add_lp must reject when guard is violated");
 }
@@ -422,7 +422,7 @@ fn verify_withdraw_rejects_invalid() {
     kani::assume(s.status == Status::Active);
     let i: usize = kani::any();
     let amount: u128 = kani::any();
-    kani::assume(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((amount) as i128))));
+    kani::assume(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((amount) as i128))));
     assert!(!withdraw(&mut s, i, amount),
         "withdraw must reject when guard is violated");
 }
@@ -517,7 +517,7 @@ fn verify_liquidate_case_0_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     let i: usize = kani::any();
-    kani::assume(!((s.accounts[(i) as usize].active == 1) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128)) && (false)));
+    kani::assume(!((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128)) && (false)));
     assert!(!liquidate_case_0(&mut s, i),
         "liquidate_case_0 must reject when guard is violated");
 }
@@ -535,7 +535,7 @@ fn verify_liquidate_case_1_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     let i: usize = kani::any();
-    kani::assume(!((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl + ((s.I) as i128) >= ((0) as i128))));
+    kani::assume(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))));
     assert!(!liquidate_case_1(&mut s, i),
         "liquidate_case_1 must reject when guard is violated");
 }
@@ -553,7 +553,7 @@ fn verify_liquidate_otherwise_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     let i: usize = kani::any();
-    kani::assume(!((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl + ((s.I) as i128) >= ((0) as i128))) && (false)));
+    kani::assume(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) && (false)));
     assert!(!liquidate_otherwise(&mut s, i),
         "liquidate_otherwise must reject when guard is violated");
 }

--- a/examples/rust/percolator/tests/kani.rs
+++ b/examples/rust/percolator/tests/kani.rs
@@ -71,7 +71,7 @@ fn account_solvent(_s: &State) -> bool {
 /// account_solvent: per-slot check at `i: AccountIdx` (v2.20 forall lowering)
 #[allow(unused_variables)]
 fn account_solvent_at(s: &State, i: usize) -> bool {
-    (!(s.accounts[(i) as usize].active == 1)) || (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))
+    (!(s.accounts[(i) as usize].active == 1)) || (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))
 }
 
 // ============================================================================

--- a/examples/rust/percolator/tests/proptest.rs
+++ b/examples/rust/percolator/tests/proptest.rs
@@ -13,12 +13,27 @@
 
 use proptest::prelude::*;
 
+#[allow(dead_code)]
+#[inline]
+fn mul_div_floor_u128(a: u128, b: u128, d: u128) -> u128 {
+if d == 0 { return 0; }
+a.saturating_mul(b) / d
+}
+
+#[allow(dead_code)]
+#[inline]
+fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {
+if d == 0 { return 0; }
+let prod = a.saturating_mul(b);
+if prod % d == 0 { prod / d } else { (prod / d).saturating_add(1) }
+}
+
 const MAX_ACCOUNTS: u16 = 1024;
 const MAX_VAULT_TVL: u64 = 10000000000000000;
 const POS_SCALE: u32 = 1000000;
 const MAX_ACCOUNT_NOTIONAL: u128 = 100000000000000000000;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 struct Account {
     active: u8,
     capital: u128,
@@ -111,11 +126,11 @@ fn account_solvent(_s: &State) -> bool {
 
 /// account_solvent: per-slot check at `i: AccountIdx`
 fn account_solvent_at(s: &State, i: usize) -> bool {
-    (!(s.accounts[(i) as usize].active == 1)) || (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl >= ((0) as i128))
+    (!(s.accounts[(i) as usize].active == 1)) || (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))
 }
 
 fn add_user(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -127,7 +142,7 @@ fn add_user(s: &mut State, i: usize) -> bool {
 }
 
 fn add_lp(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -178,7 +193,7 @@ fn deposit(s: &mut State, i: usize, amount: u128) -> bool {
 }
 
 fn withdraw(s: &mut State, i: usize, amount: u128) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((amount) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((amount) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -242,7 +257,7 @@ fn execute_trade(s: &mut State, a: usize, b: usize, size_q: i128, exec_price: u6
 }
 
 fn liquidate_case_0(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128)) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128)) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -253,7 +268,7 @@ fn liquidate_case_0(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_case_1(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl.wrapping_add(((s.I) as i128)) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -265,7 +280,7 @@ fn liquidate_case_1(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_otherwise(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl.wrapping_add(((s.I) as i128)) >= ((0) as i128))) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -870,7 +885,7 @@ proptest! {
     #[test]
     fn add_user_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))));
         prop_assert!(!add_user(&mut s, i),
             "add_user must reject when guard is violated");
     }
@@ -881,7 +896,7 @@ proptest! {
     #[test]
     fn add_lp_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))));
         prop_assert!(!add_lp(&mut s, i),
             "add_lp must reject when guard is violated");
     }
@@ -925,7 +940,7 @@ proptest! {
     #[test]
     fn withdraw_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], amount in prop_oneof![0u128..=3u128, (u128::MAX - 3)..=u128::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((amount) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((amount) as i128))));
         prop_assert!(!withdraw(&mut s, i, amount),
             "withdraw must reject when guard is violated");
     }
@@ -980,7 +995,7 @@ proptest! {
     #[test]
     fn liquidate_case_0_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128)) && (false)));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128)) && (false)));
         prop_assert!(!liquidate_case_0(&mut s, i),
             "liquidate_case_0 must reject when guard is violated");
     }
@@ -991,7 +1006,7 @@ proptest! {
     #[test]
     fn liquidate_case_1_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))) && (((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl.wrapping_add(((s.I) as i128)) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))));
         prop_assert!(!liquidate_case_1(&mut s, i),
             "liquidate_case_1 must reject when guard is violated");
     }
@@ -1002,7 +1017,7 @@ proptest! {
     #[test]
     fn liquidate_otherwise_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((s.accounts[(i) as usize].capital) as i128).wrapping_add(s.accounts[(i) as usize].pnl) >= ((0) as i128))) && (!(((s.accounts[(i) as usize].capital) as i128) + s.accounts[(i) as usize].pnl.wrapping_add(((s.I) as i128)) >= ((0) as i128))) && (false)));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) && (false)));
         prop_assert!(!liquidate_otherwise(&mut s, i),
             "liquidate_otherwise must reject when guard is violated");
     }
@@ -1247,7 +1262,8 @@ proptest! {
             V: 0,
             I: 0,
             F: 0,
-            accounts: 0,
+            accounts: [Account::default(); 1024],
+            status: Status::Active,
         };
         let mut lifecycle = Lifecycle::Active;
         let mut initialized = false;


### PR DESCRIPTION
> Tried qedgen on your nudge from [this thread](https://x.com/shek_dev/status/2054419082439704773) — wanted to try it on our [tendr.bid](https://github.com/0xharp/tender) Anchor program, which has a decent number of instructions. These are the codegen edges I hit while integrating, with fixes.

## TL;DR

Six small, isolated codegen fixes in `proptest_gen`, `chumsky_adapter`, and `rust_codegen_util`, plus one regen commit catching up the affected bundled examples. Each fix has a reproducer, ships behind a usage gate where applicable, and is verified against the full `ci.yml` gate sequence.

## What

Surfaced while integrating qedgen with [tendr.bid](https://github.com/0xharp/tender) — a brownfield Anchor program with a flat-state `.qedspec`. Each commit is independent (the regen commit at the end depends on the prior six), with a focused message explaining the bug + the fix + the surface where it shows up.

| # | Commit | What it fixes |
| - | --- | --- |
| 1 | `fix(chumsky_adapter): widen both sides when coercing Nat to Int` | Code path: spec compares an `I*` field against a Nat literal (`>= 0`). `render_rust_binary_with_coercion` cast only the Nat side to `i128`, leaving an `i64 >= i128` mismatch (E0308). Now widens both sides symmetrically. |
| 2 | `fix(rust_codegen_util): bind state-field idents via target-aware binder in resolve_value` | Effect-RHS rendering strips the `state.` prefix upstream (so each backend can apply its own state binder) but `resolve_value` then returned the bare ident, which doesn't bind in the target's body scope. Adds a `state_binder: Option<&str>` parameter so each caller passes its own (`Some("s.")` for proptest, `Some(&format!("self.{}.", acct))` for Anchor/Quasar handlers). `None` preserves legacy bare-identifier behavior. |
| 3 | `fix(proptest_gen): type-aware seed-state init for arrays + lifecycle status` | Three issues at the same code path: `Map[N] T` arrays got `field: 0` (E0308); record-typed array elements got `field: [0; N]` against `[Account; N]` (E0308); the `status:` lifecycle discriminator was hardcoded to `Status::Uninitialized`, missing for specs whose first state isn't named that (e.g. percolator: `Active`, E0599). Now uses a recursive `default_value_for_field` helper that emits `[<inner>; N]`, `<RecordName>::default()`, `0`, or `None` (skip + let rustc surface the missing field), and reads `initial_lifecycle_state(spec)` for the discriminator. |
| 4 | `fix(proptest_gen): inline mul_div helpers when standalone proptest needs them` | Brownfield workflow runs `--proptest` without `--all`, so `src/math.rs` isn't generated and `mul_div_floor_u128` calls don't resolve. Inlines the helpers — gated on `codegen::guards_use_math_helpers` (now `pub(crate)`) so specs that don't use them don't carry duplicate definitions. The same helper was extended to also probe `let_bindings.rust_expr` (specs that use mul_div in handler-level let bindings, like fee math, were previously missed). |
| 5 | `fix(proptest_gen): chunk arb_op tuples for handlers with >12 args` | proptest's `Strategy` impls cap at tuple arity 12; >12-arg handlers overflow with E0599. Chunks strategies into ≤12-arity sub-tuples with a nested destructuring pattern; ≤12-arg handlers keep their existing flat shape. |
| 6 | `fix(proptest_gen): emit recursion_limit override only when needed` | rustc's default `recursion_limit = 128` overflows on `arb_state()` for ≳40-field States. Emits `#![recursion_limit = "512"]` only when the spec's total mutable field count exceeds 32 — bundled examples (escrow ≈ 3, lending ≈ 6, multisig ≈ 5, percolator ≈ 4) keep the default. 512 = 2× rustc's suggested 256, empirically validated against a 99-field flat State. |
| 7 | `chore(examples): regen bundled codegen for proptest_gen + adapter fixes` | Catches up the six affected bundled-example artifacts so `qedgen check --regen-drift` stays clean. Per-file rationale in commit body. |

After these, our `.qedspec` produces a proptest harness that compiles and runs cleanly, and the same patches make the kani auto-gen compile too (both backends share the underlying renderers, so the fixes propagate).

## Context

We were integrating qedgen (v2.18) with [tendr.bid](https://github.com/0xharp/tender) — a sealed-bid procurement program on Solana with ~28 handlers, a fairly large flat State after canonical-pattern flattening, and `mul_div_floor` for fee math. The combination of all three (large flat State + signed time arithmetic + brownfield `--proptest` without `--all`) is what surfaced these specific edges.

Worth flagging in case useful: the multisig proptest output has separate issues (`Map[N] Pubkey` → `[Address; N]` placeholder, auth-alias unbinding) that felt more like design questions than clear bugs, so I've kept them out of scope here — happy to file a discussion issue if you'd like. The CI smoke gate runs `cargo test` against escrow's proptest harness only (the other examples are scaffold-compile only), so these particular paths just hadn't been exercised before.

## Verification

Validated end-to-end on a fork-CI run that exercises the full `ci.yml` gate sequence — link will be added once force-push triggers it. Specifically:

- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test` — full workspace: 568 passed, 0 failed, 8 ignored (the 4 codegen_smoke and 4 doctests are intentionally `#[ignore]` and run separately in the next gate step)
- `bash scripts/check-version-consistency.sh` — clean
- `bash scripts/check-readme-drift.sh` — clean
- `cargo run -p qedgen-solana-skills -- check --regen-drift` — clean
- `cargo test --test codegen_smoke -- --ignored` — 4 passed, 0 failed

No new unit tests added in this PR — relied on the existing workspace test suite (568 tests across all crates, ≈543 in `qedgen` itself) as integration check, plus the regen commit (#7) acts as a downstream-codegen integration gate. Happy to add focused tests for any of the new code paths if useful.

Local repro note: with `core.autocrlf = true` (common on WSL/Windows), the bundled snapshot fixtures and regenerated outputs disagree on line endings, which makes a few snapshot tests + the percolator smoke fail locally even though they're green on Ubuntu CI. Setting `core.autocrlf = false` for the workspace makes the local run match CI.

## Things deliberately NOT included

- **Pubkey codegen.** Touched on this area too (the `Map[N] Pubkey → [Address; N]` pattern needs an `Address` definition; `auth <name>` aliases would need binding in handler-fn bodies; `mutable_fields` filters bare `Pubkey` so properties referring to Pubkey state fields can't currently find the field). These felt like design calls more than bugs, so I'd rather raise them as a discussion issue than touch them here.
- **A patch for narrowing `mul_div_floor_u128` results to `u64`.** We carry it locally because our spec uses u64 amounts throughout, but it'd be the wrong fix for percolator-style specs that genuinely want u128 amounts — needs a real type-inference pass at the let-binding site, out of scope for this batch.
- **Broader bundled-example regen** beyond the six artifacts directly affected by these codegen changes is intentionally out of scope here, to keep the diff focused. Happy to send a follow-up regen sweep separately if useful.

Would love your read on whether the framing of these fixes makes sense — happy to split, squash, or rework any of them. If any of this doesn't match the design intent, please feel free to push back or close the PR; happy to learn what we got wrong. Thanks for building qedgen, the spec-driven flow has been a pleasure to work with end-to-end.
