### PR TITLE
fix(qedgen): codegen lowering — Lean effect-RHS qualifier + proptest chained subtraction (v2.33.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.33.0"
+version = "2.33.1"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/.qed/last-error.json
+++ b/crates/qedgen/.qed/last-error.json
@@ -1,5 +1,5 @@
 {
   "command": "probe",
-  "stderr": "No `pub fn <name>(ctx: Context<X>, ...)` handlers found under /tmp/claude-501/.tmpWZdI46. Brownfield mode needs at least one Anchor handler to fuzz; confirm `--root` points at the program crate (e.g. `programs/my_prog/`).",
-  "timestamp": "2026-06-01T06:09:48.091166000Z"
+  "stderr": "No `pub fn <name>(ctx: Context<X>, ...)` handlers found under /tmp/claude-501/.tmpG71ZHW. Brownfield mode needs at least one Anchor handler to fuzz; confirm `--root` points at the program crate (e.g. `programs/my_prog/`).",
+  "timestamp": "2026-06-02T10:02:13.717240000Z"
 }

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.33.0"
+version = "2.33.1"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/src/lean_gen_mir.rs
+++ b/crates/qedgen/src/lean_gen_mir.rs
@@ -2636,23 +2636,32 @@ fn emit_handler_transition(out: &mut String, mir: &Mir, h: &crate::mir::HandlerM
                 if is_account_pubkey_ref(&rhs.rust) {
                     continue;
                 }
+                // Re-qualify the RHS: a bare state-field ref (e.g.
+                // `reserved := state.cap`, which upstream strips to `cap`)
+                // must render as `s.cap`, while handler params and literals
+                // pass through unchanged. The indexed-state path already
+                // routes through this helper; the flat path used to emit
+                // `rhs.lean` verbatim, producing `reserved := cap`
+                // (unknown identifier `cap`) — issue #79 Bug A.
                 with_parts.push(format!(
                     "{} := {}",
                     safe_name(&path_field_name(path)),
-                    rhs.lean
+                    effect_value_to_lean_mir(&rhs.lean, &h.params)
                 ));
             }
             Stmt::CheckedAdd { path, delta, .. }
             | Stmt::WrapAdd { path, delta }
             | Stmt::SatAdd { path, delta } => {
                 let f = safe_name(&path_field_name(path));
-                with_parts.push(format!("{} := s.{} + {}", f, f, delta.lean));
+                let d = effect_value_to_lean_mir(&delta.lean, &h.params);
+                with_parts.push(format!("{} := s.{} + {}", f, f, d));
             }
             Stmt::CheckedSub { path, delta, .. }
             | Stmt::WrapSub { path, delta }
             | Stmt::SatSub { path, delta } => {
                 let f = safe_name(&path_field_name(path));
-                with_parts.push(format!("{} := s.{} - {}", f, f, delta.lean));
+                let d = effect_value_to_lean_mir(&delta.lean, &h.params);
+                with_parts.push(format!("{} := s.{} - {}", f, f, d));
             }
             _ => {}
         }
@@ -2751,7 +2760,8 @@ fn build_guard_cond_parts(mir: &Mir, h: &crate::mir::HandlerMir) -> Vec<String> 
             .map(|(_, t)| t.clone())
         {
             if ty_max_const(&ty).is_some() {
-                conds.push(format!("{} \u{2264} s.{}", delta.lean, safe_name(&field)));
+                let d = effect_value_to_lean_mir(&delta.lean, &h.params);
+                conds.push(format!("{} \u{2264} s.{}", d, safe_name(&field)));
             }
         }
     }
