### PR TITLE
feat(qedspec): bounded `exists` + ghost variables (#67 items 2, 3)

### DIFF
--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -145,10 +145,15 @@ pub enum TopItem {
     /// `ensures` clauses can call. Lowers to a Lean `def` and inlines
     /// at Kani-harness assertion sites; Rust codegen skips it entirely
     /// (it's a verification-only construct, not part of the impl
-    /// contract). Replaces the original `ghost` proposal — the user
-    /// preferred the more honest naming, since the construct *is*
-    /// a reference implementation the real Rust impl is checked against.
+    /// contract). Distinct from `Ghost`: `ref_impl` is a *stateless* pure
+    /// function the real Rust impl is checked against, whereas a `ghost`
+    /// is *stateful* spec-only auxiliary state updated per-handler.
     RefImpl(RefImplDecl),
+    /// Issue #67 item 3 — `ghost <name> : <Ty> { init {…} on H(…) {…} }`.
+    /// Spec-only auxiliary state field: participates in invariants /
+    /// properties / `requires` / `ensures` (as `state.<name>`), updated
+    /// per-handler, omitted from the on-chain program codegen.
+    Ghost(GhostDecl),
 }
 
 /// v2.24 #1 — top-level `schema` block. Body carries a list of
@@ -334,6 +339,37 @@ pub struct RefImplDecl {
     pub params: Vec<TypedField>,
     pub return_type: TypeRef,
     pub body: Node<Expr>,
+}
+
+/// Issue #67 item 3 — `ghost <name> : <Ty> { init { <expr> } on
+/// <handler>(<params>) { <name> := <expr> } … }`. A spec-only auxiliary
+/// state field: it participates in invariants, properties and `requires`/
+/// `ensures` (referenced as `state.<name>`), is updated per-handler by its
+/// `on` clauses, but never appears in the on-chain program codegen. Scalar
+/// types only (`U64`/`U128`/`I64`/`I128`/`Bool`); a ghost over a `Map`/
+/// record is rejected at lint time.
+#[derive(Debug, Clone)]
+pub struct GhostDecl {
+    pub name: String,
+    pub doc: Option<String>,
+    pub ty: TypeRef,
+    /// Initial value — a constant expression evaluated when the State is
+    /// first constructed.
+    pub init: Node<Expr>,
+    /// Per-handler update clauses. A handler with no clause leaves the
+    /// ghost unchanged (frame condition).
+    pub updates: Vec<GhostUpdate>,
+}
+
+/// One `on <handler> { <name> := <expr> }` clause of a ghost. The named
+/// handler's parameters are in scope in the update RHS (resolved by the
+/// adapter from the handler's signature, so there's no type redeclaration
+/// to drift). `stmt` is a single assignment whose `lhs` is the ghost name
+/// and whose `rhs` may reference `state.<ghost>` and the handler params.
+#[derive(Debug, Clone)]
+pub struct GhostUpdate {
+    pub handler: String,
+    pub stmt: EffectStmt,
 }
 
 /// A type reference in the source language.

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -1218,6 +1218,12 @@ pub struct ParsedSpec {
     #[allow(dead_code)]
     pub ref_impls: Vec<ParsedRefImpl>,
 
+    /// Issue #67 item 3 — `ghost <name> : <Ty> { init {…} on H {…} }`
+    /// spec-only auxiliary state. Rendered to verification-State fields
+    /// (Lean / proptest / Kani) plus per-handler update expressions;
+    /// omitted from the on-chain program codegen entirely.
+    pub ghosts: Vec<ParsedGhost>,
+
     /// v2.27 Track B — verified-callee composition (Stance 2).
     ///
     /// For each imported interface whose provider shipped a
@@ -1293,6 +1299,31 @@ pub struct ParsedRefImpl {
     pub return_type: String,
     pub lean_body: String,
     pub rust_body: String,
+}
+
+/// Issue #67 item 3 — lowered `ghost` declaration. Pre-rendered per
+/// backend, same opaque-string discipline as `ParsedRefImpl`.
+#[derive(Debug, Clone)]
+pub struct ParsedGhost {
+    pub name: String,
+    pub doc: Option<String>,
+    /// DSL type string (`U64`, `I128`, `Bool`, …). Scalar only.
+    pub ty: String,
+    /// Initial value, rendered for each backend.
+    pub init_lean: String,
+    pub init_rust: String,
+    pub updates: Vec<ParsedGhostUpdate>,
+}
+
+/// One `on <handler>` update of a ghost. `value_*` is the *complete* new
+/// value of the ghost after the handler runs (the assignment operator has
+/// already been folded in: `+= d` became `<ghost> + (d)`), so each backend
+/// just emits `<ghost> := <value>`.
+#[derive(Debug, Clone)]
+pub struct ParsedGhostUpdate {
+    pub handler: String,
+    pub value_lean: String,
+    pub value_rust: String,
 }
 
 impl ParsedSpec {
@@ -2897,6 +2928,91 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
         });
     }
 
