### PR TITLE
fix(codegen): State representation via `pragma state_repr = adt`, not the WrongState error

### DIFF
--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -762,7 +762,7 @@ pub fn is_multi_variant_adt_with_field_in_variant(spec: &ParsedSpec, field: &str
     if acct.variants.len() <= 1 {
         return false;
     }
-    if !spec.error_codes.iter().any(|c| c == "WrongState") {
+    if !spec.state_repr_is_adt() {
         return false;
     }
     acct.variants
@@ -1305,6 +1305,22 @@ impl ParsedSpec {
     /// Quasar/Anchor (the default). Single source of truth.
     pub fn is_assembly_target(&self) -> bool {
         self.has_pragma("sbpf")
+    }
+
+    /// State-representation opt-in: `pragma state_repr = adt` present → the
+    /// multi-variant State lowers as a real `inductive State` (Lean) /
+    /// wrapper-struct + inner-enum (Anchor Rust); absent → the default
+    /// flat `structure State` + `status` discriminant. Single source of
+    /// truth for the flat-vs-ADT choice across all four backends.
+    ///
+    /// Replaces the pre-v2.33 footgun where the representation was keyed
+    /// on whether the spec happened to declare a `WrongState` error
+    /// variant — an incidental Error-type name silently flipped the
+    /// State shape (and which proofs auto-discharged). `WrongState`
+    /// keeps its *other* role (the error returned on a variant-mismatch
+    /// fallthrough); only the representation signal moved here.
+    pub fn state_repr_is_adt(&self) -> bool {
+        self.pragma_value("state_repr") == Some("adt")
     }
 
     /// v2.24 §S1b — look up a `pragma <key> = <value>` assignment.
@@ -2850,6 +2866,36 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
         }
         lhs.to_string()
     };
+
+    // v2.33: `pragma state_repr = adt` selects the inductive multi-variant
+    // State representation, whose generated transitions return
+    // `Err(WrongState)` on a variant-mismatch fallthrough. Without that
+    // error variant declared, the emitted Rust references an undeclared
+    // symbol and fails to compile. Before v2.33 the two were coupled —
+    // declaring `WrongState` was *itself* the ADT opt-in — so this gap
+    // could not arise; the explicit pragma makes it possible, hence the
+    // lint. (The failure is loud at `cargo check`, not silent; this just
+    // surfaces it at spec-check time with a clear fix.)
+    if spec.state_repr_is_adt()
+        && spec
+            .account_types
+            .first()
+            .map(|a| a.variants.len() > 1)
+            .unwrap_or(false)
+        && !spec.error_codes.iter().any(|c| c == "WrongState")
+    {
+        warnings.push(CompletenessWarning {
+            rule: "adt_state_missing_wrong_state".to_string(),
+            severity: Severity::Warning,
+            priority: 2,
+            message: "`pragma state_repr = adt` is set but no `WrongState` error is declared — the inductive transitions return `Err(WrongState)` on a variant-mismatch fallthrough, which won't compile".to_string(),
+            subject: None,
+            fix: "Add `WrongState` to `type Error`, or drop `pragma state_repr = adt` to use the flat State representation.".to_string(),
+            example: None,
+            counterexample: None,
+            fix_options: vec![],
+        });
+    }
 
     for op in &spec.handlers {
         // v2.7 G4: `auth X` and `permissionless` are mutually exclusive — one
@@ -7171,6 +7217,63 @@ handler deposit (amount : U64) {
             warnings.is_empty(),
             "lint must stay silent when ensures references the field, got: {:?}",
             warnings.iter().map(|w| &w.rule).collect::<Vec<_>>()
+        );
+    }
+
+    // ========================================================================
+    // v2.33 — adt_state_missing_wrong_state lint
+    // ========================================================================
+
+    /// `pragma state_repr = adt` selects the inductive representation,
+    /// whose variant-mismatch fallthrough returns `Err(WrongState)`.
+    /// Declaring the pragma without the error variant would emit
+    /// non-compiling Rust, so `check` surfaces it. Without the pragma the
+    /// same spec lowers flat and the lint stays silent.
+    #[test]
+    fn adt_state_pragma_without_wrong_state_fires() {
+        let body = r#"
+program_id "11111111111111111111111111111111"
+
+type State
+  | Uninitialized
+  | Active of { balance : U64 }
+  | Closed
+
+type Error
+  | InvalidAmount
+
+handler open (amount : U64) : State.Uninitialized -> State.Active {
+  auth owner
+  accounts { owner : signer, writable }
+  requires amount > 0 else InvalidAmount
+}"#;
+
+        // pragma set, no WrongState → fires
+        let adt = crate::chumsky_adapter::parse_str(&format!(
+            "spec Adt\npragma state_repr = adt\n{body}"
+        ))
+        .expect("parse adt");
+        let w = check_completeness(&adt);
+        let hit = w
+            .iter()
+            .find(|w| w.rule == "adt_state_missing_wrong_state")
+            .unwrap_or_else(|| {
+                panic!(
+                    "lint must fire; got: {:?}",
+                    w.iter().map(|w| &w.rule).collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(hit.severity, Severity::Warning);
+        assert_eq!(hit.priority, 2);
+
+        // no pragma (flat) → silent even without WrongState
+        let flat =
+            crate::chumsky_adapter::parse_str(&format!("spec Flat\n{body}")).expect("parse flat");
+        assert!(
+            !check_completeness(&flat)
+                .iter()
+                .any(|w| w.rule == "adt_state_missing_wrong_state"),
+            "flat specs don't need WrongState; lint must stay silent"
         );
     }
 

--- a/crates/qedgen/src/codegen_shared.rs
+++ b/crates/qedgen/src/codegen_shared.rs
@@ -1361,8 +1361,7 @@ pub fn is_multi_variant_adt_state_pub(spec: &ParsedSpec) -> bool {
 }
 
 fn is_multi_variant_adt_state(spec: &ParsedSpec) -> bool {
-    let has_wrong_state = spec.error_codes.iter().any(|c| c == "WrongState");
-    has_wrong_state
+    spec.state_repr_is_adt()
         && spec.account_types.len() == 1
         && spec
             .account_types

--- a/crates/qedgen/src/lean_gen_mir.rs
+++ b/crates/qedgen/src/lean_gen_mir.rs
@@ -105,16 +105,15 @@ fn is_multi_account(mir: &Mir) -> bool {
     mir.account_states.len() > 1
 }
 
-/// v2.24 §S5 — true iff the single-account spec uses the
-/// multi-variant ADT shape (real `inductive State` with per-variant
-/// payload). Mirrors `lean_gen::is_multi_variant_adt_state`:
-///   * declares the `WrongState` error (the migration signal that
-///     pre-v2.24 flat-state specs lack);
+/// True iff the single-account spec opts into the multi-variant ADT
+/// shape (real `inductive State` with per-variant payload):
+///   * declares `pragma state_repr = adt` (lifted to `Mir::adt_state` via
+///     `ParsedSpec::state_repr_is_adt`) — the explicit opt-in that
+///     replaced the pre-v2.33 `WrongState`-error footgun;
 ///   * has ≥ 2 state variants;
 ///   * is not indexed (Map / record fields route elsewhere).
 fn is_multi_variant_adt(mir: &Mir) -> bool {
-    let has_wrong_state = mir.errors.variants.iter().any(|e| e == "WrongState");
-    has_wrong_state && mir.state.variants.len() > 1 && !is_indexed(mir)
+    mir.adt_state && mir.state.variants.len() > 1 && !is_indexed(mir)
 }
 
 // ----------------------------------------------------------------------
@@ -2234,6 +2233,7 @@ fn scope_mir_to_account(mir: &Mir, acct: &crate::mir::AccountStateMir) -> Mir {
         environments: mir.environments.clone(),
         records: mir.records.clone(),
         is_assembly: mir.is_assembly,
+        adt_state: mir.adt_state,
     }
 }
 
@@ -2569,7 +2569,11 @@ fn emit_lifecycle_marker(out: &mut String, mir: &Mir) {
     for s in states {
         out.push_str(&format!("  | {}\n", safe_name(s)));
     }
-    out.push_str("  deriving Repr, DecidableEq, BEq\n\n");
+    // `Inhabited` so the flat `State` (which carries a `status : Status`
+    // field) can itself derive `Inhabited` — required by the polymorphic
+    // CPI ensures-axioms (`{State} [Inhabited State] …`). Harmless for
+    // specs without CPI composition.
+    out.push_str("  deriving Repr, DecidableEq, BEq, Inhabited\n\n");
 }
 
 /// Emit one transition function per handler. Mirrors
@@ -3635,8 +3639,9 @@ fn emit_frame_conditions_adt(out: &mut String, mir: &Mir) {
         ));
         out.push_str("    -- todo!(): inductive-State frame condition. Statement needs\n");
         out.push_str("    -- per-pre-variant case analysis to express which payload\n");
-        out.push_str("    -- fields are preserved. Holds trivially for now.\n");
-        out.push_str("    True := by sorry\n\n");
+        out.push_str("    -- fields are preserved. Stated as `True` until that lands;\n");
+        out.push_str("    -- the honest placeholder proof is `trivial`, not `sorry`.\n");
+        out.push_str("    True := trivial\n\n");
     }
 }
 
@@ -3965,6 +3970,24 @@ fn emit_aborts_if_with_sorry(out: &mut String, mir: &Mir, sorry_form: &str) {
                     ));
                     continue;
                 }
