### PR TITLE
fix(v2.24.x): gate multi-variant ADT codegen on WrongState declaration

### DIFF
--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -733,17 +733,25 @@ impl ParsedHandler {
 }
 
 /// True iff the spec is a multi-variant ADT *and* the named field lives
-/// inside one or more variant payloads (not directly on the wrapper).
-/// Used by R25's `auth X → has_one = X` lowering to skip the `has_one`
-/// attribute when the field can't be reached from the Anchor wrapper —
-/// `has_one` looks up `wrapper.<field>`, which fails for fields buried
-/// in `wrapper.inner.<variant>`. See `ParsedHandlerAccount::account_attr`
-/// for the gating logic.
+/// inside one or more variant payloads (not directly on the wrapper) *and*
+/// the spec has opted into v2.24 wrapper-struct + inner-enum codegen by
+/// declaring `WrongState` in `type Error`.
+///
+/// Used by R25's `auth X → has_one = X` lowering and by
+/// `emit_variant_auth_guard` to decide whether the auth field is reachable
+/// from the Anchor wrapper. Without WrongState the spec stays on the
+/// legacy flat-struct codegen path where every field — including
+/// variant-payload fields — sits directly on the wrapper, so `has_one`
+/// keeps working and the variant-destructure guard would reference a
+/// non-existent `inner` enum.
 pub fn is_multi_variant_adt_with_field_in_variant(spec: &ParsedSpec, field: &str) -> bool {
     let Some(acct) = spec.account_types.first() else {
         return false;
     };
     if acct.variants.len() <= 1 {
+        return false;
+    }
+    if !spec.error_codes.iter().any(|c| c == "WrongState") {
         return false;
     }
     acct.variants

--- a/crates/qedgen/src/codegen.rs
+++ b/crates/qedgen/src/codegen.rs
@@ -866,13 +866,34 @@ fn generate_lib(
 }
 
 /// v2.24 S5b — `true` when the spec's state is a multi-variant ADT
-/// (two or more variants in a single account type). Drives codegen
-/// to emit the wrapper-struct + inner-enum pattern instead of the
-/// flat-fields struct + parallel `Status` enum the pre-v2.24 path
-/// produced. Single-record account types, single-variant ADTs, and
-/// multi-account specs stay on the flat path.
+/// (two or more variants in a single account type) AND the spec has
+/// declared the `WrongState` error variant that the new emission
+/// path needs for its variant-mismatch fallthroughs.
+///
+/// `WrongState` works as the **migration signal**: a spec author
+/// opts into the wrapper-struct + inner-enum emission by declaring
+/// it in `type Error`, alongside flipping bare-field effect LHS to
+/// `Variant.field` syntax. Without that declaration, codegen falls
+/// back to the legacy flat-fields struct + parallel `Status` enum
+/// emission — which keeps unmigrated bundled examples (escrow,
+/// multisig, lending, percolator) compiling on Anchor target until
+/// they migrate at their own pace.
+///
+/// v2.24.x follow-up: pre-fix the predicate only checked variant
+/// count, which meant every multi-variant ADT spec routed through
+/// the wrapper+enum path regardless of whether it had been migrated.
+/// That exposed downstream emission gaps (lib.rs pda seeds
+/// referencing variant-payload fields, guards.rs requires bodies
+/// reaching `wrapper.X` where X moved into the inner enum) that
+/// don't show up on Quasar (which stays on the flat path) but
+/// break Anchor cargo check.
+///
+/// Single-record account types, single-variant ADTs, multi-account
+/// specs, and any spec lacking `WrongState` all stay on the flat path.
 fn is_multi_variant_adt_state(spec: &ParsedSpec) -> bool {
-    spec.account_types.len() == 1
+    let has_wrong_state = spec.error_codes.iter().any(|c| c == "WrongState");
+    has_wrong_state
+        && spec.account_types.len() == 1
         && spec
             .account_types
             .first()
@@ -4274,6 +4295,7 @@ type State
 
 type Error
   | InvalidAmount
+  | WrongState
 
 handler initialize (amount : U64) : State.Uninitialized -> State.Open {
   auth initializer

--- a/crates/qedgen/src/lean_gen.rs
+++ b/crates/qedgen/src/lean_gen.rs
@@ -86,8 +86,15 @@ fn emit_state_struct(
 /// accounts, single-variant ADTs, and multi-account specs stay on the
 /// legacy flat-`structure` path. Indexed specs (records / Map fields)
 /// route through `render_indexed_state` and are unaffected.
+///
+/// v2.24.x: also gates on `WrongState` declaration as the migration
+/// signal. Specs without it keep the legacy flat-structure Lean
+/// shape — matching the Rust-side fallback so the harness layers
+/// stay consistent.
 fn is_multi_variant_adt_state(spec: &ParsedSpec) -> bool {
-    spec.account_types.len() == 1
+    let has_wrong_state = spec.error_codes.iter().any(|c| c == "WrongState");
+    has_wrong_state
+        && spec.account_types.len() == 1
         && spec
             .account_types
             .first()
@@ -5417,6 +5424,7 @@ type Error
   | ThresholdUnreachable
   | NotAMember
   | MathOverflow
+  | WrongState
 
 pda vault ["vault", creator]
 
@@ -5704,7 +5712,126 @@ liveness proposal_resolves : State.HasProposal ~> State.Active via [execute, can
     // Account-binding `.pubkey` effect handling (B + D)
     // ========================================================================
 
-    const ESCROW_SPEC: &str = include_str!("../../../examples/rust/escrow/escrow.qedspec");
+    // Inline escrow spec used by v2.24 inductive-State Lean codegen tests.
+    // Mirrors examples/rust/escrow/escrow.qedspec but declares WrongState so
+    // the multi-variant ADT path fires. The bundled spec stays unmigrated
+    // (no WrongState) to keep the Anchor scaffold smoke tests on the legacy
+    // flat-struct codegen path.
+    const ESCROW_SPEC: &str = r#"
+spec Escrow
+
+type State
+  | Uninitialized
+  | Open of {
+      initializer               : Pubkey,
+      initializer_token_account : Pubkey,
+      taker                     : Pubkey,
+      initializer_amount        : U64,
+      taker_amount              : U64,
+      escrow_token_account      : Pubkey,
+    }
+  | Closed
+
+pda escrow ["escrow", initializer]
+
+event EscrowInitialized {
+  initializer : Pubkey,
+  amount      : U64,
+}
+
+event EscrowExchanged {
+  taker  : Pubkey,
+  amount : U64,
+}
+
+event EscrowCancelled {
+  initializer : Pubkey,
+}
+
+type Error
+  | InvalidAmount
+  | Unauthorized
+  | AlreadyClosed
+  | WrongState
+
+handler initialize (deposit_amount : U64) (receive_amount : U64) : State.Uninitialized -> State.Open {
+  auth initializer
+
+  accounts {
+    initializer    : signer, writable
+    escrow         : writable, pda ["escrow", initializer]
+    mint           : readonly
+    initializer_ta : writable, type token
+    escrow_ta      : writable, type token, authority escrow
+    token_program  : program
+    system_program : program
+  }
+
+  requires deposit_amount > 0 and receive_amount > 0 else InvalidAmount
+
+  effect {
+    Open.initializer_amount        := deposit_amount
+    Open.taker_amount              := receive_amount
+    Open.initializer_token_account := initializer_ta.pubkey
+  }
+
+  transfers {
+    from initializer_ta to escrow_ta amount deposit_amount authority initializer
+  }
+
+  emits EscrowInitialized
+}
+
+handler exchange : State.Open -> State.Closed {
+  auth taker
+
+  accounts {
+    taker          : signer, writable
+    escrow         : writable, pda ["escrow", initializer]
+    initializer_ta : writable, type token
+    taker_ta       : writable, type token
+    escrow_ta      : writable, type token, authority escrow
+    token_program  : program
+  }
+
+  requires initializer_ta.pubkey == Open.initializer_token_account else Unauthorized
+
+  transfers {
+    from taker_ta to initializer_ta amount Open.taker_amount authority taker
+    from escrow_ta to taker_ta amount Open.initializer_amount authority escrow
+  }
+
+  emits EscrowExchanged
+}
+
+handler cancel : State.Open -> State.Closed {
+  auth initializer
+
+  accounts {
+    initializer    : signer, writable
+    escrow         : writable, pda ["escrow", initializer]
+    escrow_ta      : writable, type token, authority escrow
+    initializer_ta : writable, type token
+    token_program  : program
+  }
+
+  requires initializer_ta.pubkey == Open.initializer_token_account else Unauthorized
+
+  transfers {
+    from escrow_ta to initializer_ta amount Open.initializer_amount authority escrow
+  }
+
+  emits EscrowCancelled
+}
+
+invariant conservation "total tokens preserved across initialize, exchange, cancel"
+
+cover happy_path [initialize, exchange]
+
+cover cancel_path [initialize, cancel]
+
+liveness escrow_settles : State.Open ~> State.Closed via [exchange, cancel] within 1
+"#;
 
     #[test]
     fn lean_gen_drops_account_binding_pubkey_effect() {

--- a/examples/regressions/issue-8/repro-04-liveness-params.qedspec
+++ b/examples/regressions/issue-8/repro-04-liveness-params.qedspec
@@ -25,7 +25,7 @@ type State
   | Uninitialized
   | Active of { c : U8 }
 
-type Error | E
+type Error | E | WrongState
 
 handler init (p : Pubkey) : State.Uninitialized -> State.Active {
   permissionless

--- a/examples/regressions/issue-8/repro-06-cover-witness-bool.qedspec
+++ b/examples/regressions/issue-8/repro-06-cover-witness-bool.qedspec
@@ -33,7 +33,7 @@ type State
   | Uninitialized
   | Active of { flag : Bool }
 
-type Error | E
+type Error | E | WrongState
 
 handler init : State.Uninitialized -> State.Active {
   permissionless


### PR DESCRIPTION
## Summary

The v2.24 multi-variant ADT codegen path (wrapper-struct + inner-enum on Anchor target, inductive `State` on Lean) was firing for every spec with 2+ State variants. That exposed downstream emission gaps — `lib.rs` pda seeds, `guards.rs` requires bodies, etc. — for unmigrated bundled examples (escrow, multisig, lending, percolator) that hadn't flipped their bare-field effect LHS to `Variant.field` syntax yet. Anchor scaffold ``cargo check`` failed.

Gate `is_multi_variant_adt_state` on `WrongState` being declared in `type Error`. That makes `WrongState` the **migration opt-in signal**: a spec author flips into the wrapper+enum / inductive-Lean shape by declaring it, alongside the per-effect `Variant.field` syntax flip. Without it, the spec stays on the legacy flat-fields struct + parallel `Status` enum codegen path that the bundled examples still depend on.

- `crates/qedgen/src/codegen.rs` + `crates/qedgen/src/lean_gen.rs` — predicate now also checks for `WrongState`
- Test fixtures that exercise the v2.24 inductive path get `WrongState` added (inline specs in the test modules + the two `examples/regressions/issue-8` repro specs)
- `ESCROW_SPEC` in `lean_gen.rs` is now an inline literal with `WrongState` declared, so the v2.24 inductive Lean assertions still run while the bundled `examples/rust/escrow/escrow.qedspec` stays on the legacy path

## Test plan

- [x] `cargo test --release --bin qedgen` — 804/804 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --release -- -D warnings` — clean
- [x] `bash scripts/check-readme-drift.sh` — clean
- [x] `qedgen check --frozen --spec examples/rust/{escrow,multisig,lending,percolator}/` — all pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)