### PR TITLE
docs(auditor): mark sBPF unsupported in the auditor skill (v2.33.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.33.1"
+version = "2.33.2"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/.qed/last-error.json
+++ b/crates/qedgen/.qed/last-error.json
@@ -1,5 +1,5 @@
 {
   "command": "probe",
-  "stderr": "No `pub fn <name>(ctx: Context<X>, ...)` handlers found under /tmp/claude-501/.tmpG71ZHW. Brownfield mode needs at least one Anchor handler to fuzz; confirm `--root` points at the program crate (e.g. `programs/my_prog/`).",
-  "timestamp": "2026-06-02T10:02:13.717240000Z"
+  "stderr": "No `pub fn <name>(ctx: Context<X>, ...)` handlers found under /tmp/claude-501/.tmp1nPl0e. Brownfield mode needs at least one Anchor handler to fuzz; confirm `--root` points at the program crate (e.g. `programs/my_prog/`).",
+  "timestamp": "2026-06-02T11:10:06.177910000Z"
 }

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.33.1"
+version = "2.33.2"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/lending.codegen.txt
+++ b/crates/qedgen/tests/snapshots/lending.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 anchor-lang = "0.32.1"
 

--- a/crates/qedgen/tests/snapshots/percolator.codegen.txt
+++ b/crates/qedgen/tests/snapshots/percolator.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 anchor-lang = "0.32.1"
 

--- a/examples/rust/cross-program-vault/programs/Cargo.toml
+++ b/examples/rust/cross-program-vault/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/examples/rust/lending/Cargo.toml
+++ b/examples/rust/lending/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/examples/rust/multisig/Cargo.toml
+++ b/examples/rust/multisig/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.1" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.33.2" }
 
 [workspace]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.33.1",
+  "version": "2.33.2",
   "description": "Agent skill for spec-driven verification and audit of Solana programs \u2014 .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -35,13 +35,24 @@ Invoke this skill when the user asks to:
 - "check for vulnerabilities" / "find bugs in this code"
 - `/audit`
 
-Works on Solana programs targeting any qedgen-supported runtime:
+Supported runtimes:
 - **Anchor** (detected by `Anchor.toml` or `anchor-lang` in Cargo.toml)
 - **Native Rust solana-program** (detected by `solana-program` dep
   without `anchor-lang`)
-- **sBPF** (detected by `.s` files under `programs/` or `src/`)
 - **qedgen's own codegen target** (detected by `quasar-lang` dep or
   `#[qed(verified)]` markers)
+
+**sBPF / hand-written assembly (`.s` files) is NOT supported.** The
+auditor finds bugs by pattern-matching Rust *source text* (account
+structs, typed wrappers, `checked_*`); assembly carries none of those
+cues, rust-analyzer doesn't index `.s` files, and the auditor has never
+surfaced a real finding on an assembly target. **If you detect an sBPF
+program, say so plainly and stop** — don't run a thin audit that implies
+coverage it doesn't have. Redirect the user: sBPF is a first-class qedgen
+*proof/codegen* target (Lean via `qedgen asm2lean` — see the main
+`qedgen` skill), and if they want auditor-style coverage they should
+write a `.qedspec` and use spec-aware mode (the CLI-emitted predicates
+are runtime-agnostic).
 
 ## Tool surface
 
@@ -63,8 +74,7 @@ just string analysis, no type resolution required for most predicates.
 - LSP-style type queries / find-references — speeds up data-flow tracing
   for `arithmetic_overflow_wrapping` and cross-handler analysis for
   `lifecycle_one_shot_violation`. Falls back to surface analysis if
