### PR TITLE
feat(qedspec): `hook after_store` runtime assertions (#67 item 4)

### DIFF
--- a/crates/qedgen/src/ast.rs
+++ b/crates/qedgen/src/ast.rs
@@ -154,6 +154,10 @@ pub enum TopItem {
     /// properties / `requires` / `ensures` (as `state.<name>`), updated
     /// per-handler, omitted from the on-chain program codegen.
     Ghost(GhostDecl),
+    /// Issue #67 item 4 — `hook <kind> { assert … }`. Cross-cutting
+    /// assertion fired at a MIR-statement boundary; enforced in the
+    /// Kani / proptest harnesses.
+    Hook(HookDecl),
 }
 
 /// v2.24 #1 — top-level `schema` block. Body carries a list of
@@ -370,6 +374,32 @@ pub struct GhostDecl {
 pub struct GhostUpdate {
     pub handler: String,
     pub stmt: EffectStmt,
+}
+
+/// Issue #67 item 4 — `hook <kind> { assert <expr> … }`. A cross-cutting
+/// instrumentation point: its assertions fire wherever a matching MIR
+/// statement occurs in any handler. v1 enforces hooks in the runtime
+/// backends (Kani / proptest); the Lean enforcement path lands with qedsvm.
+#[derive(Debug, Clone)]
+pub struct HookDecl {
+    pub doc: Option<String>,
+    pub kind: HookKind,
+    /// One or more `assert <expr>` predicates checked at the firing point.
+    pub asserts: Vec<Node<Expr>>,
+}
+
+/// Which MIR-statement boundary a hook fires at.
+#[derive(Debug, Clone)]
+pub enum HookKind {
+    /// `after_store(<field>)` — fires immediately after any assignment to
+    /// the named state field. Anchored in the runtime transition right
+    /// after that field's effect.
+    AfterStore(String),
+    /// `before_cpi` / `before_cpi(<Iface>)` — fires before a CPI (optionally
+    /// only to the named callee). Enforcement is the Lean CPI-theorem
+    /// precondition path (deferred); the runtime state model has no CPI to
+    /// anchor to, so this currently lints as enforcement-deferred.
+    BeforeCpi(Option<String>),
 }
 
 /// A type reference in the source language.

--- a/crates/qedgen/src/check.rs
+++ b/crates/qedgen/src/check.rs
@@ -1224,6 +1224,12 @@ pub struct ParsedSpec {
     /// omitted from the on-chain program codegen entirely.
     pub ghosts: Vec<ParsedGhost>,
 
+    /// Issue #67 item 4 — `hook <kind> { assert … }` cross-cutting
+    /// assertions. Enforced in the Kani / proptest transitions at the
+    /// matching MIR-statement boundary; ignored by Lean (deferred) and the
+    /// on-chain codegen.
+    pub hooks: Vec<ParsedHook>,
+
     /// v2.27 Track B — verified-callee composition (Stance 2).
     ///
     /// For each imported interface whose provider shipped a
@@ -1324,6 +1330,31 @@ pub struct ParsedGhostUpdate {
     pub handler: String,
     pub value_lean: String,
     pub value_rust: String,
+}
+
+/// Issue #67 item 4 — lowered `hook` declaration. Pre-rendered per backend.
+#[derive(Debug, Clone)]
+pub struct ParsedHook {
+    pub kind: ParsedHookKind,
+    pub asserts: Vec<ParsedHookAssert>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedHookKind {
+    /// Fires after any store to the named state field.
+    AfterStore(String),
+    /// Fires before a CPI (optionally only to the named callee namespace).
+    BeforeCpi(Option<String>),
+}
+
+/// One `assert <expr>` in a hook body, rendered per backend.
+#[derive(Debug, Clone)]
+pub struct ParsedHookAssert {
+    /// Lean rendering, retained for the deferred Lean enforcement path
+    /// (qedsvm). Not consumed today — Lean ignores hooks.
+    #[allow(dead_code)]
+    pub lean: String,
+    pub rust: String,
 }
 
 impl ParsedSpec {
@@ -3005,6 +3036,95 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
                     ),
                     subject: Some(g.name.clone()),
                     fix: "Move the ghost to a flat single-account spec, or track the quantity in a `property` (e.g. `sum i : Idx, accounts[i].x`) until ghost support lands for this shape.".to_string(),
+                    example: None,
+                    counterexample: None,
+                    fix_options: vec![],
+                });
+            }
+        }
+    }
+
+    // Issue #67 item 4 — hook validation.
+    if !spec.hooks.is_empty() {
+        // Lean enforcement is deferred (lands with qedsvm); hooks are
+        // currently checked only in the Kani / proptest harnesses.
+        warnings.push(CompletenessWarning {
+            rule: "hook_lean_unsupported".to_string(),
+            severity: Severity::Info,
+            priority: 3,
+            message: "hooks are enforced in the Kani / proptest harnesses; Lean enforcement is deferred (lands with qedsvm)".to_string(),
+            subject: None,
+            fix: "No action needed — `qedgen verify --kani` / `--proptest` exercise the hook assertions.".to_string(),
+            example: None,
+            counterexample: None,
+            fix_options: vec![],
+        });
+        let state_field_names: std::collections::BTreeSet<&str> =
+            spec.state_fields.iter().map(|(n, _)| n.as_str()).collect();
+        let is_indexed = spec
+            .state_fields
+            .iter()
+            .any(|(_, t)| t.trim_start().starts_with("Map"));
+        let unsupported_shape = is_indexed || spec.account_types.len() > 1;
+        for hook in &spec.hooks {
+            match &hook.kind {
+                ParsedHookKind::AfterStore(field) => {
+                    if !state_field_names.contains(field.as_str()) {
+                        warnings.push(CompletenessWarning {
+                            rule: "hook_unknown_field".to_string(),
+                            severity: Severity::Warning,
+                            priority: 2,
+                            message: format!(
+                                "hook `after_store({})` names '{}', which is not a state field",
+                                field, field
+                            ),
+                            subject: None,
+                            fix: "Name a declared state field in `after_store(<field>)`."
+                                .to_string(),
+                            example: None,
+                            counterexample: None,
+                            fix_options: vec![],
+                        });
+                    }
+                    if unsupported_shape {
+                        warnings.push(CompletenessWarning {
+                            rule: "hook_unsupported_state_shape".to_string(),
+                            severity: Severity::Warning,
+                            priority: 2,
+                            message: format!(
+                                "hook `after_store({})` is declared with an indexed / multi-account state — `after_store` is wired into the flat single-account transition only",
+                                field
+                            ),
+                            subject: None,
+                            fix: "Use a flat single-account spec, or assert the post-store condition in a `property`.".to_string(),
+                            example: None,
+                            counterexample: None,
+                            fix_options: vec![],
+                        });
+                    }
+                }
+                ParsedHookKind::BeforeCpi(_) => {
+                    warnings.push(CompletenessWarning {
+                        rule: "hook_before_cpi_unsupported".to_string(),
+                        severity: Severity::Warning,
+                        priority: 2,
+                        message: "`hook before_cpi` enforcement is deferred — the runtime state model has no CPI to anchor to, and the Lean CPI-theorem precondition path lands with qedsvm".to_string(),
+                        subject: None,
+                        fix: "Encode the precondition as a `requires` on the calling handler for now, or assert it via `after_store` on the field the CPI consumes.".to_string(),
+                        example: None,
+                        counterexample: None,
+                        fix_options: vec![],
+                    });
+                }
+            }
+            if hook.asserts.is_empty() {
+                warnings.push(CompletenessWarning {
+                    rule: "hook_no_assert".to_string(),
+                    severity: Severity::Info,
+                    priority: 3,
+                    message: "hook has no `assert` clause — it checks nothing".to_string(),
+                    subject: None,
+                    fix: "Add at least one `assert <expr>` to the hook body.".to_string(),
                     example: None,
                     counterexample: None,
                     fix_options: vec![],

--- a/crates/qedgen/src/chumsky_adapter.rs
+++ b/crates/qedgen/src/chumsky_adapter.rs
@@ -3060,6 +3060,25 @@ pub fn adapt(spec: &a::Spec) -> ParsedSpec {
                     updates,
                 });
             }
+            TopItem::Hook(h) => {
+                let kind = match &h.kind {
+                    a::HookKind::AfterStore(field) => {
+                        crate::check::ParsedHookKind::AfterStore(field.clone())
+                    }
+                    a::HookKind::BeforeCpi(iface) => {
+                        crate::check::ParsedHookKind::BeforeCpi(iface.clone())
+                    }
+                };
+                let asserts = h
+                    .asserts
+                    .iter()
+                    .map(|e| crate::check::ParsedHookAssert {
+                        lean: expr_to_lean(&e.node, Ctx::Guard, consts, &env),
+                        rust: expr_to_rust(&e.node, Ctx::Guard, consts, opts_native(&env)),
+                    })
+                    .collect();
+                out.hooks.push(crate::check::ParsedHook { kind, asserts });
+            }
             TopItem::Pragma(p) => {
                 // Record the pragma name for target inference. Any given
                 // pragma may appear at most once per spec; duplicates are
@@ -5338,6 +5357,61 @@ property p : state.total == state.balance preserved_by all
             .rust_expression
             .as_deref()
             .is_some_and(|r| r.contains("s.total")));
+    }
+
+    // ========================================================================
+    // Issue #67 item 4 — `hook` lowers to a per-field assertion set.
+    // ========================================================================
+
+    #[test]
+    fn hook_after_store_lowers_to_field_assertion() {
+        let src = r#"
+spec H
+state { balance : U64, cap : U64 }
+type Error
+  | E
+hook after_store(balance) {
+  assert state.balance <= state.cap
+}
+handler deposit (amount : U64) {
+  effect { balance := state.balance + amount }
+}
+"#;
+        let typed = crate::chumsky_parser::parse(src).expect("parse");
+        let spec = adapt(&typed);
+        assert_eq!(spec.hooks.len(), 1);
+        let h = &spec.hooks[0];
+        assert!(matches!(
+            &h.kind,
+            crate::check::ParsedHookKind::AfterStore(f) if f == "balance"
+        ));
+        assert_eq!(h.asserts.len(), 1);
+        assert!(
+            h.asserts[0].rust.contains("s.balance") && h.asserts[0].rust.contains("s.cap"),
+            "assert rust should read the state fields; got {}",
+            h.asserts[0].rust
+        );
+    }
+
+    #[test]
+    fn hook_before_cpi_parses_with_optional_callee() {
+        let src = r#"
+spec H2
+state { x : U64 }
+type Error
+  | E
+hook before_cpi(Token) {
+  assert state.x > 0
+}
+handler bump { effect { x := state.x + 1 } }
+"#;
+        let typed = crate::chumsky_parser::parse(src).expect("parse");
+        let spec = adapt(&typed);
+        assert_eq!(spec.hooks.len(), 1);
+        assert!(matches!(
+            &spec.hooks[0].kind,
+            crate::check::ParsedHookKind::BeforeCpi(Some(c)) if c == "Token"
+        ));
     }
 
     #[test]

--- a/crates/qedgen/src/chumsky_parser.rs
+++ b/crates/qedgen/src/chumsky_parser.rs
@@ -2070,6 +2070,54 @@ fn ghost_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
         })
 }
 