@@ -5658,6 +5668,51 @@ mod tests {
         assert!(
             adt_lean.contains("inductive State where"),
             "pragma state_repr = adt must route to render_single_account_adt"
+        );
+    }
+
+    #[test]
+    fn flat_effect_rhs_field_ref_is_qualified() {
+        // Issue #79 Bug A: a `set` effect copying one state field into
+        // another (`reserved := state.cap`) is stored bare (`cap`) by the
+        // adapter. The flat-state transition emitter used to emit it
+        // verbatim — `reserved := cap` — which is an unknown identifier in
+        // Lean. It must re-qualify to `s.cap` (as the indexed path and the
+        // proptest backend already do), while a handler param stays bare.
+        let src = "spec BudgetRepro\n\
+            type State\n\
+            \x20 | Uninitialized\n\
+            \x20 | Active of { cap : U64, used : U64, reserved : U64 }\n\
+            type Error\n\
+            \x20 | Zero\n\
+            handler open (c : U64) : State.Uninitialized -> State.Active {\n\
+            \x20 permissionless\n\
+            \x20 accounts { payer : signer, writable }\n\
+            \x20 requires c > 0 else Zero\n\
+            \x20 effect { cap := c\n\
+            \x20          used := 0\n\
+            \x20          reserved := 0 }\n\
+            }\n\
+            handler reset : State.Active -> State.Active {\n\
+            \x20 permissionless\n\
+            \x20 accounts { caller : signer }\n\
+            \x20 effect { used := 0\n\
+            \x20          reserved := state.cap }\n\
+            }\n";
+        let parsed = crate::chumsky_adapter::parse_str(src).expect("parse budget spec");
+        let out = render(&crate::mir::lower(&parsed));
+        assert!(
+            out.contains("reserved := s.cap"),
+            "state-field RHS must render qualified `s.cap`:\n{out}"
+        );
+        assert!(
+            !out.contains("reserved := cap,") && !out.contains("reserved := cap "),
+            "bare `cap` (unknown identifier) must not appear:\n{out}"
+        );
+        // A handler param assigned to a field stays bare (it IS in scope).
+        assert!(
+            out.contains("cap := c"),
+            "handler-param RHS must stay bare `c`:\n{out}"
         );
     }
 