+    // Issue #67 item 3 — ghost-variable validation.
+    if !spec.ghosts.is_empty() {
+        let scalar = |t: &str| {
+            matches!(
+                t.trim(),
+                "U8" | "U16"
+                    | "U32"
+                    | "U64"
+                    | "U128"
+                    | "I8"
+                    | "I16"
+                    | "I32"
+                    | "I64"
+                    | "I128"
+                    | "Bool"
+            )
+        };
+        // Ghosts are only wired into the flat single-account verification
+        // State today. Indexed (`Map[N]`), multi-account, and explicit
+        // ADT-state shapes don't yet thread ghost fields through their
+        // renderers, so flag rather than silently drop them.
+        let is_indexed = spec
+            .state_fields
+            .iter()
+            .any(|(_, t)| t.trim_start().starts_with("Map"));
+        let is_multi_account = spec.account_types.len() > 1;
+        let is_adt = spec.state_repr_is_adt();
+        let unsupported_shape = is_indexed || is_multi_account || is_adt;
+        let handler_names: std::collections::BTreeSet<&str> =
+            spec.handlers.iter().map(|h| h.name.as_str()).collect();
+        for g in &spec.ghosts {
+            if !scalar(&g.ty) {
+                warnings.push(CompletenessWarning {
+                    rule: "ghost_non_scalar_type".to_string(),
+                    severity: Severity::Warning,
+                    priority: 2,
+                    message: format!(
+                        "ghost '{}' has non-scalar type '{}' — ghosts must be a scalar (U8…U128 / I8…I128 / Bool)",
+                        g.name, g.ty
+                    ),
+                    subject: Some(g.name.clone()),
+                    fix: "Use a scalar ghost type. Aggregate quantities over collections belong in a `property` via `sum i : Idx, …`, not a ghost.".to_string(),
+                    example: None,
+                    counterexample: None,
+                    fix_options: vec![],
+                });
+            }
+            for u in &g.updates {
+                if !handler_names.contains(u.handler.as_str()) {
+                    warnings.push(CompletenessWarning {
+                        rule: "ghost_update_unknown_handler".to_string(),
+                        severity: Severity::Warning,
+                        priority: 2,
+                        message: format!(
+                            "ghost '{}' has an `on {}` clause, but no handler named '{}' exists",
+                            g.name, u.handler, u.handler
+                        ),
+                        subject: Some(g.name.clone()),
+                        fix: "Name an existing handler in the `on` clause, or remove the clause."
+                            .to_string(),
+                        example: None,
+                        counterexample: None,
+                        fix_options: vec![],
+                    });
+                }
+            }
+            if unsupported_shape {
+                warnings.push(CompletenessWarning {
+                    rule: "ghost_unsupported_state_shape".to_string(),
+                    severity: Severity::Warning,
+                    priority: 2,
+                    message: format!(
+                        "ghost '{}' is declared with an indexed / multi-account / ADT state — ghost fields are only wired into the flat single-account verification State today",
+                        g.name
+                    ),
+                    subject: Some(g.name.clone()),
+                    fix: "Move the ghost to a flat single-account spec, or track the quantity in a `property` (e.g. `sum i : Idx, accounts[i].x`) until ghost support lands for this shape.".to_string(),
+                    example: None,
+                    counterexample: None,
+                    fix_options: vec![],
+                });
+            }
+        }
+    }
+
     for op in &spec.handlers {
         // v2.7 G4: `auth X` and `permissionless` are mutually exclusive — one
         // declares who can call, the other declares "anyone can call." Both
@@ -3290,9 +3406,11 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
                  `Vec<T>` / `List<T>` aren't enumerable by Kani / proptest in v2.20."
             }
             "exists_quantifier" => {
-                "v2.20 only lowers `forall`. Rephrase as `forall <binder> : <T>, \
-                 P(<binder>) ⟹ Q(<binder>)` if the property is really about a \
-                 witnessed case."
+                "A bounded `exists` (binder typed `Fin[N]`, e.g. via an index \
+                 alias like `MemberIdx = Fin[MAX_MEMBERS]`) lowers to \
+                 `(0..N).any(…)`. This `exists` ranges over an unbounded domain \
+                 (e.g. `U64`); bound the binder with a `Fin[N]` index type so it \
+                 can be enumerated."
             }
             _ => "See docs/limitations.md#unsupported-quantifier-shapes for the workaround.",
         };

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -61,11 +61,16 @@ enum Kind {
 ///   - `state_fields`: bare field name → TypeRef (top-level state fields like V, I)
 ///   - `records`: record name → field name → TypeRef (e.g. Account.capital → U128)
 ///   - `params`: current handler's params, for bare-ident lookups
-#[derive(Default)]
+///   - `aliases`: type-alias name → its target rendered as a source-DSL string
+///     (e.g. `AccountIdx` → `Fin[MAX_ACCOUNTS]`). Lets the quantifier renderer
+///     resolve a binder type written as an alias down to the underlying
+///     `Fin[N]` so it can emit a bounded `(0..N).all/.any(…)` iteration.
+#[derive(Default, Clone)]
 struct TypeEnv<'a> {
     state_fields: std::collections::BTreeMap<String, &'a a::TypeRef>,
     records: std::collections::BTreeMap<String, std::collections::BTreeMap<String, &'a a::TypeRef>>,
     params: Vec<(String, &'a a::TypeRef)>,
+    aliases: std::collections::BTreeMap<String, String>,
 }
 
 impl<'a> TypeEnv<'a> {
@@ -89,10 +94,39 @@ impl<'a> TypeEnv<'a> {
                         }
                     }
                 }
+                TopItem::TypeAlias(ta) => {
+                    env.aliases
+                        .insert(ta.name.clone(), type_ref_to_string(&ta.target));
+                }
+                // Ghosts render as state fields: `state.<ghost>` must resolve
+                // in properties / invariants / `requires` / `ensures` and in
+                // other ghosts' update RHS. They are rendering-only here — the
+                // on-chain codegen reads `ParsedSpec.state_fields`, which never
+                // includes ghosts.
+                TopItem::Ghost(g) => {
+                    env.state_fields.entry(g.name.clone()).or_insert(&g.ty);
+                }
                 _ => {}
             }
         }
         env
