### PR TITLE
fix(ci): strip stale require directive before lakefile regen

### DIFF
--- a/.github/workflows/lake-build.yml
+++ b/.github/workflows/lake-build.yml
@@ -72,6 +72,17 @@ jobs:
           for ex in examples/rust/escrow-split examples/rust/bundled-stdlib-demo; do
             if [ -f "$ex/qed.toml" ]; then
               echo "==> regen lakefile for $ex"
+              # Strip any existing `require <pkg>Proofs from "..."` lines
+              # AND the v2.27-Track-B preamble comment so codegen's
+              # `inject_verified_callee_requires` re-emits them with the
+              # CI runner's correct relative path (committed lakefile's
+              # path was computed against the author's $HOME depth).
+              # The function is idempotent on presence — if we left the
+              # stale line in place it would skip the rewrite.
+              lakefile="$ex/formal_verification/lakefile.lean"
+              if [ -f "$lakefile" ]; then
+                sed -i '/^require [a-zA-Z_][a-zA-Z0-9_]*Proofs from /d; /^-- v2\.27 Track B: verified-callee proof package/d' "$lakefile"
+              fi
               bin/qedgen codegen --lean --spec "$ex"
             fi
           done


### PR DESCRIPTION
Followup to #59 — first attempt's regen step didn't actually rewrite the lakefile because \`inject_verified_callee_requires\` is idempotent on presence: it skips when \`require <Pkg>Proofs from\` already appears, even if the path is wrong. CI saw the committed (machine-specific) path stay in place.

Fix: sed out the stale require line + Track-B preamble before \`qedgen codegen --lean\` runs. With the line gone, inject re-emits a fresh one against the CI runner's path layout.

Lake-build (Lean side) workflow run for the previous merge: https://github.com/QEDGen/solana-skills/actions/runs/26326469814

## Test plan

- [ ] Push-to-main triggers Lake build workflow which goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)