--- a/crates/qedgen/src/rust_codegen_util.rs
+++ b/crates/qedgen/src/rust_codegen_util.rs
@@ -104,16 +104,50 @@ fn wrap_arithmetic_atom(atom: &str) -> String {
 }
 
 fn wrap_arith_expr(expr: &str) -> String {
-    if let Some(pos) = expr.rfind(" + ") {
-        let lhs = &expr[..pos];
-        let rhs = &expr[pos + 3..];
-        format!("{}.wrapping_add({})", lhs.trim(), rhs.trim())
-    } else if let Some(pos) = expr.rfind(" - ") {
-        let lhs = &expr[..pos];
-        let rhs = &expr[pos + 3..];
-        format!("{}.wrapping_sub({})", lhs.trim(), rhs.trim())
-    } else {
-        expr.to_string()
+    // Split on the RIGHTMOST top-level (paren-depth-0) ` + ` / ` - ` and
+    // recurse on the LHS, so a chained expression lowers left-associatively:
+    //   `cap - used - reserved`
+    //     → `cap.saturating_sub(used).saturating_sub(reserved)`
+    // This matches Lean's left-associative `Nat` subtraction. The previous
+    // `rfind` form was both non-recursive (it left the inner operator as a
+    // bare infix, e.g. `cap - used.wrapping_sub(reserved)`, mis-grouping the
+    // expression) and used `wrapping_sub`, which diverged from the Lean tier
+    // on underflow — issue #79 Bug B. Subtraction lowers to `saturating_sub`
+    // because Lean models guard/property arithmetic over `Nat`, whose `-`
+    // truncates at 0; the proptest predicate must test the same relation the
+    // Lean proof discharges. Addition keeps `wrapping_add` (grouping fixed).
+    let bytes = expr.as_bytes();
+    let mut depth: i32 = 0;
+    let mut split: Option<(usize, u8)> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            op @ (b'+' | b'-')
+                if depth == 0
+                    && i > 0
+                    && bytes[i - 1] == b' '
+                    && i + 1 < bytes.len()
+                    && bytes[i + 1] == b' ' =>
+            {
+                split = Some((i, op));
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    match split {
+        Some((pos, op)) => {
+            let lhs = wrap_arith_expr(expr[..pos].trim());
+            let rhs = expr[pos + 1..].trim();
+            if op == b'+' {
+                format!("{}.wrapping_add({})", lhs, rhs)
+            } else {
+                format!("{}.saturating_sub({})", lhs, rhs)
+            }
+        }
+        None => expr.to_string(),
     }
 }
 
@@ -1305,6 +1339,27 @@ mod tests {
         assert_eq!(effect_target_base("s.foo"), "s");
         assert_eq!(effect_target_base("map[0]"), "map");
         assert_eq!(effect_target_base("  padded  "), "padded");
+    }
+
+    #[test]
+    fn chained_subtraction_lowers_left_assoc_saturating() {
+        // Issue #79 Bug B: `cap - used - reserved` is left-associative
+        // `Nat` subtraction in the Lean tier. The proptest guard must
+        // lower it as `cap.saturating_sub(used).saturating_sub(reserved)`
+        // — recursive, correctly grouped, and saturating (not the old
+        // `cap - used.wrapping_sub(reserved)`, which both mis-grouped and
+        // diverged from Lean on underflow).
+        let got =
+            translate_guard_to_rust("amount <= state.cap - state.used - state.reserved", true);
+        assert_eq!(
+            got,
+            "amount <= s.cap.saturating_sub(s.used).saturating_sub(s.reserved)"
+        );
+        // Addition keeps left-assoc grouping (wrapping unchanged).
+        assert_eq!(
+            translate_guard_to_rust("state.a + state.b + state.c <= state.d", true),
+            "s.a.wrapping_add(s.b).wrapping_add(s.c) <= s.d"
+        );
     }
 
     #[test]

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/lending.codegen.txt
+++ b/crates/qedgen/tests/snapshots/lending.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 anchor-lang = "0.32.1"
 
@@ -3603,7 +3603,7 @@ fn execute(s: &mut State, member_index: u8) -> bool {
 }
 
 fn cancel_proposal(s: &mut State) -> bool {
-    if !((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)) {
+    if !((s.member_count.saturating_sub(s.rejection_count) < s.threshold)) {
         return false;
     }
     if s.status != Status::HasProposal {
@@ -3898,7 +3898,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)));
+        prop_assume!(!((s.member_count.saturating_sub(s.rejection_count) < s.threshold)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }

--- a/crates/qedgen/tests/snapshots/multisig.proptest.rs
+++ b/crates/qedgen/tests/snapshots/multisig.proptest.rs
@@ -159,7 +159,7 @@ fn execute(s: &mut State, member_index: u8) -> bool {
 }
 
 fn cancel_proposal(s: &mut State) -> bool {
-    if !((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)) {
+    if !((s.member_count.saturating_sub(s.rejection_count) < s.threshold)) {
         return false;
     }
     if s.status != Status::HasProposal {
@@ -454,7 +454,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)));
+        prop_assume!(!((s.member_count.saturating_sub(s.rejection_count) < s.threshold)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }

--- a/crates/qedgen/tests/snapshots/percolator.codegen.txt
+++ b/crates/qedgen/tests/snapshots/percolator.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 anchor-lang = "0.32.1"
 

--- a/crates/qedgen/tests/snapshots/percolator.proptest.rs
+++ b/crates/qedgen/tests/snapshots/percolator.proptest.rs
@@ -135,7 +135,7 @@ fn account_solvent_at(s: &State, i: usize) -> bool {
 }
 
 fn add_user(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -147,7 +147,7 @@ fn add_user(s: &mut State, i: usize) -> bool {
 }
 
 fn add_lp(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -198,7 +198,7 @@ fn deposit(s: &mut State, i: usize, amount: u128) -> bool {
 }
 
 fn withdraw(s: &mut State, i: usize, amount: u128) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((amount) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((amount) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -262,7 +262,7 @@ fn execute_trade(s: &mut State, a: usize, b: usize, size_q: i128, exec_price: u6
 }
 
 fn liquidate_case_0(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128)) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128)) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -273,7 +273,7 @@ fn liquidate_case_0(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_case_1(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -285,7 +285,7 @@ fn liquidate_case_1(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_otherwise(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -927,7 +927,7 @@ proptest! {
     #[test]
     fn add_user_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))));
         prop_assert!(!add_user(&mut s, i),
             "add_user must reject when guard is violated");
     }
@@ -938,7 +938,7 @@ proptest! {
     #[test]
     fn add_lp_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))));
         prop_assert!(!add_lp(&mut s, i),
             "add_lp must reject when guard is violated");
     }
@@ -982,7 +982,7 @@ proptest! {
     #[test]
     fn withdraw_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], amount in prop_oneof![0u128..=3u128, (u128::MAX - 3)..=u128::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((amount) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((amount) as i128))));
         prop_assert!(!withdraw(&mut s, i, amount),
             "withdraw must reject when guard is violated");
     }