-  unavailable. sBPF predicates ignore LSP entirely (rust-analyzer
-  doesn't index `.s` files).
+  unavailable.
 
 ## Adversarial mindset
 
@@ -462,9 +472,11 @@ MEDIUM and below: a repro is encouraged but not required.
    step skipped (use the existing spec, not a synthesized skeleton).
    Phase 3 continues.
 
-   ### Runtimes the extractor doesn't cover yet (sBPF, exotic)
+   ### Runtimes the extractor doesn't cover (sBPF, exotic)
 
-   Fall back to the legacy silent scaffold or hand-walk the source
+   sBPF/assembly is out of scope for the auditor (see the "NOT
+   supported" note above) — stop and redirect rather than scaffold.
+   For other exotic-but-Rust shapes, hand-walk the source
    (`qedgen spec --idl <path>` for Anchor with IDL).
 
    ### Artifact emission
@@ -488,7 +500,9 @@ MEDIUM and below: a repro is encouraged but not required.
 
 Each category has a **spec-aware predicate** (CLI-emitted via
 `qedgen probe --spec`) and **per-runtime spec-less predicates**
-(your job to apply via Read+Grep on the impl).
+(your job to apply via Read+Grep on the impl). Spec-less predicates
+cover **Anchor and native Rust only** — sBPF/assembly is out of scope
+(see the "NOT supported" note above).
 
 ### `missing_signer` — CRITICAL
 Spec-aware: handler has no `auth X` clause and is not marked
@@ -503,8 +517,6 @@ Spec-less per-runtime:
   handler's authority-shaped account is consumed by an `invoke_signed`
   to a trusted program (stake / token / system / spl-associated-token),
   signer is enforced downstream by the callee program. Not a finding.
-- **sBPF:** look for the bytes-comparison pattern that checks the signer
-  flag in the AccountInfo header.
 
 ### `arbitrary_cpi` — HIGH
 Spec-aware: handler has a writable `token`-typed account but spec
@@ -518,8 +530,6 @@ Spec-less per-runtime:
   validates the program ID. (Pattern: many native programs centralize
   validation in helpers — recognize `check_*_program` style names as
   authoritative.)
-- **sBPF:** program-ID-comparison pattern (`ldxw` of caller-supplied
-  program-ID, compare against constant) before `invoke_signed_c`.
 - Corpus: "CPI without program-id check on Token CPI" — recurring
   audit-firm shape; the typed-`Program<T>` Anchor wrapper exists
   specifically to close it.
@@ -535,9 +545,6 @@ Spec-less per-runtime:
   `QuoteLots(u64)` or `BaseAtoms(u64)` may have `Mul`/`Add` impls that
   use raw operators on the inner field. Naive grep for `* u64` misses
   these; check the wrapper type's impls.
-- **sBPF:** `add64` / `sub64` / `mul64` without subsequent bound checks.
-  `lddw` constants compared against intermediate sums is a strong hit
-  pattern.
 - **Saturating-by-design suppression:** explicit `saturating_*` on
   rent / fee / supply math is a documented design choice in many Anza
   programs. Surface as informational only when the field is amount-shaped
@@ -575,12 +582,11 @@ Spec-less per-runtime:
   discriminator-zeroing pattern. Cross-handler analysis: same account
   shape consumed by multiple non-terminal handlers without flag
   transitions.
-- **Native / sBPF:** harder; spec-less coverage is limited at this
-  layer. Recommend the user write a `.qedspec` for robust
-  state-machine reasoning (transitions to spec-aware mode on next
-  audit).
+- **Native:** harder; spec-less coverage is limited at this layer.
+  Recommend the user write a `.qedspec` for robust state-machine
+  reasoning (transitions to spec-aware mode on next audit).
 
-### `cpi_param_swap` — HIGH (Anchor + Native; sBPF n/a)
+### `cpi_param_swap` — HIGH (Anchor + Native)
 Spec-less only — spec-aware shape is weak (the spec already declares
 `transfer from X to Y`).
 
@@ -595,7 +601,7 @@ signature gives the vault-PDA the right to authorize transfers from
 itself. This is the intended pattern for vault withdrawals; do **not**
 flag it as a swap.
 
-### `pda_canonical_bump` — MEDIUM (Anchor + Native; sBPF rare)
+### `pda_canonical_bump` — MEDIUM (Anchor + Native)
 Spec-less only.
 - **Anchor:** `#[account(seeds = [...], bump)]` — the `bump` keyword
   signals canonical-bump enforcement. Absence is the warning.
@@ -1760,9 +1766,13 @@ case the pattern shouldn't have been flagged at CRIT/HIGH).
 - **Don't ask consent for the audit's named side-effects.** `.qedspec`,
   `.qed/findings/`, `.qed/probe-suppress.toml` are all expected
   artifacts of the named operation. Show them in the digest footer.
-- **Don't refuse if the runtime is sBPF or native Rust.** Reduced
-  category coverage is OK; surface what categories apply, mark the
-  others "not applicable to this runtime."
+- **Don't refuse a native-Rust audit.** Reduced category coverage vs
+  Anchor is OK; surface what categories apply, mark the others "not
+  applicable to this runtime."
+- **Do decline an sBPF/assembly audit.** It's not supported (the
+  auditor has never surfaced a real finding on bytecode). Say so
+  plainly, don't run a thin audit that implies coverage, and redirect
+  to the qedgen proof path (`asm2lean`) or spec-aware mode.
 - **Don't dispatch to dylint / anchor-lints / external static analyzers.**
   You're in author position via the user's harness; you have strictly
   more info than dylint's HIR/MIR analysis can recover.


### PR DESCRIPTION
Patch release **v2.33.2**.

The `qedgen-auditor` skill presented sBPF/assembly as a first-class supported runtime (description, runtime list, per-class detection sub-bullets), but:
- the auditor finds bugs by pattern-matching Rust **source text** — assembly carries none of those structural cues, and rust-analyzer doesn't index `.s` files;
- **no audit has ever surfaced a real finding on a bytecode target** (every validated audit to date has run against Anchor/native/Pinocchio programs);
- the body already contradicted the headline ("sBPF n/a", "rare", "limited").

### Change
sBPF/hand-written assembly is now explicitly **NOT supported** by the auditor. On detecting an sBPF program it **declines and redirects** — to the qedgen proof path (`asm2lean`) or to spec-aware mode (CLI-emitted predicates are runtime-agnostic) — rather than running a thin audit that implies coverage it doesn't have.

- Description + runtime list: sBPF removed from supported runtimes, explicit "NOT supported" note.
- Removed the speculative per-class sBPF detection sub-bullets (`missing_signer`, `arbitrary_cpi`, `arithmetic_overflow`); `cpi_param_swap`/`pda_canonical_bump`/`lifecycle` no longer list sBPF. Spec-less predicates now documented as Anchor + native Rust only.
- "Don't refuse if sBPF" rule flipped to "**Do decline an sBPF audit**."
- sBPF remains a first-class qedgen **proof/codegen** target (`asm2lean`) — only the brownfield auditor opts out.

### Mechanics
Version bump to 2.33.2 re-stamps the version-pinned codegen snapshots + 8 example Cargo.toml tag pins (tag-line only). Gates: `cargo test` (15 binaries), fmt, clippy `-D warnings`, readme-drift, `cargo audit` + `cargo deny`, example `--regen-drift` — all clean. No generated code/Lean changed (doc + tag bumps only).