+    }
+
+    /// If `binder_ty` is a bounded index domain — either `Fin[N]` written
+    /// directly or an alias resolving to one (e.g. `AccountIdx`) — return
+    /// the bound symbol `N` (a numeric literal or a `const` name). Returns
+    /// `None` for any non-`Fin` binder type. The bound is emitted verbatim
+    /// by callers: a numeric literal renders as-is, a const name renders as
+    /// the Rust `const` the codegen already emits.
+    fn fin_bound(&self, binder_ty: &str) -> Option<String> {
+        let resolved = self
+            .aliases
+            .get(binder_ty.trim())
+            .map(String::as_str)
+            .unwrap_or(binder_ty)
+            .trim();
+        let inner = resolved.strip_prefix("Fin[")?.strip_suffix(']')?;
+        Some(inner.trim().to_string())
     }
 
     fn with_params(mut self, params: &'a [a::TypedField]) -> Self {
@@ -878,12 +912,35 @@ fn expr_to_rust(e: &Expr, ctx: Ctx, consts: ConstTable, opts: RustOpts<'_, '_>) 
             binder_ty,
             body,
         } => {
-            // Small integer types (U8, I8) can be exhaustively iterated inside
-            // a property predicate using Rust's RangeInclusive::all / any. This
-            // is correct and cheap enough for test suites (256 iterations max).
-            //
-            // Larger types (U16+) cannot be exhausted in a test loop; surface
-            // the sentinel so the caller knows to skip or escalate.
+            // A quantifier over a bounded domain lowers to an exhaustive
+            // `RangeInclusive::all` (forall) / `any` (exists) — correct and
+            // cheap for test suites. `Fin[N]` index domains iterate `0..N`;
+            // small integers (U8/I8) exhaust their full range. Wider integer
+            // domains can't be exhausted in a test loop, so the sentinel
+            // tells the caller to skip or escalate to harness-level lowering.
+            let method = match kind {
+                a::Quantifier::Forall => "all",
+                a::Quantifier::Exists => "any",
+            };
+            let body_rust = expr_to_rust(&body.node, ctx, consts, opts);
+            // `exists` over a bounded index domain (`Fin[N]`, directly or via
+            // an alias such as `AccountIdx`): iterate `0..N` with `.any(…)`.
+            // This is the collection-existence case — `exists i : AccountIdx,
+            // accounts[i]…` — and lowers to a real, non-vacuous predicate
+            // usable anywhere a bool is expected (requires / ensures /
+            // property body). `forall` over `Fin[N]` deliberately does NOT
+            // take this path: it keeps the v2.20 per-slot lowering
+            // (`{prop}_at`) so a preserved-property assertion checks the one
+            // modified slot rather than unwinding a whole-array loop in Kani.
+            // Existence has no per-slot analogue, so the bounded `.any`
+            // iteration is the correct and only mechanical lowering.
+            if matches!(kind, a::Quantifier::Exists) {
+                if let Some(bound) = opts.env.fin_bound(binder_ty) {
+                    return format!("(0..({} as usize)).any(|{}| {})", bound, binder, body_rust);
+                }
+            }
+            // Small integer domains (U8, I8) can be exhausted directly (256
+            // iterations max).
             let rust_ty = match binder_ty.as_str() {
                 "U8" => Some("u8"),
                 "I8" => Some("i8"),
@@ -899,11 +956,6 @@ fn expr_to_rust(e: &Expr, ctx: Ctx, consts: ConstTable, opts: RustOpts<'_, '_>) 
                     kind_name, binder, binder_ty
                 );
             };
