### PR TITLE
chore(release): bump package.json to 2.24.0 (CI fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "Agent skill for spec-driven verification and audit of Solana programs — .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
## Summary
- Pre-release checklist gap: `crates/qedgen/Cargo.toml` was bumped to 2.24.0 in 8d0dbba but `package.json` stayed at 2.23.0
- CI's `check-version-consistency.sh` gate fails on main after the v2.24 merge (#48)

## Test plan
- [x] `bash scripts/check-version-consistency.sh` — `Version metadata consistent: 2.24.0`