@@ -1037,7 +1037,7 @@ proptest! {
     #[test]
     fn liquidate_case_0_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128)) && (false)));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128)) && (false)));
         prop_assert!(!liquidate_case_0(&mut s, i),
             "liquidate_case_0 must reject when guard is violated");
     }
@@ -1048,7 +1048,7 @@ proptest! {
     #[test]
     fn liquidate_case_1_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))));
         prop_assert!(!liquidate_case_1(&mut s, i),
             "liquidate_case_1 must reject when guard is violated");
     }
@@ -1059,7 +1059,7 @@ proptest! {
     #[test]
     fn liquidate_otherwise_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) && (false)));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) && (false)));
         prop_assert!(!liquidate_otherwise(&mut s, i),
             "liquidate_otherwise must reject when guard is violated");
     }

--- a/examples/rust/cross-program-vault/programs/Cargo.toml
+++ b/examples/rust/cross-program-vault/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/lending/Cargo.toml
+++ b/examples/rust/lending/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/multisig/Cargo.toml
+++ b/examples/rust/multisig/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/multisig/programs/tests/proptest.rs
+++ b/examples/rust/multisig/programs/tests/proptest.rs
@@ -159,7 +159,7 @@ fn execute(s: &mut State, member_index: u8) -> bool {
 }
 
 fn cancel_proposal(s: &mut State) -> bool {
-    if !((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)) {
+    if !((s.member_count.saturating_sub(s.rejection_count) < s.threshold)) {
         return false;
     }
     if s.status != Status::HasProposal {
@@ -454,7 +454,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)));
+        prop_assume!(!((s.member_count.saturating_sub(s.rejection_count) < s.threshold)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }

--- a/examples/rust/multisig/tests/proptest.rs
+++ b/examples/rust/multisig/tests/proptest.rs
@@ -159,7 +159,7 @@ fn execute(s: &mut State, member_index: u8) -> bool {
 }
 
 fn cancel_proposal(s: &mut State) -> bool {
-    if !((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)) {
+    if !((s.member_count.saturating_sub(s.rejection_count) < s.threshold)) {
         return false;
     }
     if s.status != Status::HasProposal {
@@ -454,7 +454,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count.wrapping_sub(s.rejection_count) < s.threshold)));
+        prop_assume!(!((s.member_count.saturating_sub(s.rejection_count) < s.threshold)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
 
 [workspace]

--- a/examples/rust/percolator/tests/proptest.rs
+++ b/examples/rust/percolator/tests/proptest.rs
@@ -135,7 +135,7 @@ fn account_solvent_at(s: &State, i: usize) -> bool {
 }
 
 fn add_user(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -147,7 +147,7 @@ fn add_user(s: &mut State, i: usize) -> bool {
 }
 
 fn add_lp(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -198,7 +198,7 @@ fn deposit(s: &mut State, i: usize, amount: u128) -> bool {
 }
 
 fn withdraw(s: &mut State, i: usize, amount: u128) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((amount) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((amount) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -262,7 +262,7 @@ fn execute_trade(s: &mut State, a: usize, b: usize, size_q: i128, exec_price: u6
 }
 
 fn liquidate_case_0(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128)) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128)) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -273,7 +273,7 @@ fn liquidate_case_0(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_case_1(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) {
         return false;
     }
     if s.status != Status::Active {
@@ -285,7 +285,7 @@ fn liquidate_case_1(s: &mut State, i: usize) -> bool {
 }
 
 fn liquidate_otherwise(s: &mut State, i: usize) -> bool {
-    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) && (false)) {
+    if !((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) && (false)) {
         return false;
     }
     if s.status != Status::Active {
@@ -927,7 +927,7 @@ proptest! {
     #[test]
     fn add_user_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))));
         prop_assert!(!add_user(&mut s, i),
             "add_user must reject when guard is violated");
     }
@@ -938,7 +938,7 @@ proptest! {
     #[test]
     fn add_lp_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 0) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))));
         prop_assert!(!add_lp(&mut s, i),
             "add_lp must reject when guard is violated");
     }
@@ -982,7 +982,7 @@ proptest! {
     #[test]
     fn withdraw_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], amount in prop_oneof![0u128..=3u128, (u128::MAX - 3)..=u128::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((amount) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (s.accounts[(i) as usize].capital >= amount) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((amount) as i128))));
         prop_assert!(!withdraw(&mut s, i, amount),
             "withdraw must reject when guard is violated");
     }