-            let method = match kind {
-                a::Quantifier::Forall => "all",
-                a::Quantifier::Exists => "any",
-            };
-            let body_rust = expr_to_rust(&body.node, ctx, consts, opts);
             format!(
                 "({}::MIN..={}::MAX).{}(|{}| {})",
                 rust_ty, rust_ty, method, binder, body_rust
@@ -2701,6 +2753,20 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
                 // codegen needs for the lowered harness.
                 let quantifier_lint = match crate::quantifier::supported_shape(p) {
                     Ok(_) => None,
+                    // A bounded `exists` (over `Fin[N]`, directly or via an
+                    // alias such as `AccountIdx`) now lowers to a real
+                    // `(0..N).any(…)` harness predicate — see the `expr_to_rust`
+                    // quantifier arm. `supported_shape` rejects every `exists`
+                    // because it can't resolve aliases to decide boundedness;
+                    // the rendered Rust body is the ground truth, so when the
+                    // body lowered cleanly (no `QEDGEN_UNSUPPORTED` sentinel)
+                    // suppress the spurious P5. Unbounded `exists` (e.g. over
+                    // `U64`) still emits the sentinel and keeps the lint.
+                    Err(crate::quantifier::Reason::ExistsQuantifier { .. })
+                        if !crate::check::rust_expr_is_unsupported(&rust) =>
+                    {
+                        None
+                    }
                     Err(reason) => {
                         let kind = match &reason {
                             crate::quantifier::Reason::NestedQuantifier { .. } => {
@@ -2944,6 +3010,54 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
                     return_type: type_ref_to_string(&r.return_type),
                     lean_body,
                     rust_body,
+                });
+            }
+            TopItem::Ghost(g) => {
+                // Init value — a constant expression in single-state context.
+                let init_lean = expr_to_lean(&g.init.node, Ctx::Guard, consts, &env);
+                let init_rust = expr_to_rust(&g.init.node, Ctx::Guard, consts, opts_native(&env));
+                let mut updates = Vec::new();
+                for u in &g.updates {
+                    // Resolve the named handler's params so the update RHS can
+                    // reference them; ghost names already resolve via `env`.
+                    let handler_params: &[a::TypedField] = spec
+                        .items
+                        .iter()
+                        .find_map(|it| match &it.node {
+                            TopItem::Handler(h) if h.name == u.handler => Some(h.params.as_slice()),
+                            _ => None,
+                        })
+                        .unwrap_or(&[]);
+                    let uenv = env.clone().with_params(handler_params);
+                    let rhs_lean = expr_to_lean(&u.stmt.rhs.node, Ctx::Guard, consts, &uenv);
+                    let rhs_rust =
+                        expr_to_rust(&u.stmt.rhs.node, Ctx::Guard, consts, opts_native(&uenv));
+                    // Fold the assignment operator into a complete new-value
+                    // expression so each backend just emits `<ghost> := value`.
+                    let (value_lean, value_rust) = match u.stmt.op {
+                        a::EffectOp::Set => (rhs_lean, rhs_rust),
+                        a::EffectOp::Add | a::EffectOp::AddSat | a::EffectOp::AddWrap => (
+                            format!("s.{} + ({})", g.name, rhs_lean),
+                            format!("s.{} + ({})", g.name, rhs_rust),
+                        ),
+                        a::EffectOp::Sub | a::EffectOp::SubSat | a::EffectOp::SubWrap => (
+                            format!("s.{} - ({})", g.name, rhs_lean),
+                            format!("s.{} - ({})", g.name, rhs_rust),
+                        ),
+                    };
+                    updates.push(crate::check::ParsedGhostUpdate {
+                        handler: u.handler.clone(),
+                        value_lean,
+                        value_rust,
+                    });
+                }
+                out.ghosts.push(crate::check::ParsedGhost {
+                    name: g.name.clone(),
+                    doc: g.doc.clone(),
+                    ty: type_ref_to_string(&g.ty),
+                    init_lean,
+                    init_rust,
+                    updates,
                 });
             }
             TopItem::Pragma(p) => {
@@ -3242,6 +3356,7 @@ fn expand_handler(
         state_fields: base_env.state_fields.clone(),
         records: base_env.records.clone(),
         params: h.params.iter().map(|f| (f.name.clone(), &f.ty)).collect(),
+        aliases: base_env.aliases.clone(),
     };
     let env = &env;
     // Detect a single branch clause (phase 1: at most one branch per handler).
@@ -5121,6 +5236,108 @@ handler bump (delta : U64) : State.Active -> State.Active {
             "binary mode without old() must use post., not s. or pre.; got: {}",
             rendered
         );
+    }
+
+    // ========================================================================
+    // Issue #67 item 2 — bounded `exists` over a `Fin[N]` index domain
+    // lowers to a real `(0..N).any(…)` predicate; unbounded `exists` keeps
+    // the harness-level sentinel.
+    // ========================================================================
+
+    const EXISTS_SPEC_HEAD: &str = r#"
+spec ExistsTest
+const MAX = 8
+type Idx = Fin[MAX]
+type Member = { active : U64 }
+type State = { members : Map[MAX] Member, count : U64 }
+type Error
+  | E
+handler tick { effect { count := state.count + 1 } }
+"#;
+
+    #[test]
+    fn render_bounded_exists_over_fin_alias_lowers_to_any() {
+        let src = format!(
+            "{}{}",
+            EXISTS_SPEC_HEAD,
+            r#"property bounded_ex : exists i : Idx, state.members[i].active == 1 preserved_by [tick]"#
+        );
+        let rendered = render_property_body(&src, "bounded_ex", StateMode::Unary);
+        assert!(
+            rendered.contains("(0..(MAX as usize)).any(|i|"),
+            "bounded exists over a Fin[N] alias must iterate 0..N with .any(); got: {}",
+            rendered
+        );
+        assert!(
+            !rendered.contains(crate::check::QEDGEN_UNSUPPORTED_MARKER),
+            "bounded exists must not emit the unsupported sentinel; got: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn render_unbounded_exists_keeps_sentinel() {
+        let src = format!(
+            "{}{}",
+            EXISTS_SPEC_HEAD,
+            r#"property unbounded_ex : exists v : U64, state.count == v preserved_by [tick]"#
+        );
+        let rendered = render_property_body(&src, "unbounded_ex", StateMode::Unary);
+        assert!(
+            rendered.contains(crate::check::QEDGEN_UNSUPPORTED_MARKER),
+            "exists over an unbounded U64 domain must keep the sentinel; got: {}",
+            rendered
+        );
+    }
+
+    // ========================================================================
+    // Issue #67 item 3 — `ghost` lowers to a State field + per-handler update.
+    // ========================================================================
+
+    #[test]
+    fn ghost_lowers_to_state_field_and_per_handler_update() {
+        let src = r#"
+spec G
+state { balance : U64 }
+type Error
+  | E
+ghost total : U64 {
+  init { 0 }
+  on mint { total := state.total + amount }
+}
+handler mint (amount : U64) {
+  effect { balance := state.balance + amount }
+}
+property p : state.total == state.balance preserved_by all
+"#;
+        let typed = crate::chumsky_parser::parse(src).expect("parse");
+        let spec = adapt(&typed);
+        assert_eq!(spec.ghosts.len(), 1, "one ghost expected");
+        let g = &spec.ghosts[0];
+        assert_eq!(g.name, "total");
+        assert_eq!(g.ty, "U64");
+        assert_eq!(g.init_rust.trim(), "0");
+        assert_eq!(g.updates.len(), 1);
+        assert_eq!(g.updates[0].handler, "mint");
+        // `state.total` resolves to `s.total` (ghost registered as a state
+        // field) and the handler param `amount` is in scope.
+        assert!(
+            g.updates[0].value_rust.contains("s.total")
+                && g.updates[0].value_rust.contains("amount"),
+            "update value_rust should read the ghost + param; got {}",
+            g.updates[0].value_rust
+        );
+        assert!(
+            g.updates[0].value_lean.contains("s.total"),
+            "update value_lean should read the ghost; got {}",
+            g.updates[0].value_lean
+        );
+        // The property references the ghost as a state field.
+        let prop = spec.properties.iter().find(|p| p.name == "p").unwrap();
+        assert!(prop
+            .rust_expression
+            .as_deref()
+            .is_some_and(|r| r.contains("s.total")));
     }
 
     #[test]

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -2014,6 +2014,62 @@ fn ref_impl_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
         })
 }
 
