### PR TITLE
fix(ci): unblock lake-build + release binaries on macOS

### DIFF
--- a/.github/workflows/lake-build.yml
+++ b/.github/workflows/lake-build.yml
@@ -47,6 +47,35 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-lake-
 
+      # v2.27 — examples that import bundled stdlib (`Token from "spl"`,
+      # `Metadata from "metaplex"`) have lakefiles whose `require
+      # tokenProofs from "<rel-path>"` directive was rewritten relative
+      # to the author's `$HOME` (the bundled proof package is
+      # materialized to `~/.qedgen/cache/builtin/<key>/.qed/proofs/`).
+      # The relative-path depth depends on how deep the repo is under
+      # `$HOME` — committed lakefiles therefore only resolve cleanly on
+      # the machine they were generated on. Rebuild qedgen and re-run
+      # codegen on each affected example to (a) materialize the bundled
+      # proof package into the runner's `$HOME/.qedgen/cache/`, and
+      # (b) rewrite the lakefile's require directive with a path that
+      # resolves correctly under the runner's path layout.
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - name: Build qedgen + regen bundled-stdlib lakefiles
+        run: |
+          set -euo pipefail
+          cargo build --release --bin qedgen
+          mkdir -p bin
+          cp target/release/qedgen bin/qedgen
+          for ex in examples/rust/escrow-split examples/rust/bundled-stdlib-demo; do
+            if [ -f "$ex/qed.toml" ]; then
+              echo "==> regen lakefile for $ex"
+              bin/qedgen codegen --lean --spec "$ex"
+            fi
+          done
+
       # Populate `.lake/` for any example whose cache missed. `lake update`
       # is a no-op when the manifest matches; otherwise it fetches Mathlib.
       - name: Bootstrap missing .lake directories

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,16 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
+      # macOS runners ship Xcode's new ld-prime linker, which trips an
+      # assertion on Rust-generated symbol names longer than its internal
+      # limit (`name.size() <= maxLength` in `SymbolString.cpp`). The
+      # classic Mach-O linker handles them without complaint. Apple has
+      # an open bug; until it's fixed in `ld-prime`, every macOS Rust
+      # build of qedgen needs `-Wl,-ld_classic`. Non-macOS targets are
+      # unaffected.
       - name: Build
+        env:
+          RUSTFLAGS: ${{ startsWith(matrix.os, 'macos') && '-C link-arg=-Wl,-ld_classic' || '' }}
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package and checksum

--- a/docs/prds/RELEASE-v2.27.md
+++ b/docs/prds/RELEASE-v2.27.md
@@ -318,6 +318,7 @@ qedgen`); 4/4 codegen_smoke; 4/4 upstream_check_e2e.
 | Lockfile diff renderer misses `program_id` + `upstream_version` | `qed_lock::describe_lock_diff` | Minor; not blocking                |
 | `is_sentinel_hash` accepts `SHA256:` prefix shorthand          | Defensive against hand-edited specs | Intentional looseness            |
 | `--recursive`'s lake build runs in the host shell, not sandboxed | `main.rs` verify handler | A malicious provider's lakefile.lean could run arbitrary Lean; v2.27 trust model is "you opted into the dep when you wrote `import X from \"Y\"`"; sandboxing is v3.0+ scope |
+| Bundled-stdlib `require <pkg>Proofs from "<rel-path>"` directive in committed lakefiles is author-machine-specific | `lean_gen::inject_verified_callee_requires` + `pathdiff_relative_from` | The relative path computed against `$HOME`-rooted cache resolves to the right cache only on the author's machine layout. Other clones (and CI) must run `qedgen codegen --lean --spec <ex>` to materialize the bundled proof package + rewrite the lakefile with their own layout. Lake-build CI workflow does this automatically (v2.27.1). v2.28 design: vendor the bundled package into the consumer tree OR use a git source so the require directive is portable. |
 
 ## Upgrade notes
 


### PR DESCRIPTION
## Summary

Post-v2.27.0 CI hotfix. Two failures surfaced on the release commit:

1. **lake-build.yml** — bundled-stdlib examples (`escrow-split`, `bundled-stdlib-demo`) commit lakefiles with a relative `require tokenProofs from "<rel-path>"` directive computed at codegen time against the author's \$HOME depth. CI runners have a different layout so the relative path resolves elsewhere and `lake update` errors with \"package directory not found\". Fix: build qedgen + run `codegen --lean --spec <ex>` per affected example to materialize the bundled proof package into the runner's cache AND rewrite the lakefile's require directive with a CI-correct path before the bootstrap step.

2. **release.yml** — Xcode's `ld-prime` linker on macos-latest trips `name.size() <= maxLength` on long Rust-mangled symbol names. Apple bug; until upstream fix, pass `-Wl,-ld_classic` via `RUSTFLAGS` for macOS targets.

## Followup (v2.28)

Make the lakefile require directive use a stable path mechanism (git source, or in-repo bundled-stdlib mirror) so the committed file doesn't carry author-machine-specific paths.

## Test plan

- [ ] CI lake-build workflow goes green on this PR (auto-runs on push-to-main, not PR — but the dispatch-job confirms the YAML parses).
- [ ] After merge, re-run failed `release.yml` for v2.27.0 tag and confirm all 4 targets build.
- [ ] After merge, the `lake-build.yml` push-to-main run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)