### PR TITLE
fix(codegen): narrow `let X = mul_div_*(...)` to u64 at binding site

### DIFF
--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -945,6 +945,16 @@ fn expr_to_rust(e: &Expr, ctx: Ctx, consts: ConstTable, opts: RustOpts<'_, '_>) 
             format!("{}{}{}", l_str, sym, r_str)
         }
         Expr::Paren(inner) => format!("({})", expr_to_rust(&inner.node, ctx, consts, opts)),
+        // mul_div_{floor,ceil}_u128 are u128-typed helpers (the intermediate
+        // `a * b` can overflow u64 even when both operands are u64-bounded).
+        // Inside arbitrary expression contexts (`requires` / `ensures` /
+        // `effect` RHS) the u128 width is intentional — the spec author
+        // may compare against a u128 literal (e.g. percolator's `…
+        // mul_div_floor(...) <= 100000000000000000000`). The let-binding
+        // emit site (see `HandlerClause::Let` handler below) narrows back
+        // to U64 explicitly when the spec writes `let X = mul_div_*(…)`,
+        // because the binding's spec-declared type is U64 and downstream
+        // U64 uses (e.g. `total - X`) need to typecheck.
         Expr::MulDivFloor { a, b, d } => format!(
             "mul_div_floor_u128({}, {}, {})",
             render_helper_arg(&a.node, ctx, consts, opts),
@@ -1089,6 +1099,21 @@ fn rust_infer_kind(env: &TypeEnv, e: &Expr) -> Kind {
         Expr::Paren(inner) => rust_infer_kind(env, &inner.node),
         Expr::Old(inner) => rust_infer_kind(env, &inner.node),
         _ => env.infer(e),
+    }
+}
+
+/// `true` iff `e` is a `mul_div_floor` / `mul_div_ceil` call, possibly
+/// wrapped in `Paren` and/or `Old`. Mirrors the peel pattern in
+/// `rust_infer_kind` above so the let-binding narrow gate stays in
+/// lock-step — `let X = (mul_div_floor(...))` and `let X =
+/// old(mul_div_floor(...))` both want the same narrowing as the bare
+/// form.
+fn is_mul_div_let_rhs(e: &Expr) -> bool {
+    match e {
+        Expr::MulDivFloor { .. } | Expr::MulDivCeil { .. } => true,
+        Expr::Paren(inner) => is_mul_div_let_rhs(&inner.node),
+        Expr::Old(inner) => is_mul_div_let_rhs(&inner.node),
+        _ => false,
     }
 }
 