+/// Issue #67 item 3 — `ghost <name> : <Ty> { init { <expr> } on <handler>
+/// { <name> := <expr> } … }`. Spec-only auxiliary state. The block holds a
+/// single `init` clause followed by zero or more `on <handler>` update
+/// clauses. Each update reuses `effect_stmt()`, so the same `:=` / `+=` /
+/// `-=` operators (and `state.<ghost>` RHS references) work as in a real
+/// handler effect.
+fn ghost_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
+    let init_clause = kw("init")
+        .then_ignore(wsc())
+        .then_ignore(just('{'))
+        .then_ignore(wsc())
+        .ignore_then(expr())
+        .then_ignore(wsc())
+        .then_ignore(just('}'));
+
+    let on_clause = kw("on")
+        .ignore_then(non_keyword_ident())
+        .then_ignore(wsc())
+        .then_ignore(just('{'))
+        .then_ignore(wsc())
+        .then(effect_stmt())
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(|(handler, stmt)| GhostUpdate { handler, stmt });
+
+    doc_comments()
+        .then_ignore(kw("ghost"))
+        .then(non_keyword_ident())
+        .then_ignore(wsc())
+        .then_ignore(just(':'))
+        .then_ignore(wsc())
+        .then(type_ref())
+        .then_ignore(wsc())
+        .then_ignore(just('{'))
+        .then_ignore(wsc())
+        .then(init_clause)
+        .then_ignore(wsc())
+        .then(
+            on_clause
+                .then_ignore(wsc())
+                .repeated()
+                .collect::<Vec<GhostUpdate>>(),
+        )
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(|((((doc, name), ty), init), updates)| {
+            TopItem::Ghost(GhostDecl {
+                name,
+                doc,
+                ty,
+                init,
+                updates,
+            })
+        })
+}
+
 // invariant name : expr  OR  invariant name "description"
 /// v2.24 #1 — top-level `schema name { requires expr else Err … }`.
 /// Reusable cross-cutting guard set. Pre-fix the parser rejected the
@@ -2993,6 +3049,7 @@ fn top_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
         pda_decl(),
         event_decl(),
         environment_decl(),
+        ghost_decl(),
         program_id_decl(),
     ));
     // Note: `pubkey`, `instruction`, `assembly`, and the `errors [...]`
@@ -3532,6 +3589,7 @@ property conservation :
                 TopItem::Import { .. } => "import",
                 TopItem::Schema(_) => "schema",
                 TopItem::RefImpl(_) => "ref_impl",
+                TopItem::Ghost(_) => "ghost",
             })
             .fold(
                 std::collections::BTreeMap::<&str, usize>::new(),

--- a/crates/qedgen/src/kani_mir.rs
+++ b/crates/qedgen/src/kani_mir.rs
@@ -378,6 +378,17 @@ fn emit_account_section_structural(out: &mut String, parsed: &ParsedSpec) -> Res
             )
         };
 
+    // Issue #67 item 3 — ghosts are spec-only verification-State fields:
+    // present in the Kani State struct + symbolic init + transitions (so the
+    // BMC harness can read them and `emit_transition_fn` can assign them), but
+    // never in the on-chain program. Mirrors the proptest single-account path.
+    let state_fields_with_ghosts: Vec<(String, String)> = state_fields
+        .iter()
+        .cloned()
+        .chain(parsed.ghosts.iter().map(|g| (g.name.clone(), g.ty.clone())))
+        .collect();
+    let state_fields: &[(String, String)] = &state_fields_with_ghosts;
+
     let mutable = util::mutable_fields(state_fields);
     let has_lifecycle = lifecycle.len() >= 2;
 

