### PR TITLE
feat(v2.24.x): allow --target pinocchio with verification backends

### DIFF
--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -2797,17 +2797,39 @@ async fn dispatch(cmd: Commands) -> Result<()> {
             fill_tests,
         } => {
             require_git_repo()?;
-            if matches!(target, Target::Pinocchio) {
+            // v2.24.x: Pinocchio reserves the Rust-scaffold CLI surface
+            // but has no scaffold implementation yet. Verification
+            // backends (Kani / proptest / Lean / integration_test /
+            // CI / crucible) are spec-driven and target-agnostic —
+            // they reason about spec semantics, not the runtime
+            // representation — so they run cleanly for Pinocchio
+            // specs even without a Rust scaffold. Skip the
+            // `codegen::generate` step on Pinocchio when the user
+            // asked for at least one backend flag (or `--all`).
+            // Bail loudly only when the user requested the scaffold
+            // alone (no backend flags) and Pinocchio is the chosen
+            // target — that's the unambiguous "I want a Pinocchio
+            // Rust program" case the scaffold can't satisfy.
+            let any_backend = kani || proptest || lean || test || integration || ci || crucible;
+            let pinocchio_no_scaffold = matches!(target, Target::Pinocchio);
+            if pinocchio_no_scaffold && !any_backend && !all {
                 anyhow::bail!(
-                    "`--target pinocchio` is not yet implemented. \
-                     `--target anchor` and `--target quasar` are \
-                     supported."
+                    "`--target pinocchio` is not yet implemented for Rust scaffold codegen. \
+                     `--target anchor` and `--target quasar` are supported for scaffold. \
+                     To generate just the verification backends (Kani / proptest / Lean / etc.) \
+                     for a Pinocchio spec, pass `--kani`, `--proptest`, `--lean`, or `--all` \
+                     alongside `--target pinocchio` — the scaffold step will be skipped and \
+                     the backends will run against the spec directly."
                 );
             }
             let cwd = std::env::current_dir()?;
             let spec = init::resolve_spec_path(spec.as_deref(), &cwd)?;
-            // Rust skeleton (always)
-            codegen::generate(&spec, &output_dir, target)?;
+            // Rust skeleton — Anchor and Quasar emit; Pinocchio skips
+            // (handled above + here so `--all` on Pinocchio still
+            // works for the backend artifacts).
+            if !pinocchio_no_scaffold {
+                codegen::generate(&spec, &output_dir, target)?;
+            }
 
             if kani || all {
                 // Codegen is pure text generation; missing cargo-kani only

--- a/references/cli.md
+++ b/references/cli.md
@@ -476,6 +476,7 @@ $QEDGEN codegen --ci
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--spec` | Path | optional | Spec file or directory. Defaults to `.qed/config.json spec` |
+| `--target` | enum | `anchor` | Framework target for the Rust program crate. Values: `anchor` (Anchor-compatible, fully implemented — default); `quasar` (Blueshift `quasar_lang`, fully implemented); `pinocchio` (reserved CLI surface; scaffold codegen not yet implemented). For Pinocchio specs, the scaffold step is skipped but `--kani` / `--proptest` / `--lean` / `--integration` / `--ci` still run — pass `--target pinocchio --kani --proptest --lean` (or `--all`) to generate just the verification backends without an unwanted Anchor scaffold. Bare `--target pinocchio` (no backend flags) errors with the same message. Verification backends are spec-driven and target-agnostic by design (see the comment at the top of any generated `tests/kani.rs`). |
 | `--output-dir` | Path | `./programs` | Output directory for Rust skeleton |
 | `--all` | bool | false | Generate all artifacts |
 | `--lean` | bool | false | Generate Lean 4 proofs |


### PR DESCRIPTION
## Summary
- `qedgen codegen --target pinocchio --kani --proptest --lean` now works — skips the Rust scaffold (not implemented) but runs the verification backends, which are spec-driven and target-agnostic by design
- Bare `--target pinocchio` (no backend flags) still errors, with a clearer message explaining the workaround
- Adds the missing `--target` row to the `codegen` flag table in `references/cli.md` so an agent reading the docs gets a usable experience

## Test plan
- [x] End-to-end test in `/tmp/v224_pin_test/` — Pinocchio spec generates clean Kani / proptest / Lean without unwanted Anchor scaffold pollution
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean
- [x] `cargo test` 804 pass
- [x] `bash scripts/check-readme-drift.sh` clean