### PR TITLE
fix(ci): cd into example dir for codegen so the lakefile inject actually fires

### DIFF
--- a/.github/workflows/lake-build.yml
+++ b/.github/workflows/lake-build.yml
@@ -67,8 +67,9 @@ jobs:
         run: |
           set -euo pipefail
           cargo build --release --bin qedgen
+          repo_root="$(pwd)"
           mkdir -p bin
-          cp target/release/qedgen bin/qedgen
+          cp target/release/qedgen "$repo_root/bin/qedgen"
           for ex in examples/rust/escrow-split examples/rust/bundled-stdlib-demo; do
             if [ -f "$ex/qed.toml" ]; then
               echo "==> regen lakefile for $ex"
@@ -83,7 +84,13 @@ jobs:
               if [ -f "$lakefile" ]; then
                 sed -i '/^require [a-zA-Z_][a-zA-Z0-9_]*Proofs from /d; /^-- v2\.27 Track B: verified-callee proof package/d' "$lakefile"
               fi
-              bin/qedgen codegen --lean --spec "$ex"
+              # cd into the example: `qedgen codegen --lean`'s default
+              # output is `./formal_verification/Spec.lean` (cwd-relative).
+              # Running from the repo root would write to the wrong place
+              # AND the inject step would skip because `./formal_verification/
+              # lakefile.lean` wouldn't exist in cwd. Session-3 carry-forward
+              # `--lean-output` cwd-default limitation; fix queued for v2.27.x.
+              ( cd "$ex" && "$repo_root/bin/qedgen" codegen --lean --spec . )
               # The fresh require for `tokenProofs` / `metadataProofs`
               # isn't in the cached lake-manifest.json. Invalidate the
               # stale manifest so the bootstrap step's `lake update`


### PR DESCRIPTION
Followup to #61. Actual root cause of the lake-build cascade.

\`qedgen codegen --lean\`'s \`--lean-output\` defaults to \`./formal_verification/Spec.lean\` — cwd-relative (session-3 known limitation that bit me three times in a row). Running from repo root wrote Spec.lean to the repo root's \`./formal_verification/\`, not the example's. The lakefile inject step short-circuited because its \`if lakefile_path.exists()\` check looked at cwd's \`./formal_verification/lakefile.lean\` (which didn't exist), so \`require tokenProofs\` was never re-emitted. Hence the stale broken require stayed, then the manifest invalidation didn't help, then the bootstrap re-update couldn't resolve a require that wasn't in the lakefile.

Fix: \`(cd "$ex" && "$repo_root/bin/qedgen" codegen --lean --spec .)\`. With cwd inside the example, the default \`./formal_verification/...\` paths resolve correctly.

The earlier fixes (#60 strip, #61 manifest invalidate) stay in place — they're independently necessary once the cd lets the inject actually fire.

## Verified locally

Reproduced the failure on a clean cache + clean checkout running the workflow steps verbatim — without the cd, the inject is silent; with the cd, \`updated ./formal_verification/lakefile.lean (added 1 verified-callee require(s))\` appears. Full \`bash scripts/check-lake-build.sh\` sweep: 11 / 11 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)