@@ -3554,10 +3579,30 @@ fn adapt_handler(h: &a::HandlerDecl, consts: ConstTable, env: &TypeEnv) -> Parse
                 handler.modifies = Some(fs.clone());
             }
             a::HandlerClause::Let { name, value } => {
+                let rust = expr_to_rust(&value.node, Ctx::Guard, consts, opts_native(env));
+                // Narrow `let X = mul_div_*(...)` to U64 at the binding
+                // site — the spec-level operation is U64 → U64 but the
+                // u128 helper is used for intermediate `a * b` width.
+                // Without this, the canonical `let fee =
+                // mul_div_floor(total, fee_bps, BPS); let to_provider =
+                // total - fee` lowers to `u64 - u128`, which `cargo
+                // build` rejects. Wider arbitrary-expression contexts
+                // (`requires X mul_div_floor(...) <= U128_LIT …`) keep
+                // the u128 width via the `expr_to_rust` rendering above.
+                //
+                // `is_mul_div_let_rhs` peels `Paren` / `Old` wrappers so
+                // `let X = (mul_div_floor(...))` and `let X =
+                // old(mul_div_floor(...))` get the same narrowing as the
+                // bare form — matches the precedent in `rust_infer_kind`.
+                let rust = if is_mul_div_let_rhs(&value.node) {
+                    format!("({}) as u64", rust)
+                } else {
+                    rust
+                };
                 handler.let_bindings.push((
                     name.clone(),
                     expr_to_lean(&value.node, Ctx::Guard, consts, env),
-                    expr_to_rust(&value.node, Ctx::Guard, consts, opts_native(env)),
+                    rust,
                 ));
             }
             a::HandlerClause::Effect(blocks) => {
@@ -5240,6 +5285,137 @@ handler noop (amt : U64) {
         assert!(
             h.accounts.is_empty(),
             "noop handler should stay account-less"
+        );
+    }
+
+    /// `expr_to_rust` must render `mul_div_floor` / `mul_div_ceil` with
+    /// an `as u64` narrowing cast — the helpers return `u128` (the
+    /// intermediate `a * b` can overflow u64), but the spec-level
+    /// operation is U64 → U64. Without the cast, the canonical
+    /// `let fee = mul_div_floor(total, fee_bps, BPS); let to_provider =
+    /// total - fee` lowers to `u64 - u128`, which rejects at
+    /// `cargo build`.
+    #[test]
+    fn mul_div_floor_narrows_to_u64_at_call_site() {
+        let src = r#"spec FeeMath
+program_id "11111111111111111111111111111111"
+
+const BPS_DENOMINATOR = 10_000
+
+type State
+  | Active of { total_collected : U64 }
+
+type Error
+  | MathOverflow
+
+handler accept (total : U64) (fee_bps : U64) : State.Active -> State.Active {
+  permissionless
+  let fee = mul_div_floor(total, fee_bps, BPS_DENOMINATOR)
+  let to_provider = total - fee
+  effect { Active.total_collected += fee }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = spec
+            .handlers
+            .iter()
+            .find(|h| h.name == "accept")
+            .expect("accept handler");
+
+        // Find the `fee` binding's rendered RHS.
+        let (_, _, fee_rhs) = h
+            .let_bindings
+            .iter()
+            .find(|(name, _, _)| name == "fee")
+            .expect("fee binding");
+
+        assert!(
+            fee_rhs.contains("mul_div_floor_u128"),
+            "rendered RHS should still call the u128 helper for the intermediate width; got: {fee_rhs}"
+        );
+        assert!(
+            fee_rhs.contains("as u64"),
+            "rendered RHS must narrow back to u64 so downstream u64 uses (e.g. `total - fee`) typecheck; got: {fee_rhs}"
+        );
+    }
+
+    /// Same contract for `mul_div_ceil`.
+    #[test]
+    fn mul_div_ceil_narrows_to_u64_at_call_site() {
+        let src = r#"spec FeeMath
+program_id "11111111111111111111111111111111"
+
+const BPS_DENOMINATOR = 10_000
+
+type State
+  | Active of { total_collected : U64 }
+
+type Error
+  | MathOverflow
+
+handler accept (total : U64) (fee_bps : U64) : State.Active -> State.Active {
+  permissionless
+  let fee = mul_div_ceil(total, fee_bps, BPS_DENOMINATOR)
+  let to_provider = total - fee
+  effect { Active.total_collected += fee }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = spec
+            .handlers
+            .iter()
+            .find(|h| h.name == "accept")
+            .expect("accept handler");
+        let (_, _, fee_rhs) = h
+            .let_bindings
+            .iter()
+            .find(|(name, _, _)| name == "fee")
+            .expect("fee binding");
+        assert!(
+            fee_rhs.contains("mul_div_ceil_u128") && fee_rhs.contains("as u64"),
+            "ceil variant must narrow too; got: {fee_rhs}"
+        );
+    }
+
+    /// The let-binding narrow gate peels through `Paren` wrappers so the
+    /// author-written `let X = (mul_div_floor(...))` shape gets the same
+    /// narrowing as the bare form. Mirrors the `rust_infer_kind` peel
+    /// precedent — without it, a parenthesised RHS would silently keep
+    /// the u128 width and re-trigger the original `u64 - u128` mismatch.
+    #[test]
+    fn mul_div_in_paren_let_rhs_still_narrows_to_u64() {
+        let src = r#"spec FeeMath
+program_id "11111111111111111111111111111111"
+
+const BPS_DENOMINATOR = 10_000
+
+type State
+  | Active of { total_collected : U64 }
+
+type Error
+  | MathOverflow
+
+handler accept (total : U64) (fee_bps : U64) : State.Active -> State.Active {
+  permissionless
+  let fee = (mul_div_floor(total, fee_bps, BPS_DENOMINATOR))
+  let to_provider = total - fee
+  effect { Active.total_collected += fee }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let h = spec
+            .handlers
+            .iter()
+            .find(|h| h.name == "accept")
+            .expect("accept handler");
+        let (_, _, fee_rhs) = h
+            .let_bindings
+            .iter()
+            .find(|(name, _, _)| name == "fee")
+            .expect("fee binding");
+        assert!(
+            fee_rhs.contains("mul_div_floor_u128") && fee_rhs.contains("as u64"),
+            "parenthesised mul_div RHS must still narrow; got: {fee_rhs}"
         );
     }
 }


### PR DESCRIPTION
> Continuing from PR #45 and PR #46 — one more codegen edge surfaced while running v2.29.2 against our [tendr.bid](https://github.com/0xharp/tender) Anchor program. Thank you again for the speed on those prior reviews; the spec-first flow continues to be a real pleasure to work with.

## The fix

`mul_div_floor` / `mul_div_ceil` lower to `mul_div_{floor,ceil}_u128` in `chumsky_adapter::expr_to_rust` — the helpers return u128 because the intermediate `a * b` can overflow u64 even with u64-bounded operands. But the spec-level operation is U64 → U64 → U64 → U64, so any downstream U64 use of a `let X = mul_div_*(...)` binding fails to compile:

```
error[E0308]: mismatched types
   --> programs/.../accept_milestone.rs:N:M
    |
  N |         let to_provider = total - fee;
    |                                   ^^^ expected `u64`, found `u128`
```

The canonical failing shape is the standard fee-math pattern:

```
let fee = mul_div_floor(total, fee_bps, BPS_DENOMINATOR)
let to_provider = total - fee
```

The fix narrows the binding at the `HandlerClause::Let` parse site when the RHS is a `mul_div_*` call — the rendered RHS gets wrapped as `(...) as u64`. Other contexts (`requires` / `ensures` / `effect` RHS) keep the u128 width on purpose: the spec author may legitimately compare against a u128 literal, as the bundled `percolator` example does:

```
requires mul_div_floor(size_q, exec_price, POS_SCALE) <= MAX_ACCOUNT_NOTIONAL
```

where `MAX_ACCOUNT_NOTIONAL` is `100_000_000_000_000_000_000` (= 1e20, wider than `u64::MAX`). An unconditional narrow at the `expr_to_rust` site would reject that constant — gating on let-context preserves the existing path.

The RHS probe (`is_mul_div_let_rhs`) peels `Expr::Paren` and `Expr::Old` wrappers recursively — mirrors the precedent in `rust_infer_kind` already in the same file, so the author-written `let X = (mul_div_floor(...))` and `let X = old(mul_div_floor(...))` get the same narrowing as the bare form.

The cast is intended to be safe under the spec author's intent: writing `let X = mul_div_*(...)` declares X as U64-typed; if the actual result can exceed U64, the spec needs an explicit `requires` guard upstream of the binding, not a wider binding type.

## What changed

| File | Change |
|---|---|
| `crates/qedgen/src/chumsky_adapter.rs` | (a) Comment-only update to `expr_to_rust` MulDiv arms explaining why narrowing lives at the let-binding site, not here. (b) New helper `is_mul_div_let_rhs(&Expr) -> bool` that peels `Paren`/`Old` recursively, mirroring `rust_infer_kind`. (c) `HandlerClause::Let` parse handler: wrap the rendered RHS as `(...) as u64` when `is_mul_div_let_rhs(&value.node)`. (d) Three new tests in `mod tests` — `mul_div_floor_narrows_to_u64_at_call_site`, `mul_div_ceil_narrows_to_u64_at_call_site`, `mul_div_in_paren_let_rhs_still_narrows_to_u64` — each asserts the rendered RHS still calls the u128 helper internally AND carries the outer `as u64` cast. |

Single file, +63 / -5 lines of real change (most of the diff is the three test specs).

## Validation

- `cargo test --bin qedgen mul_div_` — 4 passed, 0 failed (three new tests + the existing `chumsky_parser::tests::parses_mul_div_floor`)
- `cargo test --bin qedgen` — 948 passed, 0 failed, 1 pre-existing ignored
- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — clean
- `bash scripts/check-lake-build.sh --strict` (lake-build workflow, manual dispatch on this branch): success in 5m 2s — Lean side unaffected.
- Bundled `percolator` example byte-identity vs upstream `main` codegen — unchanged. Its only `mul_div_floor` reference is in a `requires` clause (line 208 of `percolator.qedspec`), not a let-binding, so the codegen path this PR touches doesn't fire on it.

## Things deliberately NOT included

- **A `let X : U64 = mul_div_*(...)` typed-let-binding DSL change.** Would let the spec author declare the narrowing type explicitly instead of relying on the AST-shape probe here. That's a real DSL extension (parser + AST + lowering) and felt like a heavier design call than this surface, so I've left it out of scope here — happy to be told that's the wrong call.
- **Bundled-example regen.** Not needed for this PR — the only bundled spec using `mul_div_*` is percolator, and its single use is in a `requires` clause (not a let-binding), so its emit is byte-identical to upstream `main`.

Would love your read on whether the framing here makes sense — happy to split, squash, or rework any of it. If the AST-shape gate is too narrow / too wide for the shape you're aiming for, or if any of this doesn't match the design intent, please feel free to push back. Happy to close the PR if my understanding is wrong or the changes are incorrect.

Thank you again — really appreciate the time you take on each review.