--- a/crates/qedgen/src/lean_gen_mir.rs
+++ b/crates/qedgen/src/lean_gen_mir.rs
@@ -2231,6 +2231,7 @@ fn scope_mir_to_account(mir: &Mir, acct: &crate::mir::AccountStateMir) -> Mir {
         covers: Vec::new(),                // emit_covers_multi handles
         liveness_props: mir.liveness_props.clone(),
         environments: mir.environments.clone(),
+        ghosts: mir.ghosts.clone(),
         records: mir.records.clone(),
         is_assembly: mir.is_assembly,
         adt_state: mir.adt_state,
@@ -2667,6 +2668,16 @@ fn emit_handler_transition(out: &mut String, mir: &Mir, h: &crate::mir::HandlerM
         // issue #43.
         if mir.state.lifecycle_states.len() >= 2 {
             with_parts.push(format!("status := .{}", safe_name(post)));
+        }
+    }
+
+    // Issue #67 item 3 — ghost field updates. A ghost with an `on <this
+    // handler>` clause assigns its new value alongside the normal effects;
+    // ghosts without a clause are left unchanged (the `{ s with … }`
+    // record update preserves unmentioned fields — the frame condition).
+    for ghost in &mir.ghosts {
+        if let Some(val) = ghost.updates.get(&h.name) {
+            with_parts.push(format!("{} := {}", safe_name(&ghost.name), val.lean));
         }
     }
 
@@ -4154,6 +4165,16 @@ fn emit_state_struct(out: &mut String, mir: &Mir) {
     }
     if has_lifecycle {
         out.push_str("  status : Status\n");
+    }
+    // Issue #67 item 3 — ghost (spec-only) fields, appended LAST so the
+    // non-ghost field prefix keeps a stable order for any positional
+    // `⟨…⟩` State construction (e.g. cover witnesses).
+    for ghost in &mir.ghosts {
+        out.push_str(&format!(
+            "  {} : {}\n",
+            safe_name(&ghost.name),
+            render_ty(&ghost.ty)
+        ));
     }
     // `Inhabited` enables the polymorphic CPI ensures-axioms
     // (`{State} [Inhabited State] …`) to apply to this state; all field
@@ -5755,6 +5776,7 @@ mod tests {
             covers: vec![],
             liveness_props: vec![],
             environments: vec![],
+            ghosts: vec![],
             records: vec![],
             is_assembly: false,
             adt_state: false,
@@ -5797,6 +5819,7 @@ mod tests {
             covers: vec![],
             liveness_props: vec![],
             environments: vec![],
+            ghosts: vec![],
             records: vec![],
             is_assembly: false,
             adt_state: false,

--- a/crates/qedgen/src/mir.rs
+++ b/crates/qedgen/src/mir.rs
@@ -168,6 +168,11 @@ pub struct Mir {
     /// mutations. Each property × environment cross emits a
     /// preservation theorem.
     pub environments: Vec<EnvironmentMir>,
+    /// Issue #67 item 3 — `ghost` spec-only auxiliary state. Lowered to
+    /// extra verification-State fields (Lean / proptest / Kani) plus a
+    /// per-handler new-value expression; the on-chain codegen ignores
+    /// these entirely.
+    pub ghosts: Vec<GhostMir>,
     /// Top-level `type T = { … }` record declarations (the value types of
     /// `Map[N] T` fields, e.g. percolator's `Account`). The indexed-state
     /// Lean renderer emits a `structure T` + `instance Inhabited T` per
@@ -758,6 +763,23 @@ pub struct RefImpl {
     pub rust_body: String,
 }
 
+/// Issue #67 item 3 — lowered `ghost` declaration. A spec-only auxiliary
+/// State field with a pre-rendered initial value and a per-handler
+/// new-value expression (keyed by handler name). Backends that model the
+/// verification State (Lean / proptest / Kani) add `name : ty` as a State
+/// field, initialise it to `init`, and — in each handler that appears in
+/// `updates` — assign `name := updates[handler]` alongside the normal
+/// effects. The on-chain program codegen never reads this.
+#[derive(Debug, Clone)]
+pub struct GhostMir {
+    pub name: Symbol,
+    pub doc: Option<String>,
+    pub ty: Ty,
+    pub init: Expr,
+    /// Handler name → complete new-value expression after that handler.
+    pub updates: BTreeMap<Symbol, Expr>,
+}
+
 #[derive(Debug, Clone)]
 pub struct InterfaceDecl {
     pub name: Symbol,
@@ -1083,6 +1105,7 @@ pub fn lower(parsed: &ParsedSpec) -> Mir {
         covers: lower_covers(parsed),
         liveness_props: lower_liveness(parsed),
         environments: lower_environments(parsed),
+        ghosts: lower_ghosts(parsed),
         records: parsed.records.clone(),
         is_assembly: parsed.is_assembly_target(),
         adt_state: parsed.state_repr_is_adt(),
@@ -1373,6 +1396,37 @@ fn lower_liveness(parsed: &ParsedSpec) -> Vec<LivenessMir> {
             leads_to_state: l.leads_to_state.clone(),
             via_ops: l.via_ops.clone(),
             within_steps: l.within_steps,
+        })
+        .collect()
+}
+
+fn lower_ghosts(parsed: &ParsedSpec) -> Vec<GhostMir> {
+    parsed
+        .ghosts
+        .iter()
+        .map(|g| GhostMir {
+            name: g.name.clone(),
+            doc: g.doc.clone(),
+            ty: parse_ty(&g.ty),
+            init: Expr {
+                lean: g.init_lean.clone(),
+                rust: g.init_rust.clone(),
+                ..Default::default()
+            },
+            updates: g
+                .updates
+                .iter()
+                .map(|u| {
+                    (
+                        u.handler.clone(),
+                        Expr {
+                            lean: u.value_lean.clone(),
+                            rust: u.value_rust.clone(),
+                            ..Default::default()
+                        },
+                    )
+                })
+                .collect(),
         })
         .collect()
 }
@@ -1759,6 +1813,7 @@ mod tests {
             covers: vec![],
             liveness_props: vec![],
             environments: vec![],
+            ghosts: vec![],
             records: vec![],
             is_assembly: false,
             adt_state: false,

--- a/crates/qedgen/src/proptest_gen_mir.rs
+++ b/crates/qedgen/src/proptest_gen_mir.rs
@@ -288,6 +288,13 @@ fn emit_record_prop_composes(out: &mut String, spec: &ParsedSpec) -> Result<()> 
         if rec.fields.is_empty() {
             continue;
         }
+        // The flat-state `State` record is materialised as the state-machine
+        // struct (with its own `arb_state()`); skip the value-record form so
+        // we don't emit a colliding `arb_State()`. Mirrors the skip in
+        // `rust_codegen_util::emit_record_structs`.
+        if rec.name == "State" {
+            continue;
+        }
         out.push_str("prop_compose! {\n");
         out.push_str(&format!("    fn arb_{}()(", rec.name));
         for (i, (fname, ftype)) in rec.fields.iter().enumerate() {
@@ -555,7 +562,18 @@ fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {\n\
         }
     } else {
         // Single-account: generate flat (no module wrapper)
-        let state_fields: &[(String, String)] = &spec.state_fields;
+        // Issue #67 item 3 — ghosts are spec-only *verification*-State fields:
+        // present in the harness State struct + `arb_state` + transitions (so
+        // properties / invariants can read them and the inductive `prop_assume`
+        // ties them down), but NEVER in the on-chain program codegen, which
+        // reads `spec.state_fields` directly.
+        let state_fields_owned: Vec<(String, String)> = spec
+            .state_fields
+            .iter()
+            .cloned()
+            .chain(spec.ghosts.iter().map(|g| (g.name.clone(), g.ty.clone())))
+            .collect();
+        let state_fields: &[(String, String)] = &state_fields_owned;
         let mutable_fields = rust_codegen_util::mutable_fields(state_fields);
         let all_handlers: Vec<&ParsedHandler> = spec.handlers.iter().collect();
         let all_props: Vec<&ParsedProperty> = spec.properties.iter().collect();
@@ -947,6 +965,25 @@ fn emit_transition_functions_for(
 }
 
 /// Emit per-(handler, property) preservation tests.
+/// True iff `rust` references the state field `name` as `s.<name>`,
+/// word-bounded so `s.total` doesn't match `s.total_supply`.
+fn references_field(rust: &str, name: &str) -> bool {
+    let needle = format!("s.{}", name);
+    let mut from = 0;
+    while let Some(pos) = rust[from..].find(&needle) {
+        let end = from + pos + needle.len();
+        let next_is_word = rust[end..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if !next_is_word {
+            return true;
+        }
+        from = end;
+    }
+    false
+}
+
 fn emit_preservation_tests_for(
     out: &mut String,
     handlers: &[&ParsedHandler],
@@ -958,6 +995,20 @@ fn emit_preservation_tests_for(
     for prop in properties {
         if prop.expression.is_none() {
             continue;
+        }
+
+        // Issue #67 item 3 — a property that reads a ghost (spec-only
+        // accumulator) is validated by the init-seeded `state_machine_sequence`
+        // harness, not the single-step `_preserves_` one. A ghost is a function
+        // of the handler history, so an *arbitrary* pre-state ghost value
+        // rarely satisfies the invariant and `arb_state` rejection sampling
+        // exhausts ("too many global rejects"). The sequence harness drives the
+        // property from `init`, where the ghost/real-state relationship holds
+        // and is maintained inductively — the semantically correct check.
+        if let Some(rust) = &prop.rust_expression {
+            if spec.ghosts.iter().any(|g| references_field(rust, &g.name)) {
+                continue;
+            }
         }
 
         for op_name in &prop.preserved_by {

--- a/crates/qedgen/src/quantifier.rs
+++ b/crates/qedgen/src/quantifier.rs
@@ -51,8 +51,14 @@ pub enum Reason {
     /// (`Vec<T>`, `List<T>`, etc.). Bounded `Map[N] T` would be supported
     /// but the spec grammar uses it as a state-field type, not a binder.
     UnboundedBinderType { ty: String, span: Span },
-    /// `exists` quantifier. v2.20 only lowers `forall`; existence proofs
-    /// need a witness-emission contract that doesn't fit the harness model.
+    /// `exists` quantifier. A *bounded* `exists` (binder is a `Fin[N]`
+    /// index domain, directly or via an alias) lowers to a real
+    /// `(0..N).any(…)` harness predicate — the chumsky_adapter resolves
+    /// the alias, renders that, and suppresses this reason. This variant
+    /// only survives for an *unbounded* `exists` (e.g. over `U64`), which
+    /// can't be enumerated in a test loop. The classifier can't resolve
+    /// aliases on its own, so it conservatively reports every `exists`
+    /// here and lets the adapter clear it when the body lowered cleanly.
     ExistsQuantifier { span: Span },
 }
 
@@ -69,7 +75,9 @@ impl Reason {
                 ty
             ),
             Reason::ExistsQuantifier { .. } => {
-                "`exists` quantifier — only `forall` is lowered in v2.20".to_string()
+                "`exists` over an unbounded domain — bound the binder with a \
+                 `Fin[N]` index type (or `U8`) so it lowers to `(0..N).any(…)`"
+                    .to_string()
             }
         }
     }

--- a/crates/qedgen/src/rust_codegen_util.rs
+++ b/crates/qedgen/src/rust_codegen_util.rs
@@ -855,6 +855,14 @@ pub fn emit_record_structs(
         if rec.fields.is_empty() {
             continue;
         }
+        // The `state { … }` / `type State = { … }` flat forms produce a
+        // record literally named `State`, which the adapter keeps in
+        // `records` for other consumers. The state-machine `struct State`
+        // is emitted separately (with lifecycle + ghost fields), so skip
+        // the value-record here to avoid a duplicate `struct State`.
+        if rec.name == "State" {
+            continue;
+        }
         out.push_str(&format!("#[derive({})]\n", derives));
         out.push_str(&format!("struct {} {{\n", rec.name));
         for (fname, ftype) in &rec.fields {
@@ -1238,6 +1246,21 @@ pub fn emit_transition_fn(
     if has_lifecycle(spec) {
         if let Some(ref post) = op.post_status {
             out.push_str(&format!("    s.status = Status::{};\n", post));
+        }
+    }
+
+    // Issue #67 item 3 — ghost (spec-only) field updates. A ghost with an
+    // `on <this handler>` clause assigns its new value after the normal
+    // effects; ghosts without a clause are left unchanged (frame). The
+    // value reads `s.<ghost>` + handler params, matching the Lean
+    // transition. Arithmetic wraps under `cargo test --release` (the
+    // `verify --proptest` path), so an arbitrary-state aggregate never
+    // panics on model overflow.
+    for ghost in &spec.ghosts {
+        for u in &ghost.updates {
+            if u.handler == op.name {
+                out.push_str(&format!("    s.{} = {};\n", ghost.name, u.value_rust));
+            }
         }
     }
 

--- a/references/qedspec-dsl.md
+++ b/references/qedspec-dsl.md
@@ -388,6 +388,64 @@ multiple `ensures` clauses or when the math is too complex to inline
 readably (LP share-value, mul-div with rounding, Pyth-style price
 derivations).
 
+### `ghost`
+
+Spec-only **auxiliary state** — a field that exists purely for
+verification (invariants, properties, `requires`/`ensures`) and never
+appears in the on-chain program. Use it for a quantity the program
+doesn't store but you want to reason about: a running total, a count of
+operations, a high-water mark.
+
+```
+ghost total_supply : U64 {
+  init { 0 }
+  on mint { total_supply := state.total_supply + amount }
+  on burn { total_supply := state.total_supply - amount }
+}
+
+property supply_tracks_balance :
+  state.total_supply == state.balance
+  preserved_by all
+```
+
+- **`init { <expr> }`** — the ghost's value when the State is first
+  constructed. A constant expression.
+- **`on <handler> { <name> := <expr> }`** — how the ghost changes when
+  that handler runs. The named handler's parameters are in scope (no
+  type redeclaration), and the RHS may read the ghost's own pre-value as
+  `state.<name>`. A handler with no `on` clause leaves the ghost
+  unchanged (frame condition). `+=` / `-=` work as in a real effect.
+- Reference the ghost anywhere as `state.<name>` — in properties,
+  invariants, `requires`, `ensures`.
+
+**Codegen.** The ghost becomes a field on the *verification* State
+(Lean `structure State`, proptest / Kani `struct State`), updated
+alongside the real effects in each handler's transition. It is **omitted
+from the on-chain program codegen** (Anchor / Quasar / Pinocchio) — it
+has no storage cost and no runtime presence.
+
+**Validation note.** A ghost is a function of the handler history, so
+its invariants are checked inductively from `init`: the proptest
+`state_machine_sequence` harness drives random handler sequences from the
+initial state and asserts the property after each step. The single-step
+`<handler>_preserves_<prop>` harness is *skipped* for ghost-referencing
+properties (an arbitrary pre-state ghost value rarely satisfies the
+invariant, so rejection sampling would exhaust). The Lean preservation
+proof is written in `Proofs.lean` like any other.
+
+**Scope.** v1 wires ghosts into the **flat single-account** State shape
+(the canonical token example). Indexed (`Map[N]`), multi-account, and
+explicit-ADT state shapes fire the `ghost_unsupported_state_shape` lint —
+track the aggregate in a `property` (`sum i : Idx, accounts[i].x`)
+instead, which is fully supported there. Ghosts must be **scalar**
+(`U8…U128` / `I8…I128` / `Bool`); a non-scalar fires
+`ghost_non_scalar_type`, and an `on` clause naming a missing handler
+fires `ghost_update_unknown_handler`.
+
+`ghost` vs [`ref_impl`](#ref_impl-v225): a `ref_impl` is a *stateless*
+pure function the real Rust impl is checked against; a `ghost` is
+*stateful* spec-only state with no on-chain counterpart.
+
 ## PDA and events
 
 ### `pda`
@@ -791,12 +849,18 @@ exists l : Loan.Active, l.collateral > 0
 // Quantifiers — multi-binder (desugars to nested single-binder forms)
 forall p1 p2 : Path, black_count(p1) == black_count(p2)
 
-// Lowering notes (v2.6):
+// Lowering notes:
 //   - `implies`  Lean: → ; Rust: `(!a) || (b)` — valid in property fn bodies.
-//   - `forall` / `exists` in a `property` body emit a
-//     `/* QEDGEN_UNSUPPORTED_QUANTIFIER */` marker in Rust and the
-//     property fn returns `true`. Lift quantified universals to
-//     harness-level `kani::any()` / proptest generators instead.
+//   - `forall i : Fin[N], …` (e.g. over an index alias like `AccountIdx`)
+//     lowers to a real per-slot harness — see `property` below.
+//   - `exists i : Fin[N], …` (bounded; directly or via an index alias)
+//     lowers to Lean `∃` and Rust `(0..N).any(|i| …)`. Works in
+//     `requires` / `ensures` / `property` bodies. An *unbounded* `exists`
+//     (e.g. `exists v : U64, …`) can't be enumerated — it keeps the
+//     `/* QEDGEN_UNSUPPORTED_QUANTIFIER */` marker and the `property` fn
+//     returns `true`; bound the binder with a `Fin[N]` index type.
+//   - Nested quantifiers still emit the marker — split into single-binder
+//     properties.
 
 // Aggregate sum over a bounded index type
 sum i : AccountIdx, state.accounts[i].capital


### PR DESCRIPTION
Implements two of the five `.qedspec` evolution items from #67. See [the reconciliation comment](https://github.com/QEDGen/solana-skills/issues/67#issuecomment-4598437629) for why the other three need no code (1 & 5 already ship as `property … preserved_by` / `abstract`; 4 deferred).

## Item 2 — bounded `exists`
- `exists i : Fin[N], P` (directly or via an index alias like `AccountIdx`) lowers to Lean `∃` and proptest/Kani `(0..N).any(|i| …)`, usable in `requires` / `ensures` / property bodies.
- `forall`-over-index and `sum` aggregation already shipped sorry-free (percolator), so this closes the one remaining quantifier gap.
- Unbounded `exists` (e.g. over `U64`) still lints — now pointing at `Fin[N]`.

## Item 3 — ghost variables
```
ghost total_supply : U64 {
  init { 0 }
  on mint { total_supply := state.total_supply + amount }
  on burn { total_supply := state.total_supply - amount }
}
```
- Spec-only auxiliary state: a field on the **verification** State (Lean / proptest / Kani), updated alongside real effects per handler, **omitted from on-chain codegen**.
- Validated by the init-seeded `state_machine_sequence` proptest harness; the single-step `_preserves_` harness is skipped for ghost-referencing properties (a ghost is a history-function, so rejection sampling would exhaust).
- Lints: `ghost_non_scalar_type`, `ghost_update_unknown_handler`, `ghost_unsupported_state_shape` (flat single-account only for now).

## Also
Fixes a latent bug — flat `state {}` / `type State = {}` double-emitted `struct State` in the proptest harness (invisible because snapshot tests diff text without compiling, and bundled examples use ADT state).

## Verification
- 922 unit tests + all snapshot suites green; `clippy -D warnings` + `cargo fmt --check` clean.
- 11 files changed; no existing fixture/snapshot output changed.
- Docs: `references/qedspec-dsl.md` gains a `ghost` section + updated quantifier-lowering note.

## Scope / follow-ups
Ghosts are wired for flat single-account state (the proposal's token shape); indexed/multi-account/ADT shapes lint cleanly. Follow-ups: ghosts for those shapes, a polished `examples/` ghost showcase, Kani overflow-checking of spec-only ghost arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
