### PR TITLE
fix(kani): standalone-harness compile-shape fixes (binder + mul_div inline + array seed init)

### DIFF
--- a/crates/qedgen/src/kani.rs
+++ b/crates/qedgen/src/kani.rs
@@ -921,24 +921,43 @@ fn emit_kani_account_section(
                     .collect();
                 out.push_str(&format!("    if {}(&mut s{}) {{\n", op.name, args));
 
-                // Assert THIS field's effect only
+                // Assert THIS field's effect only.
+                //
+                // The effect-conformance harness snapshots every mutable
+                // field as `pre_<fname> = s.<fname>` BEFORE calling the
+                // transition. The post-condition RHS — `value` here — comes
+                // from the spec's effect block (e.g. `:= state.now`), with
+                // the `state.` prefix already stripped by the upstream
+                // chumsky_adapter so each backend can apply its own binder.
+                //
+                // Without binder resolution the emitted assertion reads
+                // `assert!(s.X == now)` — bare `now` is undefined in scope
+                // and the harness fails to compile with
+                // `error[E0425]: cannot find value 'now' in this scope`.
+                //
+                // `resolve_value` is identity for handler params and inlines
+                // constants; the `Some("pre_")` binder is applied only when
+                // `value` is a state field name. Same shape as the
+                // analogous fix in `rust_codegen_util::emit_one_effect` for
+                // the transition-fn emission target (`Some("s.")`).
+                let resolved = rust_codegen_util::resolve_value(value, op, spec, Some("pre_"));
                 match op_kind.as_str() {
                     "set" => {
                         out.push_str(&format!(
                             "        assert!(s.{} == {}, \"{} must equal {}\");\n",
-                            field, value, field, value
+                            field, resolved, field, resolved
                         ));
                     }
                     "add" => {
                         out.push_str(&format!(
                             "        assert!(s.{} == pre_{}.wrapping_add({}), \"{} must increment by {}\");\n",
-                            field, field, value, field, value
+                            field, field, resolved, field, resolved
                         ));
                     }
                     "sub" => {
                         out.push_str(&format!(
                             "        assert!(s.{} == pre_{}.wrapping_sub({}), \"{} must decrement by {}\");\n",
-                            field, field, value, field, value
+                            field, field, resolved, field, resolved
                         ));
                     }
                     _ => {}

--- a/crates/qedgen/src/kani.rs
+++ b/crates/qedgen/src/kani.rs
@@ -41,14 +41,35 @@ fn emit_state_init_symbolic(
 /// `status` field set to the section's initial lifecycle state. Used by init-
 /// handler harnesses (effect/preservation), where the pre-state is the
 /// canonical "before initialization" state.
+///
+/// Defaults are type-aware via `proptest_gen::default_value_for_field`:
+/// `Map[N] T` → `[<inner>; N]`, named records → `<Name>::default()`, named
+/// sums with a zero-payload variant → that variant; primitives → `0`. A
+/// `None` return means "no sensible default" — skip the field and let
+/// rustc surface the missing field with E0063, which is a clearer
+/// diagnostic than emitting wrong-type code.
+///
+/// Same shape (and same helper) as the seed-state init fix landed in
+/// `fix(proptest_gen): type-aware seed-state init for arrays + lifecycle
+/// status` (#45). Without this, every array-typed state field literals
+/// to `{}: 0` and the harness fails to compile:
+///
+///     error[E0308]: mismatched types
+///        --> tests/kani.rs:N:M
+///         |
+///       N |         rfp_milestone_amounts: 0,
+///         |                                ^ expected `[u64; 8]`, found integer
 fn emit_state_init_zeroed(
     out: &mut String,
     mutable_fields: &[&(String, String)],
     lifecycle_states: &[String],
+    spec: &ParsedSpec,
 ) {
     out.push_str("    let mut s = State {\n");
-    for (fname, _) in mutable_fields {
-        out.push_str(&format!("        {}: 0,\n", fname));
+    for (fname, ftype) in mutable_fields {
+        if let Some(default) = crate::proptest_gen::default_value_for_field(ftype, spec) {
+            out.push_str(&format!("        {}: {},\n", fname, default));
+        }
     }
     if let Some(initial) = lifecycle_states.first() {
         if lifecycle_states.len() >= 2 {
@@ -618,7 +639,7 @@ fn emit_kani_account_section(
                 let needs_local_binder = prop.per_slot.is_some() && !handler_takes_binder;
 
                 if is_init {
-                    emit_state_init_zeroed(out, mutable_fields, lifecycle_states);
+                    emit_state_init_zeroed(out, mutable_fields, lifecycle_states, spec);
                 } else {
                     emit_state_init_symbolic(out, mutable_fields, lifecycle_states);
                     emit_pre_status_assume(out, op, lifecycle_states);
@@ -790,7 +811,7 @@ fn emit_kani_account_section(
                 ));
 
                 if is_init {
-                    emit_state_init_zeroed(out, mutable_fields, lifecycle_states);
+                    emit_state_init_zeroed(out, mutable_fields, lifecycle_states, spec);
                 } else {
                     emit_state_init_symbolic(out, mutable_fields, lifecycle_states);
                     emit_pre_status_assume(out, op, lifecycle_states);
@@ -894,7 +915,7 @@ fn emit_kani_account_section(
 
                 // Symbolic state
                 if is_init {
-                    emit_state_init_zeroed(out, mutable_fields, lifecycle_states);
+                    emit_state_init_zeroed(out, mutable_fields, lifecycle_states, spec);
                 } else {
                     emit_state_init_symbolic(out, mutable_fields, lifecycle_states);
                     emit_pre_status_assume(out, op, lifecycle_states);

--- a/crates/qedgen/src/kani.rs
+++ b/crates/qedgen/src/kani.rs
@@ -130,6 +130,42 @@ pub fn generate(spec_path: &Path, output_path: &Path) -> Result<()> {
     out.push_str("// ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----\n");
     out.push_str("#![cfg(kani)]\n\n");
 
+    // ── Math helpers (mirrors proptest_gen) ─────────────────────────────
+    // The standalone kani harness lives at `programs/<prog>/tests/kani.rs`
+    // (no `pub use crate::math::*`) — generated under `qedgen codegen
+    // --kani` against an existing program crate that hasn't been emitted
+    // via `--all`. In that case `src/math.rs` is never (re)generated, so
+    // any `mul_div_floor_u128` / `mul_div_ceil_u128` calls emitted by
+    // `chumsky_adapter::expr_to_rust` have no definition in scope:
+    //
+    //     error[E0425]: cannot find function `mul_div_floor_u128`
+    //                   in this scope
+    //
+    // Same mismatch + same fix shape as
+    // `fix(proptest_gen): inline mul_div helpers when standalone proptest
+    // needs them` (#45). Inline the canonical bodies here too, gated by
+    // the same `guards_use_math_helpers` predicate so we ship the helpers
+    // ONLY when the spec actually calls into them — otherwise we'd ship
+    // two sources of truth for the helpers (kani.rs + math.rs) with the
+    // silent-divergence risk that implies for any future change.
+    if crate::codegen::guards_use_math_helpers(&spec) {
+        out.push_str(
+            "#[allow(dead_code)]\n\
+#[inline]\n\
+fn mul_div_floor_u128(a: u128, b: u128, d: u128) -> u128 {\n\
+    if d == 0 { return 0; }\n\
+    a.saturating_mul(b) / d\n\
+}\n\n\
+#[allow(dead_code)]\n\
+#[inline]\n\
+fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {\n\
+    if d == 0 { return 0; }\n\
+    let prod = a.saturating_mul(b);\n\
+    if prod % d == 0 { prod / d } else { (prod / d).saturating_add(1) }\n\
+}\n\n",
+        );
+    }
+
     // ── State model header ───────────────────────────────────────────────
     out.push_str(
         "// ============================================================================\n",

--- a/crates/qedgen/src/proptest_gen.rs
+++ b/crates/qedgen/src/proptest_gen.rs
@@ -170,7 +170,7 @@ fn strategy_for_field(
 /// type with payload variants); the caller should skip the seed-init for
 /// that field and rely on `cargo` to surface the missing field, which
 /// gives a clearer diagnostic than emitting wrong-type code.
-fn default_value_for_field(dsl_type: &str, spec: &ParsedSpec) -> Option<String> {
+pub(crate) fn default_value_for_field(dsl_type: &str, spec: &ParsedSpec) -> Option<String> {
     let dsl_type = dsl_type.trim();
     // Map[BOUND] T → [<default of T>; N]
     if let Some(rest) = dsl_type.strip_prefix("Map") {

--- a/examples/rust/escrow/tests/kani.rs
+++ b/examples/rust/escrow/tests/kani.rs
@@ -109,12 +109,12 @@ fn verify_initialize_rejects_invalid() {
 #[kani::solver(cadical)]
 fn verify_initialize_effect_initializer_amount() {
     let mut s = State {
-        initializer: 0,
-        initializer_token_account: 0,
-        taker: 0,
+        initializer: [0u8; 32],
+        initializer_token_account: [0u8; 32],
+        taker: [0u8; 32],
         initializer_amount: 0,
         taker_amount: 0,
-        escrow_token_account: 0,
+        escrow_token_account: [0u8; 32],
         status: Status::Uninitialized,
     };
     let deposit_amount: u64 = kani::any();
@@ -137,12 +137,12 @@ fn verify_initialize_effect_initializer_amount() {
 #[kani::solver(cadical)]
 fn verify_initialize_effect_taker_amount() {
     let mut s = State {
-        initializer: 0,
-        initializer_token_account: 0,
-        taker: 0,
+        initializer: [0u8; 32],
+        initializer_token_account: [0u8; 32],
+        taker: [0u8; 32],
         initializer_amount: 0,
         taker_amount: 0,
-        escrow_token_account: 0,
+        escrow_token_account: [0u8; 32],
         status: Status::Uninitialized,
     };
     let deposit_amount: u64 = kani::any();
@@ -165,12 +165,12 @@ fn verify_initialize_effect_taker_amount() {
 #[kani::solver(cadical)]
 fn verify_initialize_effect_initializer_token_account() {
     let mut s = State {
-        initializer: 0,
-        initializer_token_account: 0,
-        taker: 0,
+        initializer: [0u8; 32],
+        initializer_token_account: [0u8; 32],
+        taker: [0u8; 32],
         initializer_amount: 0,
         taker_amount: 0,
-        escrow_token_account: 0,
+        escrow_token_account: [0u8; 32],
         status: Status::Uninitialized,
     };
     let deposit_amount: u64 = kani::any();

--- a/examples/rust/lending/tests/kani.rs
+++ b/examples/rust/lending/tests/kani.rs
@@ -131,7 +131,7 @@ fn verify_deposit_rejects_invalid() {
 #[kani::solver(cadical)]
 fn verify_init_pool_preserves_pool_solvency() {
     let mut s = State {
-        authority: 0,
+        authority: [0u8; 32],
         total_deposits: 0,
         total_borrows: 0,
         interest_rate: 0,
@@ -176,7 +176,7 @@ fn verify_deposit_preserves_pool_solvency() {
 #[kani::solver(cadical)]
 fn verify_init_pool_effect_interest_rate() {
     let mut s = State {
-        authority: 0,
+        authority: [0u8; 32],
         total_deposits: 0,
         total_borrows: 0,
         interest_rate: 0,
@@ -197,7 +197,7 @@ fn verify_init_pool_effect_interest_rate() {
 #[kani::solver(cadical)]
 fn verify_init_pool_effect_total_deposits() {
     let mut s = State {
-        authority: 0,
+        authority: [0u8; 32],
         total_deposits: 0,
         total_borrows: 0,
         interest_rate: 0,
@@ -218,7 +218,7 @@ fn verify_init_pool_effect_total_deposits() {
 #[kani::solver(cadical)]
 fn verify_init_pool_effect_total_borrows() {
     let mut s = State {
-        authority: 0,
+        authority: [0u8; 32],
         total_deposits: 0,
         total_borrows: 0,
         interest_rate: 0,

--- a/examples/rust/multisig/programs/tests/kani.rs
+++ b/examples/rust/multisig/programs/tests/kani.rs
@@ -330,11 +330,11 @@ fn verify_remove_member_rejects_invalid() {
 #[kani::solver(cadical)]
 fn verify_create_vault_preserves_threshold_bounded() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -526,11 +526,11 @@ fn verify_remove_member_preserves_threshold_bounded() {
 #[kani::solver(cadical)]
 fn verify_create_vault_preserves_votes_bounded() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -652,11 +652,11 @@ fn verify_remove_member_preserves_votes_bounded() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_threshold() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -682,11 +682,11 @@ fn verify_create_vault_effect_threshold() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_member_count() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -712,11 +712,11 @@ fn verify_create_vault_effect_member_count() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_approval_count() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -742,11 +742,11 @@ fn verify_create_vault_effect_approval_count() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_rejection_count() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,

--- a/examples/rust/multisig/tests/kani.rs
+++ b/examples/rust/multisig/tests/kani.rs
@@ -330,11 +330,11 @@ fn verify_remove_member_rejects_invalid() {
 #[kani::solver(cadical)]
 fn verify_create_vault_preserves_threshold_bounded() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -526,11 +526,11 @@ fn verify_remove_member_preserves_threshold_bounded() {
 #[kani::solver(cadical)]
 fn verify_create_vault_preserves_votes_bounded() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -652,11 +652,11 @@ fn verify_remove_member_preserves_votes_bounded() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_threshold() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -682,11 +682,11 @@ fn verify_create_vault_effect_threshold() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_member_count() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -712,11 +712,11 @@ fn verify_create_vault_effect_member_count() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_approval_count() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,
@@ -742,11 +742,11 @@ fn verify_create_vault_effect_approval_count() {
 #[kani::solver(cadical)]
 fn verify_create_vault_effect_rejection_count() {
     let mut s = State {
-        creator: 0,
+        creator: [0u8; 32],
         threshold: 0,
         member_count: 0,
-        members: 0,
-        voted: 0,
+        members: [[0u8; 32]; 32],
+        voted: [0; 32],
         approval_count: 0,
         rejection_count: 0,
         status: Status::Uninitialized,

--- a/examples/rust/percolator/tests/kani.rs
+++ b/examples/rust/percolator/tests/kani.rs
@@ -14,6 +14,21 @@
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 #![cfg(kani)]
 
+#[allow(dead_code)]
+#[inline]
+fn mul_div_floor_u128(a: u128, b: u128, d: u128) -> u128 {
+if d == 0 { return 0; }
+a.saturating_mul(b) / d
+}
+
+#[allow(dead_code)]
+#[inline]
+fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {
+if d == 0 { return 0; }
+let prod = a.saturating_mul(b);
+if prod % d == 0 { prod / d } else { (prod / d).saturating_add(1) }
+}
+
 // ============================================================================
 // State model (derived from qedspec — no framework dependencies)
 // ============================================================================


### PR DESCRIPTION
Continued from where PR #45 left off — taking v2.21.0 for a spin on our [tendr.bid](https://github.com/0xharp/tender) Anchor program. Three more codegen edges surfaced on the standalone kani harness path that the bundled examples don't quite exercise. Each is small and isolated; full validation evidence below. Thank you for the speed on the v2.20 and v2.21 releases, by the way — it's been a great experience tracking the cutting edge.

## The fixes

**1. `fix(kani): resolve effect-conformance RHS via target-aware binder`**

v2.21's per-handler effect-conformance harness (the per-field `verify_X_effect_Y()` fns) emits the RHS as a bare identifier, so any spec whose effect block copies a state field into another state field fails to compile:

```
error[E0425]: cannot find value `now` in this scope
   --> tests/kani.rs:N:M
    |
  N |         assert!(s.rfp_created_at == now, "...");
    |                                    ^^^
```

The snapshot binding `pre_now` is already declared earlier in the same fn — fix is one `resolve_value(.., Some("pre_"))` call ahead of the match arms. `resolve_value` is identity for params and inlines constants, so any effect whose RHS isn't a state-field name is unchanged.

**2. `fix(kani): inline mul_div helpers when standalone kani harness needs them`**

The standalone `tests/kani.rs` doesn't `pub use crate::math::*`, so any spec calling `mul_div_floor` from an effect's let-binding fails to compile with `error[E0425]: cannot find function 'mul_div_floor_u128'`. Inline the canonical helper bodies right after `#![cfg(kani)]`, gated by `guards_use_math_helpers` so specs that don't use mul_div get a zero-byte change.

**3. `fix(kani): type-aware seed-state init via shared default_value_for_field`**

`emit_state_init_zeroed` literaled every field to `0` regardless of type. With v2.21's S3 Pubkey lowering and any `Map[N] T` field, that produces:

```
error[E0308]: mismatched types
   --> tests/kani.rs:N:M
    |
  N |         rfp_milestone_amounts: 0,
    |                                ^ expected `[u64; 8]`, found integer
```

Reuse the existing `default_value_for_field` helper (visibility bumped to `pub(crate)`) which already handles `Map[N] T`, records, Pubkey, sums, and primitives. The three call sites in `emit_kani_account_section` thread `spec` through.

## Chore commit

`chore(examples): regen bundled kani harnesses for kani.rs fixes` catches up the five affected `tests/kani.rs` files (escrow, lending, multisig + multisig/programs, percolator) so `qedgen check --regen-drift` stays clean on the kani path. Scope is intentionally tight — only the five files these fixes change. Other v2.21 drift under `src/integration_tests.rs` / `Cargo.toml` / `qed.lock` is left for separate maintainer cleanup if needed.

## Validation

- `cargo test -p qedgen-solana-skills --bin qedgen`: 688 passed, 0 failed, 1 ignored
- `cargo clippy --release -p qedgen-solana-skills -- -D warnings`: clean
- `cargo fmt --check`: clean
- Bundled example byte-identity vs stock v2.21.0 binary on all 5 examples: every diff line falls in one of the three known fix categories (mul_div helper insert, Pubkey/array defaults, pre_ binder rewrite) — verified with diff
- `qedgen check --regen-drift` on the kani path: clean
- `bash scripts/check-lake-build.sh --strict` (lake-build workflow, manual dispatch on this branch): success in 4m22s — Lean side unaffected

## Heads-up on pre-existing CI

For visibility (so it doesn't read as a regression from this PR): upstream main's CI is also currently red on the v2.21.0 release commit ([run `26032919566`](https://github.com/QEDGen/solana-skills/actions/runs/26032919566)) with the same 5 failing tests this PR's CI will also show:

- `escrow_codegen_is_deterministic`
- `escrow_split_multi_spec_is_deterministic`
- `lending_codegen_is_deterministic`
- `multisig_codegen_is_deterministic`
- `percolator_codegen_is_deterministic`

Looks like `crates/qedgen/tests/codegen_determinism.rs` calls `qedgen codegen --all` which gates on Kani install, but the `test` job in `.github/workflows/ci.yml` doesn't install Kani before running tests. Happy to send a small follow-up PR adding a `cargo install --locked kani-verifier && cargo kani setup` step (or whatever shape you'd prefer) if useful — totally fine if you'd rather handle it separately.

Thanks again — please let me know if anything needs reshaping. Happy to correct my understanding if I've inadvertently shipped something wrong here.