+/// Issue #67 item 4 — `hook after_store(<field>) { assert <expr> … }` /
+/// `hook before_cpi[(<Iface>)] { assert <expr> … }`. Cross-cutting
+/// assertion(s) checked at a MIR-statement boundary.
+fn hook_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clone {
+    let assert_clause = kw("assert")
+        .ignore_then(expr())
+        .then_ignore(wsc())
+        .then_ignore(just(';').or_not());
+    let asserts = assert_clause
+        .then_ignore(wsc())
+        .repeated()
+        .collect::<Vec<Node<Expr>>>();
+
+    let after_store = kw("after_store")
+        .then_ignore(wsc())
+        .then_ignore(just('('))
+        .then_ignore(wsc())
+        .ignore_then(non_keyword_ident())
+        .then_ignore(wsc())
+        .then_ignore(just(')'))
+        .map(HookKind::AfterStore);
+
+    let before_cpi = kw("before_cpi")
+        .then_ignore(wsc())
+        .ignore_then(
+            just('(')
+                .then_ignore(wsc())
+                .ignore_then(non_keyword_ident())
+                .then_ignore(wsc())
+                .then_ignore(just(')'))
+                .or_not(),
+        )
+        .map(HookKind::BeforeCpi);
+
+    let kind = choice((after_store, before_cpi));
+
+    doc_comments()
+        .then_ignore(kw("hook"))
+        .then(kind)
+        .then_ignore(wsc())
+        .then_ignore(just('{'))
+        .then_ignore(wsc())
+        .then(asserts)
+        .then_ignore(wsc())
+        .then_ignore(just('}'))
+        .map(|((doc, kind), asserts)| TopItem::Hook(HookDecl { doc, kind, asserts }))
+}
+
 // invariant name : expr  OR  invariant name "description"
 /// v2.24 #1 — top-level `schema name { requires expr else Err … }`.
 /// Reusable cross-cutting guard set. Pre-fix the parser rejected the
