### PR TITLE
chore(v2.24): rustfmt fix

### DIFF
--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -920,10 +920,8 @@ impl ParsedHandlerAccount {
                     // Quasar's flat-struct emission still has every
                     // variant-payload field at top level, so
                     // `has_one = field` works there as before.
-                    let suppress_for_anchor_variant = matches!(
-                        target,
-                        crate::Target::Anchor
-                    ) && is_multi_variant_adt_with_field_in_variant(spec, who);
+                    let suppress_for_anchor_variant = matches!(target, crate::Target::Anchor)
+                        && is_multi_variant_adt_with_field_in_variant(spec, who);
                     if !suppress_for_anchor_variant {
                         parts.push(format!("has_one = {}", who));
                     }


### PR DESCRIPTION
Trivial — `cargo fmt --check` red on main after PR #50 merge. Multi-line `matches!` macro collapsed to a single line + chained `&&` per rustfmt.