@@ -1037,7 +1037,7 @@ proptest! {
     #[test]
     fn liquidate_case_0_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128)) && (false)));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128)) && (false)));
         prop_assert!(!liquidate_case_0(&mut s, i),
             "liquidate_case_0 must reject when guard is violated");
     }
@@ -1048,7 +1048,7 @@ proptest! {
     #[test]
     fn liquidate_case_1_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))));
         prop_assert!(!liquidate_case_1(&mut s, i),
             "liquidate_case_1 must reject when guard is violated");
     }
@@ -1059,7 +1059,7 @@ proptest! {
     #[test]
     fn liquidate_otherwise_rejects_invalid(s in arb_boundary_state(), i in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128).wrapping_add(((s.accounts[(i) as usize].pnl) as i128)) as i128)) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128).wrapping_add(((s.I) as i128)) as i128)) >= ((0) as i128))) && (false)));
+        prop_assume!(!((s.accounts[(i) as usize].active == 1) && (!(((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) >= ((0) as i128))) && (!(((((((s.accounts[(i) as usize].capital) as i128) + ((s.accounts[(i) as usize].pnl) as i128)) as i128) + ((s.I) as i128)) as i128) >= ((0) as i128))) && (false)));
         prop_assert!(!liquidate_otherwise(&mut s, i),
             "liquidate_otherwise must reject when guard is violated");
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "description": "Agent skill for spec-driven verification and audit of Solana programs \u2014 .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
Closes #79. Patch release **v2.33.1**.

## Bug A — Lean flat-state effect RHS lost its qualifier
A `set`/`add`/`sub` effect copying one state field into another (`reserved := state.cap`) lowered to `reserved := cap` in the flat-state Lean transition — an unknown identifier, so `lake build` fails. The adapter deliberately stores effect values bare (`state.cap` → `cap`, "to match pest output"); the Lean **indexed** path and the **proptest** backend already re-qualify bare state-field refs to `s.<field>`, but the flat-state emitter emitted `rhs.lean` verbatim.

**Fix:** route the flat path's Assign/Add/Sub RHS through the existing `effect_value_to_lean_mir` helper (as the indexed path does). Handler params and literals stay bare; bare state-field refs become `s.cap`.

## Bug B — proptest chained subtraction mis-grouped + wrong operation
`amount <= cap - used - reserved` lowered to `s.cap - s.used.wrapping_sub(s.reserved)` — `wrap_arith_expr` split on a single `rfind` without recursing (inner operator left as bare infix → wrong grouping) and used `wrapping_sub`, where Lean models guard/property arithmetic over `Nat` (truncated, saturating at 0).

**Fix:** split on the rightmost top-level (paren-depth-aware) operator and recurse on the LHS (left-associative, matching Lean), emitting `saturating_sub` for subtraction so the proptest predicate tests the same relation the Lean proof discharges → `s.cap.saturating_sub(s.used).saturating_sub(s.reserved)`. Addition keeps `wrapping_add` with grouping fixed.

## Fallout (correct, expected)
Regenerating snapshots surfaced two latent instances of the same Bug B divergence in bundled examples:
- **multisig**: `member_count.wrapping_sub(rejection_count) < threshold` → `saturating_sub` (was silently wrong — wraps to a huge value when `rejection_count > member_count`).
- **percolator**: 16 `wrapping_add` inside `(… as i128)` exact-arithmetic casts → consistent plain `+` (the old output was internally inconsistent from the non-recursion bug).

No generated **Lean** for any bundled example changed (none use Bug A's pattern), so the lake-build outcome is identical to v2.33.0.

## Tests / gates
- New regressions: `chained_subtraction_lowers_left_assoc_saturating`, `flat_effect_rhs_field_ref_is_qualified`.
- `cargo test` (all 15 binaries), `cargo fmt --check`, `cargo clippy -- -D warnings`, `check-readme-drift.sh`, `cargo audit` + `cargo deny check`, example `--regen-drift`: all clean.
- Version bumped (Cargo.toml + package.json, consistency check passes); codegen snapshots + 8 example Cargo.toml tag pins re-stamped to v2.33.1.