@@ -3050,6 +3098,7 @@ fn top_item<'a>() -> impl Parser<'a, &'a str, Node<TopItem>, Err<'a>> + Clone {
         event_decl(),
         environment_decl(),
         ghost_decl(),
+        hook_decl(),
         program_id_decl(),
     ));
     // Note: `pubkey`, `instruction`, `assembly`, and the `errors [...]`
@@ -3590,6 +3639,7 @@ property conservation :
                 TopItem::Schema(_) => "schema",
                 TopItem::RefImpl(_) => "ref_impl",
                 TopItem::Ghost(_) => "ghost",
+                TopItem::Hook(_) => "hook",
             })
             .fold(
                 std::collections::BTreeMap::<&str, usize>::new(),

--- a/crates/qedgen/src/proptest_gen_mir.rs
+++ b/crates/qedgen/src/proptest_gen_mir.rs
@@ -837,8 +837,13 @@ fn emit_account_section(
         )?;
     }
 
-    // Sequence test
-    if !owned_props.is_empty() && handlers.len() > 1 {
+    // Sequence test. Emitted when there are properties to check across a
+    // multi-handler state machine, OR when the spec declares hooks (issue
+    // #67 item 4) — the sequence harness drives random op sequences from
+    // `init`, which is what exercises the `after_store` assertions injected
+    // into the transitions (without a driver the hooks would never fire).
+    let want_sequence = (!owned_props.is_empty() && handlers.len() > 1) || !spec.hooks.is_empty();
+    if want_sequence && !handlers.is_empty() {
         emit_sequence_test_for(
             out,
             handlers,

--- a/crates/qedgen/src/rust_codegen_util.rs
+++ b/crates/qedgen/src/rust_codegen_util.rs
@@ -1108,6 +1108,28 @@ pub fn emit_property_predicates_with(
 
 /// Emit transition functions for handlers. Each returns true if guard passes.
 /// `wrapping` controls whether add/sub effects use wrapping arithmetic.
+/// Issue #67 item 4 — emit any `hook after_store(<field>)` assertions that
+/// fire after a store to `field`. Anchored right after the field's effect in
+/// the runtime transition, so the assertion sees the post-store state. A
+/// failed assertion panics, which both the proptest and Kani harnesses
+/// surface as a failure / verification violation. On-chain codegen doesn't
+/// use this transition emitter, so hooks never reach the program.
+fn emit_after_store_hooks(out: &mut String, spec: &ParsedSpec, field: &str, indent: &str) {
+    let base = effect_target_base(field);
+    for hook in &spec.hooks {
+        if let crate::check::ParsedHookKind::AfterStore(f) = &hook.kind {
+            if f == base {
+                for a in &hook.asserts {
+                    out.push_str(&format!(
+                        "{}assert!({}, \"hook after_store({}) violated\");\n",
+                        indent, a.rust, base
+                    ));
+                }
+            }
+        }
+    }
+}
+
 pub fn emit_transition_fn(
     out: &mut String,
     op: &ParsedHandler,
@@ -1214,6 +1236,7 @@ pub fn emit_transition_fn(
                     value,
                     "            ",
                 );
+                emit_after_store_hooks(out, spec, field, "            ");
             }
             out.push_str("        }\n");
         }
@@ -1236,6 +1259,7 @@ pub fn emit_transition_fn(
                 continue;
             }
             emit_one_effect(out, op, spec, wrapping, field, op_kind, value, "    ");
+            emit_after_store_hooks(out, spec, field, "    ");
         }
     }
 

--- a/references/qedspec-dsl.md
+++ b/references/qedspec-dsl.md
@@ -446,6 +446,46 @@ fires `ghost_update_unknown_handler`.
 pure function the real Rust impl is checked against; a `ghost` is
 *stateful* spec-only state with no on-chain counterpart.
 
+### `hook`
+
+A cross-cutting **assertion fired at a statement boundary** inside any
+handler — for checking a condition at an *intermediate* point, not just at
+handler exit (which is what `property` covers).
+
+```
+hook after_store(balance) {
+  assert state.balance <= state.cap
+}
+```
+
+- **`after_store(<field>)`** — fires immediately after any store to
+  `<field>`, in every handler that writes it. The assertion sees the
+  post-store state. The RHS may read state and handler params.
+- One or more `assert <expr>` per hook (optional trailing `;`).
+
+**Enforcement.** Hooks are checked in the **runtime backends** (Kani +
+proptest): the assertion is injected into the spec-model transition right
+after the field's effect, so a violation surfaces as a verification
+failure / failing test. The `state_machine_sequence` proptest harness is
+emitted whenever a spec declares hooks, so the assertions are actually
+exercised across random handler sequences. Hooks are **omitted from the
+on-chain program codegen** entirely.
+
+**Lean.** Lean enforcement is deferred (it lands with qedsvm); a spec with
+hooks fires the informational `hook_lean_unsupported` lint. Use
+`qedgen verify --kani` / `--proptest` to exercise them today.
+
+**`before_cpi`.** `hook before_cpi { … }` / `hook before_cpi(<Iface>) { … }`
+parses, but enforcement is deferred (`hook_before_cpi_unsupported` lint):
+the runtime state model has no CPI to anchor to, and the natural home —
+the Lean CPI-theorem precondition — is on the deferred Lean path. Encode
+the precondition as a `requires` on the calling handler for now.
+
+**Scope / lints.** `after_store` is wired into the **flat single-account**
+transition; indexed/multi-account shapes fire
+`hook_unsupported_state_shape`. `after_store(<field>)` naming a non-state
+field fires `hook_unknown_field`; an empty hook body fires `hook_no_assert`.
+
 ## PDA and events
 
 ### `pda`


### PR DESCRIPTION
Implements the last open item of #67 — now buildable since #66 (MIR) landed, because hook firing sites map cleanly onto statement boundaries.

## `hook after_store(<field>) { assert <expr> }`
A cross-cutting assertion checked at an **intermediate** point — right after a store to `<field>` — not just at handler exit like `property`.

```
hook after_store(balance) {
  assert state.balance <= state.cap
}
```

- **Enforced in Kani + proptest**: the assertion is injected into the shared spec-model transition (`emit_transition_fn`) right after the field's effect, so a violation is a failing test / verification violation. (Both backends treat a panic inside the transition as a failure.)
- The proptest `state_machine_sequence` harness is now emitted whenever a spec declares hooks — without a driver the injected assertions would never execute. **Verified non-vacuous**: an unguarded violating handler is caught; a guarded one passes.
- **Omitted from on-chain codegen** (it doesn't use `emit_transition_fn`).

## Lean: deferred (lands with qedsvm)
A spec with hooks fires the informational `hook_lean_unsupported` lint; Lean ignores hooks. Use `qedgen verify --kani` / `--proptest` to exercise them.

## `before_cpi`: parsed, enforcement deferred
`hook before_cpi[(<Iface>)]` parses but lints `hook_before_cpi_unsupported` — the runtime state model has no CPI to anchor to, and its natural home (the Lean CPI-theorem precondition) is on the deferred Lean path. Encode the precondition as a `requires` for now.

## Lints
`hook_unknown_field`, `hook_unsupported_state_shape` (flat single-account only), `hook_no_assert`.

## Verification
- 924 unit tests + all snapshot suites green; `clippy -D warnings` + `cargo fmt --check` clean.
- 7 files, +345/−2; no MIR change (hooks read from `ParsedSpec`, like the other instrumentation sub-emitters); no existing snapshot changed.
- Docs: `references/qedspec-dsl.md` gains a `hook` section.

With this, **all five #67 items are addressed**: 1 & 5 documented as already-shipped, 2 (`exists`) + 3 (ghosts) in #77, 4 (hooks) here. `before_cpi` + full Lean hook enforcement remain follow-ups (the latter via qedsvm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
