### PR TITLE
release: v2.28.1 — version-metadata patch

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -441,7 +441,7 @@ After `qedgen generate`:
 
 Before cutting a new release or tag:
 
-1. **Bump version** in `crates/qedgen/Cargo.toml` — `install.sh` derives its version from there
+1. **Bump version** in BOTH `crates/qedgen/Cargo.toml` AND `package.json` — `install.sh` derives its version from Cargo.toml; the `check-version-consistency.sh` CI gate fails the build if the two drift (v2.28.0 shipped with this exact mismatch; v2.28.1 hotfixed it). Run `bash scripts/check-version-consistency.sh` after bumping to confirm.
 2. **`cargo fmt --check`** — matches the CI gate; `cargo test` does NOT run fmt, so this is an easy miss if skipped
 3. **`cargo clippy -- -D warnings`** — matches the CI gate (plain `cargo clippy` is too lenient)
 4. **`cargo test`** — all tests must pass

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.28.0"
+version = "2.28.1"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/docs/prds/RELEASE-v2.28.1.md
+++ b/docs/prds/RELEASE-v2.28.1.md
@@ -1,0 +1,44 @@
+# Release v2.28.1 — version-metadata patch
+
+CI-only patch on top of v2.28.0. No code, no DSL, no bundled-stdlib
+changes. v2.28.0 shipped with `crates/qedgen/Cargo.toml` at `2.28.0`
+but `package.json` still at `2.27.1` — the pre-release checklist only
+called out the Cargo bump, so `package.json` was missed. The
+`check-version-consistency.sh` CI gate caught it on the merge commit;
+v2.28.1 syncs both files and amends the checklist so the next release
+catches the gap before tagging.
+
+## What's in
+
+- **`package.json`** bumped `2.27.1` → `2.28.1` (and `Cargo.toml`
+  goes `2.28.0` → `2.28.1`) so the version-consistency CI gate goes
+  green on main.
+- **`CLAUDE.md` pre-release checklist** step 1 now says "Bump version
+  in BOTH `Cargo.toml` AND `package.json`" and points at
+  `scripts/check-version-consistency.sh` as the local validator. The
+  lowercase `claude.md` mirror stays byte-identical (same file on
+  case-insensitive macOS filesystems).
+
+## What's NOT in
+
+- Same surface as v2.28.0. Bundled-stdlib proof packages, the
+  `verify --lean` trust-surface report, DSL, CLI flags — all
+  unchanged. v2.28.0 release binaries (uploaded by `release.yml` on
+  the v2.28.0 tag) remain the runtime artifacts for users who pulled
+  before v2.28.1; the difference between v2.28.0 and v2.28.1
+  binaries is the embedded version string and the bundled
+  `package.json`.
+
+## Test plan
+
+- [x] `bash scripts/check-version-consistency.sh` — `Version metadata consistent: 2.28.1`
+- [x] `cargo fmt --check`
+- [x] `cargo clippy --release -- -D warnings` (no code change, but
+      we re-validate to keep the gate-sequence honest)
+- [ ] Post-tag: `release.yml` uploads v2.28.1 binaries
+- [ ] Post-tag: `CI` workflow on the tag commit goes green
+
+## Upgrade notes
+
+- Same surface as v2.28.0. No spec, lock, or codegen changes; bundled
+  examples don't need regen.

--- a/docs/prds/RELEASE-v2.28.1.md
+++ b/docs/prds/RELEASE-v2.28.1.md
@@ -18,6 +18,15 @@ catches the gap before tagging.
   `scripts/check-version-consistency.sh` as the local validator. The
   lowercase `claude.md` mirror stays byte-identical (same file on
   case-insensitive macOS filesystems).
+- **Bundled examples' `qedgen-macros` tag pin** sed-bumped across 7
+  Cargo.toml files (escrow, lending, multisig, percolator + their
+  `programs/` sub-crates) from `tag = "v2.27.1"` → `tag = "v2.28.1"`.
+  `codegen::render_qedgen_cargo_toml` embeds the value via
+  `env!("CARGO_PKG_VERSION")`, so the `check --regen-drift` CI gate
+  expects the pinned tag to match the current crate version. Same
+  gap shipped in v2.24.1 as commit 4ee40bd; pre-release checklist
+  should grow a regen step in a future release to catch this before
+  tagging.
 
 ## What's NOT in
 

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.27.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.28.1" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.27.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.28.1" }
 
 [workspace]

--- a/examples/rust/lending/Cargo.toml
+++ b/examples/rust/lending/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.27.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.28.1" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.27.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.28.1" }
 
 [workspace]

--- a/examples/rust/multisig/Cargo.toml
+++ b/examples/rust/multisig/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.27.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.28.1" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.27.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.28.1" }
 
 [workspace]

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.27.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.28.1" }
 
 [workspace]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.27.1",
+  "version": "2.28.1",
   "description": "Agent skill for spec-driven verification and audit of Solana programs — .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
## Summary

CI hotfix on top of v2.28.0. `package.json` was missed in the v2.28.0 bump (still at 2.27.1 while `Cargo.toml` went to 2.28.0); the `check-version-consistency.sh` gate caught the drift on the merge commit.

- Bumps both `crates/qedgen/Cargo.toml` and `package.json` to `2.28.1`.
- Amends `CLAUDE.md` pre-release checklist step 1 to call out the `package.json` bump explicitly + point at `scripts/check-version-consistency.sh` as the local validator.

Same surface as v2.28.0; no DSL / bundled-stdlib / codegen changes.

## Test plan

- [x] `bash scripts/check-version-consistency.sh` — `Version metadata consistent: 2.28.1`
- [x] `cargo fmt --check`
- [ ] Post-merge: `CI` workflow on main goes green
- [ ] Post-tag: `release.yml` uploads v2.28.1 binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)