### PR TITLE
fix(ci): invalidate stale lake-manifest.json after lakefile regen

### DIFF
--- a/.github/workflows/lake-build.yml
+++ b/.github/workflows/lake-build.yml
@@ -84,6 +84,12 @@ jobs:
                 sed -i '/^require [a-zA-Z_][a-zA-Z0-9_]*Proofs from /d; /^-- v2\.27 Track B: verified-callee proof package/d' "$lakefile"
               fi
               bin/qedgen codegen --lean --spec "$ex"
+              # The fresh require for `tokenProofs` / `metadataProofs`
+              # isn't in the cached lake-manifest.json. Invalidate the
+              # stale manifest so the bootstrap step's `lake update`
+              # repopulates it. `.lake/` itself can stay (Mathlib oleans
+              # are still valid); only the manifest references need a refresh.
+              rm -f "$ex/formal_verification/lake-manifest.json"
             fi
           done
 


### PR DESCRIPTION
Followup to #60 — the lakefile-strip-then-regen path successfully rewrote the lakefile, but the cached lake-manifest.json (restored from the lake-cache step) didn't know about the new \`require tokenProofs\` directive. \`lake update\` in bootstrap was a no-op because the manifest existed, so the sweep failed with \`unknown module prefix 'Token'\`.

Fix: \`rm -f \$ex/formal_verification/lake-manifest.json\` after codegen. Bootstrap step's missing-manifest check then re-runs \`lake update\`, repopulating the manifest with the new require.

Lake-build run for the previous attempt: https://github.com/QEDGen/solana-skills/actions/runs/26326844673

🤖 Generated with [Claude Code](https://claude.com/claude-code)