+            } else if req_pos.is_some() {
+                // ADT path: the transition matches on the `State`
+                // variant *before* the guard `if`, so the flat
+                // `rw [if_neg]` script is ill-formed. `cases s <;>
+                // simp_all` discharges every variant uniformly: the
+                // active variant reduces via `h` (¬guard ⇒ else-branch
+                // ⇒ `none`), the other variants hit the catch-all
+                // `_ => none`. Gated on the predicate being an actual
+                // guard conjunct (`req_pos.is_some()`) — otherwise `h`
+                // wouldn't contradict the guard and the goal isn't
+                // provable, so we fall through to the `sorry`
+                // placeholder and keep the obligation honest.
+                let proof = format!(" := by\n  unfold {}\n  cases s <;> simp_all\n", trans_name);
+                out.push_str(&format!(
+                    "    (h : \u{00AC}({})) : {} s signer{} = none{}\n",
+                    r.pred.0.lean, trans_name, param_args, proof
+                ));
+                continue;
             }
             out.push_str(&format!(
                 "    (h : \u{00AC}({})) : {} s signer{} = none := {}\n\n",
@@ -4132,7 +4155,10 @@ fn emit_state_struct(out: &mut String, mir: &Mir) {
     if has_lifecycle {
         out.push_str("  status : Status\n");
     }
-    out.push_str("  deriving Repr, DecidableEq, BEq\n\n");
+    // `Inhabited` enables the polymorphic CPI ensures-axioms
+    // (`{State} [Inhabited State] …`) to apply to this state; all field
+    // types (Pubkey / Nat / Bool / Status) are themselves Inhabited.
+    out.push_str("  deriving Repr, DecidableEq, BEq, Inhabited\n\n");
 }
 
 // ----------------------------------------------------------------------
@@ -5220,6 +5246,23 @@ fn overflow_proof_script(
 
     let has_cond = !build_guard_cond_parts(mir, h).is_empty();
 
+    // With a single numeric field the post-condition is ONE proposition
+    // (`valid_<T> s'.f`), not a `∧`-chain — so `refine ⟨?_⟩` would be
+    // ill-typed (`⟨…⟩` needs an anonymous-constructor target). Emit the
+    // tuple-introducing `refine` only when there are ≥ 2 fields; with one
+    // field discharge the lone goal directly (the `simp/omega` line if it
+    // is the changed field, else `exact h_valid` for an unchanged carry).
+    let emit_body = |proof: &mut String, indent: &str| {
+        if n > 1 {
+            proof.push_str(&format!("{}refine {}\n", indent, refine_str));
+        } else if simp_goals.is_empty() {
+            proof.push_str(&format!("{}exact h_valid\n", indent));
+        }
+        for g in &simp_goals {
+            proof.push_str(&format!("{}\n", g));
+        }
+    };
+
     let mut proof = String::new();
     if has_cond {
         proof.push_str(&format!(
@@ -5227,17 +5270,11 @@ fn overflow_proof_script(
             trans_name
         ));
         proof.push_str("  · next hg =>\n    cases h\n");
-        proof.push_str(&format!("    refine {}\n", refine_str));
-        for g in &simp_goals {
-            proof.push_str(&format!("{}\n", g));
-        }
+        emit_body(&mut proof, "    ");
         proof.push_str("  · contradiction\n\n");
     } else {
         proof.push_str(&format!(" := by\n  unfold {} at h; cases h\n", trans_name));
-        proof.push_str(&format!("  refine {}\n", refine_str));
-        for g in &simp_goals {
-            proof.push_str(&format!("{}\n", g));
-        }
+        emit_body(&mut proof, "  ");
         proof.push('\n');
     }
     proof
@@ -5550,6 +5587,59 @@ mod tests {
         crate::mir::lower(&parsed)
     }
 
+    /// v2.33 — the inductive multi-variant State representation is opted
+    /// into via `pragma state_repr = adt`, decoupled from the incidental
+    /// `WrongState` error variant that keyed it pre-v2.33 (the footgun:
+    /// adding/removing a lifecycle error silently flipped flat↔ADT).
+    /// Same State shape + same `WrongState` error ⇒ flat by default,
+    /// `inductive State` only when the pragma is present.
+    #[test]
+    fn state_repr_pragma_dispatches_inductive_vs_flat() {
+        // No effect bodies → no `Variant.field`-vs-bare effect-syntax
+        // dependence; the dispatch keys only on the pragma + shape.
+        let body = "\n\
+            program_id \"11111111111111111111111111111111\"\n\
+            \n\
+            type State\n\
+            \x20 | Uninitialized\n\
+            \x20 | Active of { balance : U64 }\n\
+            \x20 | Closed\n\
+            \n\
+            type Error\n\
+            \x20 | InvalidAmount\n\
+            \x20 | WrongState\n\
+            \n\
+            handler open (amount : U64) : State.Uninitialized -> State.Active {\n\
+            \x20 auth owner\n\
+            \x20 accounts { owner : signer, writable }\n\
+            \x20 requires amount > 0 else InvalidAmount\n\
+            }\n";
+
+        let flat = crate::chumsky_adapter::parse_str(&format!("spec Flat\n{body}"))
+            .expect("parse flat spec");
+        let flat_lean = render(&crate::mir::lower(&flat));
+        assert!(
+            flat_lean.contains("structure State where"),
+            "default (no pragma) must lower to the flat struct"
+        );
+        assert!(
+            !flat_lean.contains("inductive State where"),
+            "default must NOT take the inductive ADT path"
+        );
+
+        let adt = crate::chumsky_adapter::parse_str(&format!(
+            "spec Adt\npragma state_repr = adt\n{body}"
+        ))
+        .expect("parse adt spec");
+        let adt_mir = crate::mir::lower(&adt);
+        assert!(adt_mir.adt_state, "pragma must lift to Mir::adt_state");
+        let adt_lean = render(&adt_mir);
+        assert!(
+            adt_lean.contains("inductive State where"),
+            "pragma state_repr = adt must route to render_single_account_adt"
+        );
+    }
+
     #[test]
     fn render_emits_header_namespace_state() {
         let mir = lower_fixture("examples/rust/escrow/escrow.qedspec");
@@ -5667,6 +5757,7 @@ mod tests {
             environments: vec![],
             records: vec![],
             is_assembly: false,
+            adt_state: false,
         };
         let out = render(&mir);
         assert!(
@@ -5708,6 +5799,7 @@ mod tests {
             environments: vec![],
             records: vec![],
             is_assembly: false,
+            adt_state: false,
         };
         let out = render(&mir);
         assert!(

--- a/crates/qedgen/src/mir.rs
+++ b/crates/qedgen/src/mir.rs
@@ -185,6 +185,15 @@ pub struct Mir {
     /// at the codegen call site (it is not lifted into MIR — with only one
     /// consumer there is no cross-codegen divergence for MIR to prevent).
     pub is_assembly: bool,
+    /// State-representation opt-in (`pragma state_repr = adt`, via
+    /// `ParsedSpec::state_repr_is_adt`). True → the multi-variant State
+    /// lowers as a real `inductive State` (Lean) / wrapper-struct +
+    /// inner-enum (Anchor Rust); false (default) → flat `structure
+    /// State` + `status` discriminant. Replaces the pre-v2.33 footgun
+    /// that keyed the choice on an incidental `WrongState` error
+    /// variant. `lean_gen_mir::is_multi_variant_adt` reads this; the
+    /// `ParsedSpec`-based codegens read `state_repr_is_adt()` directly.
+    pub adt_state: bool,
 }
 
 // ----------------------------------------------------------------------
@@ -1076,6 +1085,7 @@ pub fn lower(parsed: &ParsedSpec) -> Mir {
         environments: lower_environments(parsed),
         records: parsed.records.clone(),
         is_assembly: parsed.is_assembly_target(),
+        adt_state: parsed.state_repr_is_adt(),
     }
 }
 
@@ -1751,6 +1761,7 @@ mod tests {
             environments: vec![],
             records: vec![],
             is_assembly: false,
+            adt_state: false,
         };
         assert_eq!(mir.name, "Test");
         assert!(mir.handlers.is_empty());

--- a/crates/qedgen/tests/mir_snapshot.rs
+++ b/crates/qedgen/tests/mir_snapshot.rs
@@ -13,15 +13,19 @@
 //! (`UPDATE_SNAPSHOTS=1 cargo test --test mir_snapshot` writes them
 //! in place).
 //!
-//! These snapshots are NOT a byte-equivalence assertion against the
-//! legacy codegen. The legacy comparison is documented at the
-//! commit-message level:
-//!   * ADT path (bundled-stdlib-demo, cross-program-vault):
-//!     byte-identical to legacy.
-//!   * escrow-split: byte-identical post Phase 1c-9 §15
-//!     `cover_trace_proof` auto-discharge.
-//!   * Flat path (escrow): byte-identical post Phase 1c-10
-//!     flat-path emitter alignment.
+//! Path coverage across fixtures (post-v2.33, when `pragma state_repr =
+//! adt` became the explicit opt-in for the inductive multi-variant
+//! State, replacing the incidental `WrongState`-error footgun):
+//!   * Flat path (escrow, escrow-split, bundled-stdlib-demo, lending):
+//!     the default `structure State` + `status` discriminant. These
+//!     were legacy ADT byte-identity fixtures before the representation
+//!     default flipped to flat.
+//!   * ADT path (cross-program-vault): declares `pragma state_repr =
+//!     adt` — its hand-written instruction logic destructures the
+//!     inner-enum, so it is the bundled `inductive State` /
+//!     `render_single_account_adt` showcase. The dispatch itself (same
+//!     shape ⇒ flat vs ADT by pragma) is additionally unit-tested by
+//!     `lean_gen_mir::tests::state_repr_pragma_dispatches_inductive_vs_flat`.
 //!   * Indexed path (multisig): byte-identical post Phase 1e
 //!     indexed-state lowering (Mathlib + IndexedState imports,
 //!     `Map[N] T` capacity, `Function.update` collapse).

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.Spec.lean
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.Spec.lean
@@ -11,34 +11,22 @@ open QEDGen.Solana
 inductive Status where
   | Uninitialized
   | Open
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
-inductive State where
-  | Uninitialized
-  | Open (pool_balance : Nat)
-  deriving Repr, DecidableEq, BEq
-
-instance : Inhabited State := ⟨.Uninitialized⟩
-
-def State.status : State → Status
-  | .Uninitialized => .Uninitialized
-  | .Open _ => .Open
-
-def State.pool_balance : State → Nat
-  | .Uninitialized => 0
-  | .Open pool_balance => pool_balance
+structure State where
+  pool_balance : Nat
+  status : Status
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def initializeTransition (s : State) (signer : Pubkey) (initial : Nat) : Option State :=
-  match s with
-  | .Uninitialized =>
-    if initial > 0 then some (.Open initial) else none
-  | _ => none
+  if s.status = .Uninitialized ∧ initial > 0 then
+    some { s with pool_balance := initial, status := .Open }
+  else none
 
 def depositTransition (s : State) (signer : Pubkey) (amount : Nat) : Option State :=
-  match s with
-  | .Open pool_balance =>
-    if amount > 0 ∧ pool_balance + amount ≤ 18446744073709551615 then some (.Open (pool_balance + amount)) else none
-  | _ => none
+  if s.status = .Open ∧ amount > 0 ∧ s.pool_balance + amount ≤ 18446744073709551615 then
+    some { s with pool_balance := s.pool_balance + amount, status := .Open }
+  else none
 
 -- `Token.transfer` ensures #0 (from_balance): caller supplied no `state_binders` for these abstract fields; ensures not pulled into caller proof. Bind via `state_binders { from_balance = state.<field> }` to consume.
 /-- Token.transfer.ensures @ `deposit` call #0 (stance 2: discharged via imported callee proof). -/
@@ -59,21 +47,18 @@ def applyOp (s : State) (signer : Pubkey) : Operation → Option State
 -- ============================================================================
 
 theorem initialize_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (initial : Nat)
-    (h : ¬(initial > 0)) : initializeTransition s signer initial = none := by sorry
+    (h : ¬(initial > 0)) : initializeTransition s signer initial = none := by
+  unfold initializeTransition
+  rw [if_neg (fun hg => h hg.2)]
 
 theorem deposit_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (amount : Nat)
-    (h : ¬(amount > 0)) : depositTransition s signer amount = none := by sorry
+    (h : ¬(amount > 0)) : depositTransition s signer amount = none := by
+  unfold depositTransition
+  rw [if_neg (fun hg => h hg.2.1)]
 
 -- ============================================================================
 -- Frame conditions (modifies)
 -- ============================================================================
-
-theorem deposit_frame (s s' : State) (signer : Pubkey) (amount : Nat)
-    (h : depositTransition s signer amount = some s') :
-    -- todo!(): inductive-State frame condition. Statement needs
-    -- per-pre-variant case analysis to express which payload
-    -- fields are preserved. Holds trivially for now.
-    True := by sorry
 
 -- ============================================================================
 -- Overflow safety obligations (auto-generated for operations with add effects)
@@ -82,6 +67,11 @@ theorem deposit_frame (s s' : State) (signer : Pubkey) (amount : Nat)
 theorem deposit_overflow_safe (s s' : State) (signer : Pubkey) (amount : Nat)
     (h_valid : valid_u64 s.pool_balance)
     (h : depositTransition s signer amount = some s') :
-    valid_u64 s'.pool_balance := by sorry
+    valid_u64 s'.pool_balance := by
+  unfold depositTransition at h; split at h
+  · next hg =>
+    cases h
+    simp only [valid_u64, Valid.valid_u64, Valid.U64_MAX]; omega
+  · contradiction
 
 end PoolDemo

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -74,7 +74,6 @@ use anchor_lang::prelude::*;
 use crate::guards;
 use qedgen_macros::qed;
 use crate::errors::*;
-use crate::state::PoolDemoAccountInner;
 use crate::Deposit;
 
 impl Deposit {
@@ -98,7 +97,6 @@ impl Deposit {
 use anchor_lang::prelude::*;
 use crate::guards;
 use qedgen_macros::qed;
-use crate::state::PoolDemoAccountInner;
 use crate::Initialize;
 
 impl Initialize {
@@ -164,33 +162,17 @@ pub struct Deposit {
 use anchor_lang::prelude::*;
 
 #[account]
-#[derive(InitSpace)]
 pub struct PoolDemoAccount {
-    pub inner: PoolDemoAccountInner,
+    pub pool_balance: u64,
+    pub status: u8,
 }
 
-/// Variant-payload state for PoolDemoAccount. The Anchor wrapper above
-/// carries the account discriminator; this enum carries the
-/// state-machine variant + per-variant payload fields.
-#[derive(AnchorSerialize, AnchorDeserialize, InitSpace, Clone, Debug, PartialEq)]
-pub enum PoolDemoAccountInner {
-    Uninitialized,
-    Open {
-        pool_balance: u64,
-    },
-}
-
-impl PoolDemoAccountInner {
-    /// v2.29 Slice B accessor for `pool_balance`. Panics on variants
-/// that don't carry the field — guarded against by the
-/// per-handler lifecycle check that fires before any
-/// `requires` emission in `crate::guards`.
-    pub fn pool_balance(&self) -> &u64 {
-        match self {
-            Self::Open { pool_balance, .. } => pool_balance,
-            _ => panic!("PoolDemoAccountInner::pool_balance() called on a variant without `pool_balance`"),
-        }
-    }
+/// Program lifecycle states.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Status {
+    Uninitialized = 0,
+    Open = 1,
 }
 // ---- END GENERATED ----
 

--- a/crates/qedgen/tests/snapshots/cross-program-vault.Spec.lean
+++ b/crates/qedgen/tests/snapshots/cross-program-vault.Spec.lean
@@ -66,7 +66,9 @@ def applyOp (s : State) (signer : Pubkey) : Operation → Option State
 -- ============================================================================
 
 theorem deposit_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (amount : Nat)
-    (h : ¬(amount > 0)) : depositTransition s signer amount = none := by sorry
+    (h : ¬(amount > 0)) : depositTransition s signer amount = none := by
+  unfold depositTransition
+  cases s <;> simp_all
 
 -- ============================================================================
 -- Frame conditions (modifies)
@@ -76,8 +78,9 @@ theorem deposit_frame (s s' : State) (signer : Pubkey) (amount : Nat)
     (h : depositTransition s signer amount = some s') :
     -- todo!(): inductive-State frame condition. Statement needs
     -- per-pre-variant case analysis to express which payload
-    -- fields are preserved. Holds trivially for now.
-    True := by sorry
+    -- fields are preserved. Stated as `True` until that lands;
+    -- the honest placeholder proof is `trivial`, not `sorry`.
+    True := trivial
 
 -- ============================================================================
 -- Overflow safety obligations (auto-generated for operations with add effects)

--- a/crates/qedgen/tests/snapshots/escrow-split.Spec.lean
+++ b/crates/qedgen/tests/snapshots/escrow-split.Spec.lean
@@ -12,66 +12,31 @@ inductive Status where
   | Uninitialized
   | Open
   | Closed
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
-inductive State where
-  | Uninitialized
-  | Open (initializer : Pubkey) (taker : Pubkey) (initializer_amount : Nat) (taker_amount : Nat) (escrow_token_account : Pubkey)
-  | Closed
-  deriving Repr, DecidableEq, BEq
-
-instance : Inhabited State := ⟨.Uninitialized⟩
-
-def State.status : State → Status
-  | .Uninitialized => .Uninitialized
-  | .Open _ _ _ _ _ => .Open
-  | .Closed => .Closed
-
-def State.initializer : State → Pubkey
-  | .Uninitialized => default
-  | .Open initializer _ _ _ _ => initializer
-  | .Closed => default
-
-def State.taker : State → Pubkey
-  | .Uninitialized => default
-  | .Open _ taker _ _ _ => taker
-  | .Closed => default
-
-def State.initializer_amount : State → Nat
-  | .Uninitialized => 0
-  | .Open _ _ initializer_amount _ _ => initializer_amount
-  | .Closed => 0
-
-def State.taker_amount : State → Nat
-  | .Uninitialized => 0
-  | .Open _ _ _ taker_amount _ => taker_amount
-  | .Closed => 0
-
-def State.escrow_token_account : State → Pubkey
-  | .Uninitialized => default
-  | .Open _ _ _ _ escrow_token_account => escrow_token_account
-  | .Closed => default
+structure State where
+  initializer : Pubkey
+  taker : Pubkey
+  initializer_amount : Nat
+  taker_amount : Nat
+  escrow_token_account : Pubkey
+  status : Status
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def cancelTransition (s : State) (signer : Pubkey) : Option State :=
-  match s with
-  | .Open initializer taker initializer_amount taker_amount escrow_token_account =>
-    if signer = initializer then some (.Closed) else none
-  | _ => none
+  if signer = s.initializer ∧ s.status = .Open then
+    some { s with status := .Closed }
+  else none
 
 def exchangeTransition (s : State) (signer : Pubkey) : Option State :=
-  match s with
-  | .Open initializer taker initializer_amount taker_amount escrow_token_account =>
-    if signer = taker then some (.Closed) else none
-  | _ => none
+  if signer = s.taker ∧ s.status = .Open then
+    some { s with status := .Closed }
+  else none
 
 def initializeTransition (s : State) (signer : Pubkey) (deposit_amount : Nat) (receive_amount : Nat) : Option State :=
-  -- todo!(): post-variant `Open` has unconstrained field(s) not derivable from spec: taker, escrow_token_account
-  -- Using type defaults; add effects or handler params to constrain these.
-  match s with
-  | .Uninitialized =>
-    let initializer := signer
-    if deposit_amount > 0 ∧ receive_amount > 0 then some (.Open initializer default deposit_amount receive_amount default) else none
-  | _ => none
+  if signer = s.initializer ∧ s.status = .Uninitialized ∧ deposit_amount > 0 ∧ receive_amount > 0 then
+    some { s with initializer_amount := deposit_amount, taker_amount := receive_amount, status := .Open }
+  else none
 
 -- `Token.transfer` ensures #0 (from_balance): caller supplied no `state_binders` for these abstract fields; ensures not pulled into caller proof. Bind via `state_binders { from_balance = state.<field> }` to consume.
 -- `Token.transfer` ensures #1 (to_balance): caller supplied no `state_binders` for these abstract fields; ensures not pulled into caller proof. Bind via `state_binders { to_balance = state.<field> }` to consume.
@@ -105,7 +70,9 @@ def applyOp (s : State) (signer : Pubkey) : Operation → Option State
 -- ============================================================================
 
 theorem initialize_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (deposit_amount : Nat) (receive_amount : Nat)
-    (h : ¬(deposit_amount > 0 ∧ receive_amount > 0)) : initializeTransition s signer deposit_amount receive_amount = none := by sorry
+    (h : ¬(deposit_amount > 0 ∧ receive_amount > 0)) : initializeTransition s signer deposit_amount receive_amount = none := by
+  unfold initializeTransition
+  rw [if_neg (fun hg => h ⟨hg.2.2.1, hg.2.2.2⟩)]
 
 -- ============================================================================
 -- Cover properties — reachability (existential proofs)
@@ -116,8 +83,8 @@ theorem cover_happy_path : ∃ (s0 : State) (signer : Pubkey),
     ∃ (v0_0 : Nat) (v0_1 : Nat), ∃ (s1 : State), initializeTransition s0 signer v0_0 v0_1 = some s1 ∧
 exchangeTransition s1 signer ≠ none := by
   let pk : Pubkey := ⟨0, 0, 0, 0⟩
-  let s0 : State := (.Uninitialized : State)
-  let s1 : State := (.Open pk pk 1 1 pk : State)
+  let s0 : State := ⟨pk, pk, 0, 0, pk, .Uninitialized⟩
+  let s1 : State := ⟨pk, pk, 1, 1, pk, .Open⟩
   exact ⟨s0, pk, 1, 1, s1, by decide, by decide⟩
 
 /-- cancel_path — trace [initialize, cancel] is reachable. -/
@@ -125,8 +92,8 @@ theorem cover_cancel_path : ∃ (s0 : State) (signer : Pubkey),
     ∃ (v0_0 : Nat) (v0_1 : Nat), ∃ (s1 : State), initializeTransition s0 signer v0_0 v0_1 = some s1 ∧
 cancelTransition s1 signer ≠ none := by
   let pk : Pubkey := ⟨0, 0, 0, 0⟩
-  let s0 : State := (.Uninitialized : State)
-  let s1 : State := (.Open pk pk 1 1 pk : State)
+  let s0 : State := ⟨pk, pk, 0, 0, pk, .Uninitialized⟩
+  let s1 : State := ⟨pk, pk, 1, 1, pk, .Open⟩
   exact ⟨s0, pk, 1, 1, s1, by decide, by decide⟩
 
 -- ============================================================================
@@ -142,6 +109,14 @@ def applyOps (s : State) (signer : Pubkey) : List Operation → Option State
 /-- escrow_settles — from Open leads to Closed within 1 steps via [exchange, cancel]. -/
 theorem liveness_escrow_settles (s : State) (signer : Pubkey)
     (h : s.status = .Open) :
-    ∃ ops, ops.length ≤ 1 ∧ ∀ s', applyOps s signer ops = some s' → s'.status = .Closed := by sorry
+    ∃ ops, ops.length ≤ 1 ∧ ∀ s', applyOps s signer ops = some s' → s'.status = .Closed := by
+  refine ⟨[.exchange], by decide, fun s' h_apply => ?_⟩
+  simp only [applyOps, applyOp, exchangeTransition] at h_apply
+  split at h_apply
+  · next heq =>
+    split at heq
+    · next hg => simp at heq h_apply; subst heq; subst h_apply; rfl
+    · simp at heq
+  · simp at h_apply
 
 end Escrow

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -32,7 +32,6 @@ pub enum EscrowError {
     WrongState = 3,
     InvalidLifecycle = 4,
     MathOverflow = 5,
-    InvalidPda = 6,
 }
 // ---- END GENERATED ----
 
@@ -75,36 +74,24 @@ use crate::*;
 /// Guards for `cancel`.  
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn cancel<'info>(ctx: &mut Cancel<'info>) -> Result<()> {
-    // lifecycle: require inner == Open
-    if !matches!(ctx.escrow.inner, EscrowAccountInner::Open { .. }) { return Err(crate::errors::EscrowError::InvalidLifecycle.into()); }
-    // auth: variant payload Open.initializer == ctx.initializer.key()
-    let EscrowAccountInner::Open { initializer: auth_field, .. } = &ctx.escrow.inner
-    else { return Err(EscrowError::InvalidLifecycle.into()); };
-    if auth_field != &ctx.initializer.key() { return Err(EscrowError::Unauthorized.into()); }
+    // lifecycle: require status == Open
+    if ctx.escrow.status != Status::Open as u8 { return Err(crate::errors::EscrowError::InvalidLifecycle.into()); }
     // authority: ctx.escrow_ta.owner != ctx.escrow.key()
     if ctx.escrow_ta.owner != ctx.escrow.key() { return Err(EscrowError::Unauthorized.into()); }
+    // lifecycle: status := Closed
+    ctx.escrow.status = Status::Closed as u8;
     Ok(())
 }
 
 /// Guards for `exchange`.  
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn exchange<'info>(ctx: &mut Exchange<'info>) -> Result<()> {
-    // lifecycle: require inner == Open
-    if !matches!(ctx.escrow.inner, EscrowAccountInner::Open { .. }) { return Err(crate::errors::EscrowError::InvalidLifecycle.into()); }
-    // auth: variant payload Open.taker == ctx.taker.key()
-    let EscrowAccountInner::Open { taker: auth_field, .. } = &ctx.escrow.inner
-    else { return Err(EscrowError::InvalidLifecycle.into()); };
-    if auth_field != &ctx.taker.key() { return Err(EscrowError::Unauthorized.into()); }
-    // R28 PDA check: ctx.escrow matches its declared seeds (Anchor)
-    {
-        let __seeds: &[&[u8]] = &[b"escrow", ctx.escrow.inner.initializer().as_ref(), &[ctx.escrow.bump]];
-        let __expected = anchor_lang::solana_program::pubkey::Pubkey::create_program_address(__seeds, &crate::ID).map_err(|_| EscrowError::InvalidPda)?;
-        if ctx.escrow.key() != __expected {
-            return Err(EscrowError::InvalidPda.into());
-        }
-    }
+    // lifecycle: require status == Open
+    if ctx.escrow.status != Status::Open as u8 { return Err(crate::errors::EscrowError::InvalidLifecycle.into()); }
     // authority: ctx.escrow_ta.owner != ctx.escrow.key()
     if ctx.escrow_ta.owner != ctx.escrow.key() { return Err(EscrowError::Unauthorized.into()); }
+    // lifecycle: status := Closed
+    ctx.escrow.status = Status::Closed as u8;
     Ok(())
 }
 
@@ -115,6 +102,8 @@ pub fn initialize<'info>(ctx: &mut Initialize<'info>, deposit_amount: u64, recei
     if ctx.escrow_ta.owner != ctx.escrow.key() { return Err(EscrowError::Unauthorized.into()); }
     // requires: deposit_amount > 0 ∧ receive_amount > 0
     if !((deposit_amount > 0) && (receive_amount > 0)) { return Err(EscrowError::InvalidAmount.into()); }
+    // lifecycle: status := Open
+    ctx.escrow.status = Status::Open as u8;
     Ok(())
 }
 
@@ -130,18 +119,14 @@ pub fn initialize<'info>(ctx: &mut Initialize<'info>, deposit_amount: u64, recei
 use anchor_lang::prelude::*;
 use crate::guards;
 use qedgen_macros::qed;
-use crate::errors::*;
-use crate::state::EscrowAccountInner;
 use crate::{Cancel, CancelBumps};
 
 impl<'info> Cancel<'info> {
-    #[qed(verified, spec = "..", handler = "cancel", hash = "3b4dcd18c74f53c1", spec_hash = "030f42b60ac489f1")]
+    #[qed(verified, spec = "..", handler = "cancel", hash = "424451424ac67012", spec_hash = "030f42b60ac489f1")]
     #[inline(always)]
     pub fn handler(&mut self, bumps: &CancelBumps) -> Result<()> {
         guards::cancel(self)?;
         let _ = bumps;
-        if !matches!(self.escrow.inner, EscrowAccountInner::Open { .. }) { return Err(EscrowError::WrongState.into()); }
-        self.escrow.inner = EscrowAccountInner::Closed;
         // Spec: emit!(EscrowCancelled)
         // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
         {
@@ -152,7 +137,7 @@ impl<'info> Cancel<'info> {
                 authority: self.escrow.to_account_info(),
             };
             let cpi_program = self.token_program.to_account_info();
-            token::transfer(CpiContext::new(cpi_program, cpi_accounts), (*self.escrow.inner.initializer_amount()))?;
+            token::transfer(CpiContext::new(cpi_program, cpi_accounts), self.escrow.initializer_amount)?;
         }
         todo!("fill non-mechanical effects, events, transfers, calls")
     }
@@ -168,18 +153,14 @@ impl<'info> Cancel<'info> {
 use anchor_lang::prelude::*;
 use crate::guards;
 use qedgen_macros::qed;
-use crate::errors::*;
-use crate::state::EscrowAccountInner;
 use crate::{Exchange, ExchangeBumps};
 
 impl<'info> Exchange<'info> {
-    #[qed(verified, spec = "..", handler = "exchange", hash = "5c5eee4269d66f4d", spec_hash = "b3781c2e64f2bf85")]
+    #[qed(verified, spec = "..", handler = "exchange", hash = "7d4afdf9da9f4dcb", spec_hash = "b3781c2e64f2bf85")]
     #[inline(always)]
     pub fn handler(&mut self, bumps: &ExchangeBumps) -> Result<()> {
         guards::exchange(self)?;
         let _ = bumps;
-        if !matches!(self.escrow.inner, EscrowAccountInner::Open { .. }) { return Err(EscrowError::WrongState.into()); }
-        self.escrow.inner = EscrowAccountInner::Closed;
         // Spec: emit!(EscrowExchanged)
         // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
         {
@@ -190,7 +171,7 @@ impl<'info> Exchange<'info> {
                 authority: self.taker.to_account_info(),
             };
             let cpi_program = self.token_program.to_account_info();
-            token::transfer(CpiContext::new(cpi_program, cpi_accounts), (*self.escrow.inner.taker_amount()))?;
+            token::transfer(CpiContext::new(cpi_program, cpi_accounts), self.escrow.taker_amount)?;
         }
         // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
         {
@@ -201,7 +182,7 @@ impl<'info> Exchange<'info> {
                 authority: self.escrow.to_account_info(),
             };
             let cpi_program = self.token_program.to_account_info();
-            token::transfer(CpiContext::new(cpi_program, cpi_accounts), (*self.escrow.inner.initializer_amount()))?;
+            token::transfer(CpiContext::new(cpi_program, cpi_accounts), self.escrow.initializer_amount)?;
         }
         todo!("fill non-mechanical effects, events, transfers, calls")
     }
@@ -217,17 +198,16 @@ impl<'info> Exchange<'info> {
 use anchor_lang::prelude::*;
 use crate::guards;
 use qedgen_macros::qed;
-use crate::state::EscrowAccountInner;
 use crate::{Initialize, InitializeBumps};
 
 impl<'info> Initialize<'info> {
-    #[qed(verified, spec = "..", handler = "initialize", hash = "47fbbabe9a8494ba", spec_hash = "467f6506b9a3a3ba")]
+    #[qed(verified, spec = "..", handler = "initialize", hash = "06dc441f4bb69193", spec_hash = "467f6506b9a3a3ba")]
     #[inline(always)]
     pub fn handler(&mut self, deposit_amount: u64, receive_amount: u64, bumps: &InitializeBumps) -> Result<()> {
         guards::initialize(self, deposit_amount, receive_amount)?;
         let _ = bumps;
-        // Spec effect (needs fill): Open.initializer_amount set deposit_amount
-        // Spec effect (needs fill): Open.taker_amount set receive_amount
+        self.escrow.initializer_amount = deposit_amount;
+        self.escrow.taker_amount = receive_amount;
         // Spec: emit!(EscrowInitialized)
         // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
         {
@@ -294,7 +274,7 @@ use anchor_spl::token::{Token, TokenAccount};
 pub struct Cancel<'info> {
     #[account(mut)]
     pub initializer: Signer<'info>,
-    #[account(mut, seeds = [b"escrow", initializer.key().as_ref()], bump)]
+    #[account(mut, seeds = [b"escrow", initializer.key().as_ref()], bump, has_one = initializer)]
     pub escrow: Account<'info, EscrowAccount>,
     #[account(mut)]
     pub escrow_ta: Account<'info, TokenAccount>,
@@ -307,7 +287,7 @@ pub struct Cancel<'info> {
 pub struct Exchange<'info> {
     #[account(mut)]
     pub taker: Signer<'info>,
-    #[account(mut)]
+    #[account(mut, seeds = [b"escrow", escrow.initializer.as_ref()], bump, has_one = taker)]
     pub escrow: Account<'info, EscrowAccount>,
     #[account(mut)]
     pub initializer_ta: Account<'info, TokenAccount>,
@@ -322,7 +302,7 @@ pub struct Exchange<'info> {
 pub struct Initialize<'info> {
     #[account(mut)]
     pub initializer: Signer<'info>,
-    #[account(mut, seeds = [b"escrow", initializer.key().as_ref()], bump)]
+    #[account(mut, seeds = [b"escrow", initializer.key().as_ref()], bump, has_one = initializer)]
     pub escrow: Account<'info, EscrowAccount>,
     pub mint: AccountInfo<'info>,
     #[account(mut)]
@@ -339,79 +319,23 @@ pub struct Initialize<'info> {
 use anchor_lang::prelude::*;
 
 #[account]
-#[derive(InitSpace)]
 pub struct EscrowAccount {
-    pub inner: EscrowAccountInner,
+    pub initializer: Pubkey,
+    pub taker: Pubkey,
+    pub initializer_amount: u64,
+    pub taker_amount: u64,
+    pub escrow_token_account: Pubkey,
     pub bump: u8,
+    pub status: u8,
 }
 
-/// Variant-payload state for EscrowAccount. The Anchor wrapper above
-/// carries the account discriminator; this enum carries the
-/// state-machine variant + per-variant payload fields.
-#[derive(AnchorSerialize, AnchorDeserialize, InitSpace, Clone, Debug, PartialEq)]
-pub enum EscrowAccountInner {
-    Uninitialized,
-    Open {
-        initializer: Pubkey,
-        taker: Pubkey,
-        initializer_amount: u64,
-        taker_amount: u64,
-        escrow_token_account: Pubkey,
-    },
-    Closed,
-}
-
-impl EscrowAccountInner {
-    /// v2.29 Slice B accessor for `escrow_token_account`. Panics on variants
-/// that don't carry the field — guarded against by the
-/// per-handler lifecycle check that fires before any
-/// `requires` emission in `crate::guards`.
-    pub fn escrow_token_account(&self) -> &Pubkey {
-        match self {
-            Self::Open { escrow_token_account, .. } => escrow_token_account,
-            _ => panic!("EscrowAccountInner::escrow_token_account() called on a variant without `escrow_token_account`"),
-        }
-    }
-    /// v2.29 Slice B accessor for `initializer`. Panics on variants
-/// that don't carry the field — guarded against by the
-/// per-handler lifecycle check that fires before any
-/// `requires` emission in `crate::guards`.
-    pub fn initializer(&self) -> &Pubkey {
-        match self {
-            Self::Open { initializer, .. } => initializer,
-            _ => panic!("EscrowAccountInner::initializer() called on a variant without `initializer`"),
-        }
-    }
-    /// v2.29 Slice B accessor for `initializer_amount`. Panics on variants
-/// that don't carry the field — guarded against by the
-/// per-handler lifecycle check that fires before any
-/// `requires` emission in `crate::guards`.
-    pub fn initializer_amount(&self) -> &u64 {
-        match self {
-            Self::Open { initializer_amount, .. } => initializer_amount,
-            _ => panic!("EscrowAccountInner::initializer_amount() called on a variant without `initializer_amount`"),
-        }
-    }
-    /// v2.29 Slice B accessor for `taker`. Panics on variants
-/// that don't carry the field — guarded against by the
-/// per-handler lifecycle check that fires before any
-/// `requires` emission in `crate::guards`.
-    pub fn taker(&self) -> &Pubkey {
-        match self {
-            Self::Open { taker, .. } => taker,
-            _ => panic!("EscrowAccountInner::taker() called on a variant without `taker`"),
-        }
-    }
-    /// v2.29 Slice B accessor for `taker_amount`. Panics on variants
-/// that don't carry the field — guarded against by the
-/// per-handler lifecycle check that fires before any
-/// `requires` emission in `crate::guards`.
-    pub fn taker_amount(&self) -> &u64 {
-        match self {
-            Self::Open { taker_amount, .. } => taker_amount,
-            _ => panic!("EscrowAccountInner::taker_amount() called on a variant without `taker_amount`"),
-        }
-    }
+/// Program lifecycle states.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Status {
+    Uninitialized = 0,
+    Open = 1,
+    Closed = 2,
 }
 // ---- END GENERATED ----
 

--- a/crates/qedgen/tests/snapshots/escrow.Spec.lean
+++ b/crates/qedgen/tests/snapshots/escrow.Spec.lean
@@ -11,7 +11,7 @@ inductive Status where
   | Uninitialized
   | Open
   | Closed
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 structure State where
   initializer : Pubkey
@@ -21,7 +21,7 @@ structure State where
   taker_amount : Nat
   escrow_token_account : Pubkey
   status : Status
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def initializeTransition (s : State) (signer : Pubkey) (deposit_amount : Nat) (receive_amount : Nat) : Option State :=
   if signer = s.initializer ∧ s.status = .Uninitialized ∧ deposit_amount > 0 ∧ receive_amount > 0 then

--- a/crates/qedgen/tests/snapshots/lending.Spec.lean
+++ b/crates/qedgen/tests/snapshots/lending.Spec.lean
@@ -11,7 +11,7 @@ inductive PoolStatus where
   | Uninitialized
   | Active
   | Paused
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 structure PoolState where
   authority : Pubkey
@@ -19,7 +19,7 @@ structure PoolState where
   total_borrows : Nat
   interest_rate : Nat
   status : PoolStatus
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def init_poolTransition (s : PoolState) (signer : Pubkey) (rate : Nat) : Option PoolState :=
   if signer = s.authority ∧ s.status = .Uninitialized ∧ rate > 0 then
@@ -67,7 +67,7 @@ inductive LoanStatus where
   | Empty
   | Active
   | Liquidated
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 structure LoanState where
   borrower : Pubkey
@@ -75,7 +75,7 @@ structure LoanState where
   amount : Nat
   collateral : Nat
   status : LoanStatus
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def borrowTransition (s : LoanState) (signer : Pubkey) (amount : Nat) (collateral : Nat) : Option LoanState :=
   if signer = s.borrower ∧ s.status = .Empty ∧ amount > 0 ∧ collateral > 0 then

--- a/examples/rust/bundled-stdlib-demo/formal_verification/Spec.lean
+++ b/examples/rust/bundled-stdlib-demo/formal_verification/Spec.lean
@@ -11,34 +11,22 @@ open QEDGen.Solana
 inductive Status where
   | Uninitialized
   | Open
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
-inductive State where
-  | Uninitialized
-  | Open (pool_balance : Nat)
-  deriving Repr, DecidableEq, BEq
-
-instance : Inhabited State := ⟨.Uninitialized⟩
-
-def State.status : State → Status
-  | .Uninitialized => .Uninitialized
-  | .Open _ => .Open
-
-def State.pool_balance : State → Nat
-  | .Uninitialized => 0
-  | .Open pool_balance => pool_balance
+structure State where
+  pool_balance : Nat
+  status : Status
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def initializeTransition (s : State) (signer : Pubkey) (initial : Nat) : Option State :=
-  match s with
-  | .Uninitialized =>
-    if initial > 0 then some (.Open initial) else none
-  | _ => none
+  if s.status = .Uninitialized ∧ initial > 0 then
+    some { s with pool_balance := initial, status := .Open }
+  else none
 
 def depositTransition (s : State) (signer : Pubkey) (amount : Nat) : Option State :=
-  match s with
-  | .Open pool_balance =>
-    if amount > 0 ∧ pool_balance + amount ≤ 18446744073709551615 then some (.Open (pool_balance + amount)) else none
-  | _ => none
+  if s.status = .Open ∧ amount > 0 ∧ s.pool_balance + amount ≤ 18446744073709551615 then
+    some { s with pool_balance := s.pool_balance + amount, status := .Open }
+  else none
 
 -- `Token.transfer` ensures #0 (from_balance): caller supplied no `state_binders` for these abstract fields; ensures not pulled into caller proof. Bind via `state_binders { from_balance = state.<field> }` to consume.
 /-- Token.transfer.ensures @ `deposit` call #0 (stance 2: discharged via imported callee proof). -/
@@ -59,21 +47,18 @@ def applyOp (s : State) (signer : Pubkey) : Operation → Option State
 -- ============================================================================
 
 theorem initialize_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (initial : Nat)
-    (h : ¬(initial > 0)) : initializeTransition s signer initial = none := by sorry
+    (h : ¬(initial > 0)) : initializeTransition s signer initial = none := by
+  unfold initializeTransition
+  rw [if_neg (fun hg => h hg.2)]
 
 theorem deposit_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (amount : Nat)
-    (h : ¬(amount > 0)) : depositTransition s signer amount = none := by sorry
+    (h : ¬(amount > 0)) : depositTransition s signer amount = none := by
+  unfold depositTransition
+  rw [if_neg (fun hg => h hg.2.1)]
 
 -- ============================================================================
 -- Frame conditions (modifies)
 -- ============================================================================
-
-theorem deposit_frame (s s' : State) (signer : Pubkey) (amount : Nat)
-    (h : depositTransition s signer amount = some s') :
-    -- todo!(): inductive-State frame condition. Statement needs
-    -- per-pre-variant case analysis to express which payload
-    -- fields are preserved. Holds trivially for now.
-    True := by sorry
 
 -- ============================================================================
 -- Overflow safety obligations (auto-generated for operations with add effects)
@@ -82,6 +67,11 @@ theorem deposit_frame (s s' : State) (signer : Pubkey) (amount : Nat)
 theorem deposit_overflow_safe (s s' : State) (signer : Pubkey) (amount : Nat)
     (h_valid : valid_u64 s.pool_balance)
     (h : depositTransition s signer amount = some s') :
-    valid_u64 s'.pool_balance := by sorry
+    valid_u64 s'.pool_balance := by
+  unfold depositTransition at h; split at h
+  · next hg =>
+    cases h
+    simp only [valid_u64, Valid.valid_u64, Valid.U64_MAX]; omega
+  · contradiction
 
 end PoolDemo

--- a/examples/rust/cross-program-vault/vault.qedspec
+++ b/examples/rust/cross-program-vault/vault.qedspec
@@ -21,6 +21,14 @@
 
 spec Vault
 
+// This example's hand-written instruction logic destructures the
+// inner-enum (`VaultAccountInner` / `acct.inner`), so it deliberately
+// uses the inductive multi-variant State representation. Before v2.33
+// that was implied by declaring the `WrongState` error; it is now
+// explicit. Vault is the bundled ADT-representation showcase — every
+// other example lowers to the default flat `structure State`.
+pragma state_repr = adt
+
 program_id "11111111111111111111111111111111"
 
 import AdminConfig from "admin_config"

--- a/examples/rust/escrow-split/formal_verification/Spec.lean
+++ b/examples/rust/escrow-split/formal_verification/Spec.lean
@@ -12,64 +12,31 @@ inductive Status where
   | Uninitialized
   | Open
   | Closed
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
-inductive State where
-  | Uninitialized
-  | Open (initializer : Pubkey) (taker : Pubkey) (initializer_amount : Nat) (taker_amount : Nat) (escrow_token_account : Pubkey)
-  | Closed
-  deriving Repr, DecidableEq, BEq
-
-def State.status : State → Status
-  | .Uninitialized => .Uninitialized
-  | .Open _ _ _ _ _ => .Open
-  | .Closed => .Closed
-
-def State.initializer : State → Pubkey
-  | .Uninitialized => default
-  | .Open initializer _ _ _ _ => initializer
-  | .Closed => default
-
-def State.taker : State → Pubkey
-  | .Uninitialized => default
-  | .Open _ taker _ _ _ => taker
-  | .Closed => default
-
-def State.initializer_amount : State → Nat
-  | .Uninitialized => 0
-  | .Open _ _ initializer_amount _ _ => initializer_amount
-  | .Closed => 0
-
-def State.taker_amount : State → Nat
-  | .Uninitialized => 0
-  | .Open _ _ _ taker_amount _ => taker_amount
-  | .Closed => 0
-
-def State.escrow_token_account : State → Pubkey
-  | .Uninitialized => default
-  | .Open _ _ _ _ escrow_token_account => escrow_token_account
-  | .Closed => default
+structure State where
+  initializer : Pubkey
+  taker : Pubkey
+  initializer_amount : Nat
+  taker_amount : Nat
+  escrow_token_account : Pubkey
+  status : Status
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def cancelTransition (s : State) (signer : Pubkey) : Option State :=
-  match s with
-  | .Open initializer taker initializer_amount taker_amount escrow_token_account =>
-    if signer = initializer then some (.Closed) else none
-  | _ => none
+  if signer = s.initializer ∧ s.status = .Open then
+    some { s with status := .Closed }
+  else none
 
 def exchangeTransition (s : State) (signer : Pubkey) : Option State :=
-  match s with
-  | .Open initializer taker initializer_amount taker_amount escrow_token_account =>
-    if signer = taker then some (.Closed) else none
-  | _ => none
+  if signer = s.taker ∧ s.status = .Open then
+    some { s with status := .Closed }
+  else none
 
 def initializeTransition (s : State) (signer : Pubkey) (deposit_amount : Nat) (receive_amount : Nat) : Option State :=
-  -- todo!(): post-variant `Open` has unconstrained field(s) not derivable from spec: taker, escrow_token_account
-  -- Using type defaults; add effects or handler params to constrain these.
-  match s with
-  | .Uninitialized =>
-    let initializer := signer
-    if deposit_amount > 0 ∧ receive_amount > 0 then some (.Open initializer default deposit_amount receive_amount default) else none
-  | _ => none
+  if signer = s.initializer ∧ s.status = .Uninitialized ∧ deposit_amount > 0 ∧ receive_amount > 0 then
+    some { s with initializer_amount := deposit_amount, taker_amount := receive_amount, status := .Open }
+  else none
 
 -- `Token.transfer` ensures #0 (from_balance): caller supplied no `state_binders` for these abstract fields; ensures not pulled into caller proof. Bind via `state_binders { from_balance = state.<field> }` to consume.
 -- `Token.transfer` ensures #1 (to_balance): caller supplied no `state_binders` for these abstract fields; ensures not pulled into caller proof. Bind via `state_binders { to_balance = state.<field> }` to consume.
@@ -103,7 +70,9 @@ def applyOp (s : State) (signer : Pubkey) : Operation → Option State
 -- ============================================================================
 
 theorem initialize_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (deposit_amount : Nat) (receive_amount : Nat)
-    (h : ¬(deposit_amount > 0 ∧ receive_amount > 0)) : initializeTransition s signer deposit_amount receive_amount = none := by sorry
+    (h : ¬(deposit_amount > 0 ∧ receive_amount > 0)) : initializeTransition s signer deposit_amount receive_amount = none := by
+  unfold initializeTransition
+  rw [if_neg (fun hg => h ⟨hg.2.2.1, hg.2.2.2⟩)]
 
 -- ============================================================================
 -- Cover properties — reachability (existential proofs)
@@ -114,8 +83,8 @@ theorem cover_happy_path : ∃ (s0 : State) (signer : Pubkey),
     ∃ (v0_0 : Nat) (v0_1 : Nat), ∃ (s1 : State), initializeTransition s0 signer v0_0 v0_1 = some s1 ∧
 exchangeTransition s1 signer ≠ none := by
   let pk : Pubkey := ⟨0, 0, 0, 0⟩
-  let s0 : State := (.Uninitialized : State)
-  let s1 : State := (.Open pk pk 1 1 pk : State)
+  let s0 : State := ⟨pk, pk, 0, 0, pk, .Uninitialized⟩
+  let s1 : State := ⟨pk, pk, 1, 1, pk, .Open⟩
   exact ⟨s0, pk, 1, 1, s1, by decide, by decide⟩
 
 /-- cancel_path — trace [initialize, cancel] is reachable. -/
@@ -123,8 +92,8 @@ theorem cover_cancel_path : ∃ (s0 : State) (signer : Pubkey),
     ∃ (v0_0 : Nat) (v0_1 : Nat), ∃ (s1 : State), initializeTransition s0 signer v0_0 v0_1 = some s1 ∧
 cancelTransition s1 signer ≠ none := by
   let pk : Pubkey := ⟨0, 0, 0, 0⟩
-  let s0 : State := (.Uninitialized : State)
-  let s1 : State := (.Open pk pk 1 1 pk : State)
+  let s0 : State := ⟨pk, pk, 0, 0, pk, .Uninitialized⟩
+  let s1 : State := ⟨pk, pk, 1, 1, pk, .Open⟩
   exact ⟨s0, pk, 1, 1, s1, by decide, by decide⟩
 
 -- ============================================================================
@@ -140,6 +109,14 @@ def applyOps (s : State) (signer : Pubkey) : List Operation → Option State
 /-- escrow_settles — from Open leads to Closed within 1 steps via [exchange, cancel]. -/
 theorem liveness_escrow_settles (s : State) (signer : Pubkey)
     (h : s.status = .Open) :
-    ∃ ops, ops.length ≤ 1 ∧ ∀ s', applyOps s signer ops = some s' → s'.status = .Closed := by sorry
+    ∃ ops, ops.length ≤ 1 ∧ ∀ s', applyOps s signer ops = some s' → s'.status = .Closed := by
+  refine ⟨[.exchange], by decide, fun s' h_apply => ?_⟩
+  simp only [applyOps, applyOp, exchangeTransition] at h_apply
+  split at h_apply
+  · next heq =>
+    split at heq
+    · next hg => simp at heq h_apply; subst heq; subst h_apply; rfl
+    · simp at heq
+  · simp at h_apply
 
 end Escrow

--- a/examples/rust/escrow/formal_verification/Spec.lean
+++ b/examples/rust/escrow/formal_verification/Spec.lean
@@ -11,69 +11,32 @@ inductive Status where
   | Uninitialized
   | Open
   | Closed
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
-inductive State where
-  | Uninitialized
-  | Open (initializer : Pubkey) (initializer_token_account : Pubkey) (taker : Pubkey) (initializer_amount : Nat) (taker_amount : Nat) (escrow_token_account : Pubkey)
-  | Closed
-  deriving Repr, DecidableEq, BEq
-
-def State.status : State → Status
-  | .Uninitialized => .Uninitialized
-  | .Open _ _ _ _ _ _ => .Open
-  | .Closed => .Closed
-
-def State.initializer : State → Pubkey
-  | .Uninitialized => default
-  | .Open initializer _ _ _ _ _ => initializer
-  | .Closed => default
-
-def State.initializer_token_account : State → Pubkey
-  | .Uninitialized => default
-  | .Open _ initializer_token_account _ _ _ _ => initializer_token_account
-  | .Closed => default
-
-def State.taker : State → Pubkey
-  | .Uninitialized => default
-  | .Open _ _ taker _ _ _ => taker
-  | .Closed => default
-
-def State.initializer_amount : State → Nat
-  | .Uninitialized => 0
-  | .Open _ _ _ initializer_amount _ _ => initializer_amount
-  | .Closed => 0
-
-def State.taker_amount : State → Nat
-  | .Uninitialized => 0
-  | .Open _ _ _ _ taker_amount _ => taker_amount
-  | .Closed => 0
-
-def State.escrow_token_account : State → Pubkey
-  | .Uninitialized => default
-  | .Open _ _ _ _ _ escrow_token_account => escrow_token_account
-  | .Closed => default
+structure State where
+  initializer : Pubkey
+  initializer_token_account : Pubkey
+  taker : Pubkey
+  initializer_amount : Nat
+  taker_amount : Nat
+  escrow_token_account : Pubkey
+  status : Status
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def initializeTransition (s : State) (signer : Pubkey) (deposit_amount : Nat) (receive_amount : Nat) : Option State :=
-  -- todo!(): post-variant `Open` has unconstrained field(s) not derivable from spec: initializer_token_account, taker, escrow_token_account
-  -- Using type defaults; add effects or handler params to constrain these.
-  match s with
-  | .Uninitialized =>
-    let initializer := signer
-    if deposit_amount > 0 ∧ receive_amount > 0 then some (.Open initializer default default deposit_amount receive_amount default) else none
-  | _ => none
+  if signer = s.initializer ∧ s.status = .Uninitialized ∧ deposit_amount > 0 ∧ receive_amount > 0 then
+    some { s with initializer_amount := deposit_amount, taker_amount := receive_amount, status := .Open }
+  else none
 
 def exchangeTransition (s : State) (signer : Pubkey) : Option State :=
-  match s with
-  | .Open initializer initializer_token_account taker initializer_amount taker_amount escrow_token_account =>
-    if signer = taker then some (.Closed) else none
-  | _ => none
+  if signer = s.taker ∧ s.status = .Open then
+    some { s with status := .Closed }
+  else none
 
 def cancelTransition (s : State) (signer : Pubkey) : Option State :=
-  match s with
-  | .Open initializer initializer_token_account taker initializer_amount taker_amount escrow_token_account =>
-    if signer = initializer then some (.Closed) else none
-  | _ => none
+  if signer = s.initializer ∧ s.status = .Open then
+    some { s with status := .Closed }
+  else none
 
 /-- initialize transfer envelope: initializer_ta → escrow_ta amount deposit_amount authority initializer.
     Verifies CPI shape (program ID, account list, discriminator).
@@ -191,7 +154,9 @@ def applyOp (s : State) (signer : Pubkey) : Operation → Option State
 -- ============================================================================
 
 theorem initialize_aborts_if_InvalidAmount (s : State) (signer : Pubkey) (deposit_amount : Nat) (receive_amount : Nat)
-    (h : ¬(deposit_amount > 0 ∧ receive_amount > 0)) : initializeTransition s signer deposit_amount receive_amount = none := by sorry
+    (h : ¬(deposit_amount > 0 ∧ receive_amount > 0)) : initializeTransition s signer deposit_amount receive_amount = none := by
+  unfold initializeTransition
+  rw [if_neg (fun hg => h ⟨hg.2.2.1, hg.2.2.2⟩)]
 
 -- ============================================================================
 -- Cover properties — reachability (existential proofs)
@@ -202,8 +167,8 @@ theorem cover_happy_path : ∃ (s0 : State) (signer : Pubkey),
     ∃ (v0_0 : Nat) (v0_1 : Nat), ∃ (s1 : State), initializeTransition s0 signer v0_0 v0_1 = some s1 ∧
 exchangeTransition s1 signer ≠ none := by
   let pk : Pubkey := ⟨0, 0, 0, 0⟩
-  let s0 : State := (.Uninitialized : State)
-  let s1 : State := (.Open pk pk pk 1 1 pk : State)
+  let s0 : State := ⟨pk, pk, pk, 0, 0, pk, .Uninitialized⟩
+  let s1 : State := ⟨pk, pk, pk, 1, 1, pk, .Open⟩
   exact ⟨s0, pk, 1, 1, s1, by decide, by decide⟩
 
 /-- cancel_path — trace [initialize, cancel] is reachable. -/
@@ -211,8 +176,8 @@ theorem cover_cancel_path : ∃ (s0 : State) (signer : Pubkey),
     ∃ (v0_0 : Nat) (v0_1 : Nat), ∃ (s1 : State), initializeTransition s0 signer v0_0 v0_1 = some s1 ∧
 cancelTransition s1 signer ≠ none := by
   let pk : Pubkey := ⟨0, 0, 0, 0⟩
-  let s0 : State := (.Uninitialized : State)
-  let s1 : State := (.Open pk pk pk 1 1 pk : State)
+  let s0 : State := ⟨pk, pk, pk, 0, 0, pk, .Uninitialized⟩
+  let s1 : State := ⟨pk, pk, pk, 1, 1, pk, .Open⟩
   exact ⟨s0, pk, 1, 1, s1, by decide, by decide⟩
 
 -- ============================================================================
@@ -228,6 +193,14 @@ def applyOps (s : State) (signer : Pubkey) : List Operation → Option State
 /-- escrow_settles — from Open leads to Closed within 1 steps via [exchange, cancel]. -/
 theorem liveness_escrow_settles (s : State) (signer : Pubkey)
     (h : s.status = .Open) :
-    ∃ ops, ops.length ≤ 1 ∧ ∀ s', applyOps s signer ops = some s' → s'.status = .Closed := by sorry
+    ∃ ops, ops.length ≤ 1 ∧ ∀ s', applyOps s signer ops = some s' → s'.status = .Closed := by
+  refine ⟨[.exchange], by decide, fun s' h_apply => ?_⟩
+  simp only [applyOps, applyOp, exchangeTransition] at h_apply
+  split at h_apply
+  · next heq =>
+    split at heq
+    · next hg => simp at heq h_apply; subst heq; subst h_apply; rfl
+    · simp at heq
+  · simp at h_apply
 
 end Escrow

--- a/examples/rust/lending/formal_verification/Spec.lean
+++ b/examples/rust/lending/formal_verification/Spec.lean
@@ -11,7 +11,7 @@ inductive PoolStatus where
   | Uninitialized
   | Active
   | Paused
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 structure PoolState where
   authority : Pubkey
@@ -19,7 +19,7 @@ structure PoolState where
   total_borrows : Nat
   interest_rate : Nat
   status : PoolStatus
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def init_poolTransition (s : PoolState) (signer : Pubkey) (rate : Nat) : Option PoolState :=
   if signer = s.authority ∧ s.status = .Uninitialized ∧ rate > 0 then
@@ -67,7 +67,7 @@ inductive LoanStatus where
   | Empty
   | Active
   | Liquidated
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 structure LoanState where
   borrower : Pubkey
@@ -75,7 +75,7 @@ structure LoanState where
   amount : Nat
   collateral : Nat
   status : LoanStatus
-  deriving Repr, DecidableEq, BEq
+  deriving Repr, DecidableEq, BEq, Inhabited
 
 def borrowTransition (s : LoanState) (signer : Pubkey) (amount : Nat) (collateral : Nat) : Option LoanState :=
   if signer = s.borrower ∧ s.status = .Empty ∧ amount > 0 ∧ collateral > 0 then

--- a/references/qedspec-dsl.md
+++ b/references/qedspec-dsl.md
@@ -1074,6 +1074,28 @@ Body whitelist for `pragma sbpf`: `const`, `pubkey`, `instruction`, `errors`.
 Core DSL items (`handler`, `type`, `property`, `invariant`, `interface`, …)
 stay at the top level.
 
+### Assignment pragmas — `pragma <key> = <value>`
+
+Scalar codegen directives that tune *how* a spec lowers, without a body:
+
+```fsharp
+pragma checked_overflow_error = MathOverflow   // error returned on a checked-add overflow
+pragma state_repr = adt                        // inductive multi-variant State (see below)
+```
+
+**`pragma state_repr = adt`** — opt a multi-variant `type State | A | B of { … } | C`
+into the inductive representation: Lean lowers it to a real `inductive State` (with
+per-variant payload + match-based transitions) and Anchor Rust to the wrapper-struct +
+inner-enum shape. **Absent (the default), a multi-variant State lowers flat** — a
+`structure State` carrying every variant's fields plus a `status : Status` discriminant.
+The flat form auto-discharges more proof obligations (abort / liveness / overflow), so
+prefer it unless you specifically want the inductive sum-type modeling.
+
+> Before v2.33 this choice was keyed implicitly on whether the spec declared a
+> `WrongState` error variant — so adding or removing a lifecycle error silently flipped
+> the State representation. The pragma makes it explicit. `WrongState` keeps its
+> independent role as the error returned on a variant-mismatch fallthrough.
+
 ## Interface declarations
 
 Contracts for programs you CPI into. Uniform surface across three tiers:


### PR DESCRIPTION
## Problem

The flat-struct vs inductive multi-variant `State` representation was keyed on whether a spec happened to declare a `WrongState` **error** variant (`is_multi_variant_adt_state` checked `error_codes.contains("WrongState")`). So adding or removing a lifecycle error silently flipped the State shape — *and* which proof obligations auto-discharge (the flat path auto-fills abort/liveness/overflow; the ADT path punts liveness+overflow to `sorry`).

Surfaced because **escrow** (no `WrongState` → flat) and **escrow-split** (has `WrongState` → ADT) are the same program but lowered to different representations purely on that incidental error name.

## Fix

Decouple representation from the error: an explicit **`pragma state_repr = adt`** opts a multi-variant State into the inductive form; **the default is flat**. One source of truth — `ParsedSpec::state_repr_is_adt()` (`pragma_value("state_repr") == Some("adt")`) lifted to `Mir::adt_state` — feeds all four backends (`lean_gen_mir` reads `mir.adt_state`; `codegen_shared` + `check.rs` read `state_repr_is_adt()`). `WrongState` keeps its **independent** role as the variant-mismatch fallthrough error; the new `adt_state_missing_wrong_state` P2 lint fires if you set the pragma without declaring it.

## Flat-path bugs this exposed (and fixes)

Routing the formerly-incidentally-ADT examples through the flat path surfaced two latent flat-path defects (no flat example had previously hit flat+overflow or flat+Token-CPI):

- flat `State` / `Status` now `deriving … , Inhabited` — required by the polymorphic CPI ensures-axioms (bundled-stdlib-demo's Token CPI);
- the single-numeric-field overflow proof no longer emits the ill-typed `refine ⟨?_⟩` for a non-conjunction goal.

The ADT abort (`cases s <;> simp_all`) + frame (`True := trivial`) proofs also landed, closing those `sorry`s on the ADT path.

## Examples

All flatten — escrow, escrow-split, bundled-stdlib-demo, lending → flat, **sorry-free, building** — **except `cross-program-vault`**, whose hand-written instruction logic destructures the inner-enum (`acct.inner`) and genuinely needs ADT. It now declares `pragma state_repr = adt` and is the bundled ADT-representation showcase.

## Coverage / validation

- In-process unit test: same State shape ⇒ flat by default, inductive only with the pragma.
- `adt_state_missing_wrong_state` lint regression-tested both directions.
- `mir_snapshot` ADT-path coverage via cross-program-vault.
- **Green:** `cargo test` (16 suites / 918 unit), `cargo fmt --check`, `cargo clippy -- -D warnings`, zero-sorry (examples), `check --regen-drift`, `check-lake-build.sh` (0 failed).

## Notes

- Anticipatory `v2.33` in comments/docs; **no version bump** in this PR (release step).
- Out of scope: ADT-path overflow + liveness proof templates remain `sorry` (only cross-program-vault's snapshot carries one; nothing zero-sorry-gated does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)