### PR TITLE
chore(auditor): default to Opus 4.8; scrub named protocols/programs

### DIFF
--- a/docs/security-primer.md
+++ b/docs/security-primer.md
@@ -1,7 +1,7 @@
 # Solana Security Primer
 
-Long-form reference for the named exploits and operational
-threat-model incidents the QEDGen Auditor's category catalog cites
+Long-form reference for the exploit classes and operational
+threat-model shapes the QEDGen Auditor's category catalog cites
 in its `Corpus:` lines. This file lives outside the loaded skill
 surface — it's intended as human-readable background for someone
 exploring the repo, **not** loaded into the auditor's context on
@@ -16,25 +16,30 @@ in `SKILL.md`. Don't expand this primer at the cost of catalog
 expressiveness — the primer is reference, the catalog is the
 working surface.
 
+Incidents are described by their *vulnerability class*, not by the
+protocol they happened to. The shape is what generalizes; the name
+is not.
+
 ---
 
-## Part 1 — Named on-chain exploits
+## Part 1 — On-chain exploit classes
 
-The nine incidents below are public, code-pattern exploits (not
+The nine classes below are public, code-pattern exploits (not
 key-management / supply-chain incidents — those are in Part 2).
 Each maps to one or more SKILL.md categories' `Corpus:` line.
 Auditors investigating that category should re-read the relevant
 entry here to refresh their mental model of *how the primitive
 actually got exercised at scale*.
 
-### Wormhole sysvar-instructions spoof (2022, $326M)
+### Sysvar-instructions spoof (2022, ~$326M)
 
 **SKILL.md categories:** `account_type_confusion`, `arbitrary_cpi`
 
-**Root cause:** `verify_signatures` used `load_instruction_at`
-(deprecated) which did not check that the input account was the
-real `sysvar::instructions` account; attacker passed a fake sysvar
-that looked like a successful prior secp256k1 verification.
+**Root cause:** signature verification used a deprecated
+instruction-introspection call that did not check that the input
+account was the real `sysvar::instructions` account; attacker
+passed a fake sysvar that looked like a successful prior secp256k1
+verification.
 
 **Attack flow:**
 1. Construct an account whose data mimics the layout the
@@ -42,10 +47,10 @@ that looked like a successful prior secp256k1 verification.
    Ed25519 / secp256k1 verify.
 2. Pass that fake account in the position the program expected
    the real sysvar.
-3. `verify_signatures` reads the fake "previous" verification,
-   marks the guardian set as approved.
-4. Call `complete_wrapped` to mint 120k wETH on Solana with no
-   Ethereum-side lock.
+3. The verifier reads the fake "previous" verification, marks the
+   guardian / signer set as approved.
+4. Call the privileged mint path to issue wrapped assets with no
+   collateral-side lock.
 
 **Grep for:**
 - `load_instruction_at(` (deprecated; use
@@ -63,24 +68,25 @@ account type confusion (treating any AccountInfo as a sysvar).
 
 ---
 
-### Cashio fake-account chain (2022, $52.8M)
+### Fake-account collateral chain (2022, ~$52.8M)
 
 **SKILL.md categories:** `field_chain_missing_root_anchor`,
 `missing_owner_check`
 
-**Root cause:** no "trusted root" — the `mint` field on the arrow
-account was never validated against the real Saber LP mint.
-Attacker forged the entire chain (arrow → crate_collateral_tokens
-→ mint) with worthless underlying.
+**Root cause:** no "trusted root" — the `mint` field on the leaf
+account was never validated against the real LP mint. Attacker
+forged the entire chain (leaf → collateral-tokens → mint) with
+worthless underlying.
 
 **Attack flow:**
-1. Create a fake `arrow` account with a mint pointer to
+1. Create a fake leaf account with a mint pointer to
    attacker-controlled tokens.
-2. Create a fake `crate_collateral_tokens` account that points to
-   the fake arrow.
-3. Pass the fake chain into `print_cash`, which trusts the leaf
-   and walks up.
-4. Mint 2B CASH against zero real collateral; dump.
+2. Create a fake collateral-tokens account that points to the
+   fake leaf.
+3. Pass the fake chain into the mint instruction, which trusts the
+   leaf and walks up.
+4. Mint billions of stablecoin units against zero real collateral;
+   dump.
 
 **Grep for:**
 - Account-A reads pubkey field from Account-B without verifying
@@ -97,30 +103,29 @@ the swap path).
 
 ---
 
-### Mango Markets oracle manipulation (2022, $114M)
+### Thin-spot-oracle cross-margin manipulation (2022, ~$114M)
 
 **SKILL.md categories:** `oracle_staleness`,
 `frontrunnable_no_slippage`, `flash_loan_amplified_governance`
 
-**Root cause:** thin spot oracle for low-liquidity governance
-token (MNGO); single-block price ramp via cross-trading from one
-attacker account to another, leveraging artificially-inflated
-MNGO as collateral against real assets.
+**Root cause:** thin spot oracle for a low-liquidity governance
+token; single-block price ramp via cross-trading from one attacker
+account to another, leveraging the artificially-inflated token as
+collateral against real assets.
 
 **Attack flow:**
-1. Open offsetting long+short positions in MNGO-PERP from two
-   attacker accounts ($10M USDC seed).
-2. Pump MNGO spot price 2¢ → 91¢ in ~10 minutes with
+1. Open offsetting long+short perp positions in the thin token
+   from two attacker accounts (~$10M seed).
+2. Pump the token's spot price ~45x in ~10 minutes with
    low-liquidity buys.
 3. Long-side account's collateral value balloons; borrow ~$114M
-   of real assets (USDC, BTC, ETH, SOL, mSOL) against it.
-4. Walk away — short side gets liquidated, but the borrows
+   of real assets against it.
+4. Walk away — the short side gets liquidated, but the borrows
    already left.
 
 **Grep for:**
 - Oracle reads with no TWAP / no min-confidence-interval check
-- Single-source price feeds (one Pyth product, no Switchboard
-  cross-check)
+- Single-source price feeds (one oracle product, no cross-check)
 - Collateral valuation that uses spot price without
   liquidity-adjusted haircut on thin markets
 - `borrow_value = collateral_value * ltv` patterns where
@@ -132,14 +137,15 @@ borrow caps = no circuit breaker.
 
 ---
 
-### Crema Finance fake tick account (2022, $8.8M)
+### Fake CLMM tick account (2022, ~$8.8M)
 
 **SKILL.md categories:** `account_type_confusion`,
 `missing_owner_check`
 
-**Root cause:** CLMM accepted attacker-supplied "tick" account
-without owner check or PDA derivation check; tick stored in-band
-fee-growth values that the program trusted.
+**Root cause:** a concentrated-liquidity AMM accepted an
+attacker-supplied "tick" account without owner check or PDA
+derivation check; the tick stored in-band fee-growth values that
+the program trusted.
 
 **Attack flow:**
 1. Flash-loan from a lending protocol.
@@ -164,7 +170,7 @@ tick crossed).
 
 ---
 
-### Saber / SPL token-swap rounding (2022, ~$700M at risk; Neodyme public disclosure pre-exploit)
+### Stable-swap bidirectional rounding (2022, ~$700M at risk; public pre-exploit disclosure)
 
 **SKILL.md category:** `rounding_direction_round_trip`
 
@@ -194,21 +200,21 @@ round-trips before pool empties).
 
 ---
 
-### Solend USDH oracle manipulation (2022, $1.26M)
+### DEX-pool-sourced oracle write-lock manipulation (2022, ~$1.26M)
 
 **SKILL.md category:** `oracle_staleness`
 
-**Root cause:** USDH price feed sourced from a single Saber pool;
-attacker write-locked the pool account in the same slot as the
-oracle update to prevent arbitrage and inflate the read.
+**Root cause:** a stablecoin price feed sourced from a single DEX
+pool; attacker write-locked the pool account in the same slot as
+the oracle update to prevent arbitrage and inflate the read.
 
 **Attack flow:**
-1. Predict the slot the oracle will sample USDH price.
-2. Send a tx in that slot that write-locks the Saber USDH/USDC
-   pool while pumping price.
+1. Predict the slot the oracle will sample the price.
+2. Send a tx in that slot that write-locks the source pool while
+   pumping price.
 3. Oracle reads inflated price ($1 → $15).
-4. Deposit USDH as collateral, borrow $1.26M of real assets,
-   walk.
+4. Deposit the stablecoin as collateral, borrow ~$1.26M of real
+   assets, walk.
 
 **Grep for:**
 - Oracle wrapper reading from a DEX pool reserve as the price
@@ -224,20 +230,21 @@ permissionless borrow against single-asset.
 
 ---
 
-### Nirvana flash-loan oracle pump (2022, $3.5M)
+### Self-priced-token flash-loan pump (2022, ~$3.5M)
 
 **SKILL.md category:** `oracle_staleness` (specifically, the
 self-priced-token sub-shape)
 
-**Root cause:** ANA price oracle read from internal bonding curve
-which itself responded to flash-loan-sized buys.
+**Root cause:** the protocol token's price oracle read from an
+internal bonding curve which itself responded to flash-loan-sized
+buys.
 
 **Attack flow:**
-1. Borrow $10M USDC flash loan from a lending protocol.
-2. Mint ANA via Nirvana's bonding curve, pumping its internal
-   price.
-3. Use the inflated ANA holdings as collateral to drain the
-   treasury at the new price.
+1. Borrow ~$10M flash loan from a lending protocol.
+2. Mint the protocol token via its bonding curve, pumping its
+   internal price.
+3. Use the inflated holdings as collateral to drain the treasury
+   at the new price.
 4. Repay flash loan, keep delta.
 
 **Grep for:**
@@ -251,28 +258,29 @@ requirement); same-tx price+borrow (no cooldown).
 
 ---
 
-### Loopscale RateX collateral mispricing (2025, $5.8M)
+### Niche-collateral single-read mispricing (2025, ~$5.8M)
 
 **SKILL.md category:** `oracle_staleness`
 
-**Root cause:** isolated lending market priced RateX PT tokens
-from a single point-in-time pool read with no TWAP; attacker
-manipulated the source pool to overstate collateral.
+**Root cause:** an isolated lending market priced a niche
+principal-token from a single point-in-time pool read with no
+TWAP; attacker manipulated the source pool to overstate
+collateral.
 
 **Attack flow:**
-1. Identify which market uses the manipulable RateX-PT pool as
-   its price source.
+1. Identify which market uses the manipulable principal-token pool
+   as its price source.
 2. Trade against that pool to push the spot price upward in one
    block.
-3. Deposit PT tokens at inflated valuation, borrow USDC / SOL up
-   to the inflated cap.
+3. Deposit the principal tokens at inflated valuation, borrow
+   stablecoin / SOL up to the inflated cap.
 4. Walk; the rest of the market is collateralized in real assets.
 
 **Grep for:**
 - New / niche / illiquid token added as collateral with the same
   oracle pattern as blue-chip
 - Per-market collateral pricing where the function pulls a fresh
-  read each call (no TWAP, no Pyth confidence band)
+  read each call (no TWAP, no oracle confidence band)
 - "Genesis vault" or "isolated pool" that shares a price oracle
   with an attacker-influenceable venue
 
@@ -282,7 +290,7 @@ token); single-block price + borrow.
 
 ---
 
-### Jet Protocol C-ratio close-account bypass (2022, $25M near-miss; private disclosure)
+### Sentinel-null close-account solvency bypass (2022, ~$25M near-miss)
 
 **SKILL.md categories:** `sentinel_null_key_array_short_circuit`,
 `pda_lifecycle_reuse_after_close`
@@ -290,7 +298,7 @@ token); single-block price + borrow.
 **Root cause:** position-array iteration broke the loop when it
 encountered `Pubkey::default()` as a sentinel for "closed
 account"; attacker placed real positions *after* the closed slot
-so they were skipped during collateralization check.
+so they were skipped during the collateralization check.
 
 **Attack flow:**
 1. Open a benign position to fill array slot 0.
@@ -313,7 +321,7 @@ permissionless position-open (creates the array hole).
 
 ## Part 2 — Operational / off-chain threat-model incidents
 
-The five incidents below are *off-chain* — key custody, social
+The five shapes below are *off-chain* — key custody, social
 engineering, supply chain, telemetry. They don't map to a code
 pattern in SKILL.md because the bug isn't in the program; the
 bug is in the operational envelope around it. Auditors should
@@ -323,7 +331,7 @@ threat-models that handwave these — "the admin key is secure,"
 and a real audit interrogates those claims rather than accepting
 them.
 
-### Raydium admin-key trojan (2022, $4.4M)
+### Hot-wallet admin-key trojan (2022, ~$4.4M)
 
 **Threat-model shape:** privileged operations gated by a single
 hot-wallet authority; key exfiltrated by malware on the operator's
@@ -344,7 +352,7 @@ draws.
 
 ---
 
-### Cypher economic-loop exploit (2023, $1M)
+### Self-trade economic-loop exploit (2023, ~$1M)
 
 **Threat-model shape:** margin / PnL accounting that updates from
 same-tx self-trade fills — the program had no notion that a trade
@@ -362,14 +370,14 @@ self-cross allowed.
 
 ---
 
-### Durable-nonce admin-takeover (2026-04, $285M)
+### Durable-nonce admin-takeover (2026-04, ~$285M)
 
-**Threat-model shape:** governance multisig signed
+**Threat-model shape:** a governance multisig signed
 durable-nonce-anchored transactions that were submitted weeks
 later. Attackers spent months building social trust as a fake
 quant firm, captured signatures intended for one purpose, then
 replayed them with attacker-controlled durable-nonce accounts to
-execute admin transfer.
+execute an admin transfer.
 
 **Attack flow:**
 1. Social-engineer access; create 4 durable-nonce accounts (2
@@ -381,7 +389,7 @@ execute admin transfer.
 4. Submit when context shifts (after a real test withdrawal);
    transfer admin authority to attacker.
 5. Whitelist a fake collateral token, deposit 500M of it, borrow
-   $285M.
+   ~$285M.
 
 **Auditor question:** does the program's admin-transfer flow
 have a time-lock? Does it use a fresh recent blockhash (not a
@@ -396,19 +404,19 @@ signature-validity model = arbitrary delay; instant admin reconfig
 
 ---
 
-### Mobile wallet Sentry-telemetry key leak (2022, $6M, 9,231 wallets)
+### Telemetry-SDK key leak (2022, ~$6M, ~9,231 wallets)
 
-**Threat-model shape:** mobile wallet pointed Sentry SDK at a
-self-hosted endpoint, transmitted private-key material in error
-logs. Attacker observed leaked secrets at the Sentry endpoint
-and reconstructed private keys for affected users.
+**Threat-model shape:** a mobile wallet pointed a crash-telemetry
+SDK at a self-hosted endpoint and transmitted private-key material
+in error logs. Attacker observed leaked secrets at the telemetry
+endpoint and reconstructed private keys for affected users.
 
 **Auditor question:** for any companion SDK shipping with the
 program (frontend, signing service, indexer), does any
 secret-bearing object pass through a logging / telemetry SDK
-without redaction? Sentry, LogRocket, Datadog, OpenTelemetry —
-all need an explicit `beforeSend` scrubber or a structured
-"this field never gets logged" pattern.
+without redaction? Any crash-reporting / observability SDK needs
+an explicit `beforeSend` scrubber or a structured "this field
+never gets logged" pattern.
 
 **Compose with:** off-chain — listed here because Solana program
 audits frequently include a companion SDK whose telemetry leaks
@@ -416,11 +424,12 @@ PDA seeds, derivation paths, or unsigned tx payloads.
 
 ---
 
-### Solana web3.js supply-chain backdoor (2024-12, ~$130-160k)
+### Client-library supply-chain backdoor (2024-12, ~$130-160k)
 
-**Threat-model shape:** spear-phish on npm publish-credential
-holder; v1.95.6 / 1.95.7 shipped with `addToQueue` exfiltrating
-private keys via fake CloudFlare headers.
+**Threat-model shape:** spear-phish on an npm publish-credential
+holder; two patch versions of a widely-used Solana client library
+shipped with code exfiltrating private keys via fake CloudFlare
+headers.
 
 **Attack flow:**
 1. Phish credentials + 2FA from a maintainer.
@@ -451,11 +460,12 @@ threat model: they need pen-testing on the signing-prompt
 surface, anti-phishing review of the dApp-pairing handshake,
 and OS-level isolation review for key storage.
 
-The Slope and web3.js incidents in Part 2 illustrate why this
-boundary matters: both were catastrophic for users despite the
-on-chain programs being correct. An auditor finding "the program
-holds no admin keys" is a *true* statement that doesn't bound the
-user's risk if their wallet leaks signatures.
+The telemetry-leak and supply-chain incidents in Part 2
+illustrate why this boundary matters: both were catastrophic for
+users despite the on-chain programs being correct. An auditor
+finding "the program holds no admin keys" is a *true* statement
+that doesn't bound the user's risk if their wallet leaks
+signatures.
 
 When auditing a project that ships both program code and a
 wallet / signing companion, escalate the wallet surface to a

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -16,7 +16,7 @@ The auditor's §3c trust-surface walk and authority-side intent-drift
 sweep require sustained multi-step reasoning across the program's
 dependency graph and documented invariants. Use one of:
 
-- **Claude Opus 4.7 with extended thinking** (Claude Code — this
+- **Claude Opus 4.8 with extended thinking** (Claude Code — this
   skill auto-injects `ultrathink` via a UserPromptSubmit hook
   installed alongside the skill; see `hooks/README.md`).
 - **GPT-5.5 in high-reasoning mode** (Codex / Cursor / other
@@ -104,13 +104,12 @@ Working assumptions when auditing:
   findings. Walk the Category catalog below before writing the
   report and ask, for each category's Corpus line, "could the same
   shape happen here?" Investigate even if the category isn't in the
-  spec-aware probe output. For long-form narrative on the named
-  incidents the Corpus lines cite (Wormhole, Cashio, Mango, Saber,
-  Crema, Solend, Nirvana, Loopscale, Jet, King-of-the-SOL) and the
-  operational threat-model context (key-management compromises,
-  supply-chain attacks), see `docs/security-primer.md` in the
-  repository — kept outside the loaded skill surface to preserve
-  the auditor's context budget for live audit work.
+  spec-aware probe output. For long-form narrative on the public
+  exploit classes the Corpus lines cite and the operational
+  threat-model context (key-management compromises, supply-chain
+  attacks), see `docs/security-primer.md` in the repository — kept
+  outside the loaded skill surface to preserve the auditor's context
+  budget for live audit work.
 - **Authority-side intent-drift is the catalog's edge.** Hand audits
   implicitly model an unprivileged attacker; *"the authority is
   trusted"* dismisses most authority-side findings as out-of-scope.
@@ -118,7 +117,7 @@ Working assumptions when auditing:
   own authority is still a real finding — users count on documented
   behavior even when they trust the operator. Walk every privileged
   action against every documented invariant in source comments / README
-  / docstrings. Phoenix's empirical study (5 catalog hits both prior
+  / docstrings. An internal empirical study (5 catalog hits both prior
   audits missed) is the corpus.
 
 If you finish an audit and your worst finding is a generic
@@ -565,13 +564,11 @@ value.
 Detection cue: pattern-match on `.saturating_sub(<expr with raw * or
 +>)`, `.checked_add(<expr with raw mul>)`, etc.
 
-- Corpus: pre-audit `phoenix-v1` (commit `85b9158`,
-  `src/state/markets/fifo.rs::match_order` lines 1041-1046) —
-  `inflight_order.adjusted_quote_lot_budget.saturating_sub(
-  self.tick_size * order_id.price_in_ticks *
-  num_base_lots_quoted)`. The three-way `u64` multiplication panics on
-  extreme parameters; `saturating_sub` only catches subtraction
-  underflow.
+- Corpus: a pre-audit order-book program — in the order-matching path,
+  `adjusted_quote_lot_budget.saturating_sub(tick_size *
+  price_in_ticks * num_base_lots_quoted)`. The three-way `u64`
+  multiplication panics on extreme parameters; `saturating_sub` only
+  catches subtraction underflow.
 
 ### `lifecycle_one_shot_violation` — MEDIUM
 Spec-aware: spec models lifecycle states; handler mutates state but
@@ -610,7 +607,7 @@ Spec-less only.
   via helpers (e.g., `check_pool_authority_address(...)?` returning a
   bump seed) is also canonical — recognize the indirection.
 
-### `account_type_confusion` — CRITICAL (Wormhole shape)
+### `account_type_confusion` — CRITICAL (well-known-account spoof shape)
 Spec-less only — a "well-known" account (sysvar, token program,
 mint, mint-authority, vault) is typed as `AccountInfo<'info>` /
 `UncheckedAccount` instead of its strongly-typed wrapper. Attacker
@@ -623,14 +620,14 @@ shape; downstream reads trust the spoof.
 - **Native:** AccountInfo passed for a sysvar / mint / token
   program without an `==` check on the well-known program ID, or for
   a user account without an `is_initialized` discriminator check.
-- Corpus: Wormhole sysvar-instructions spoof (2022, $326M; OtterSec /
-  Wormhole joint post-mortem); Cashio fake-account chain (2022,
-  $52.8M; canonical example, mint trust chain); Crema Finance fake
-  tick account (2022, $8.8M — CLMM tick-account sub-shape); Sysvar
-  typed as `AccountInfo` (recurring Anchor variant of the Wormhole
-  shape). For the field-level forgery sub-class where the typed
-  wrapper passes but a stored `Pubkey` field is unanchored, see
-  `field_chain_missing_root_anchor` (Cashio's underlying shape).
+- Corpus: the sysvar-instructions spoof class (2022, ~$326M loss; a
+  forged instructions-sysvar account); the fake-account mint-trust-chain
+  class (2022, ~$52.8M); the fake CLMM tick-account sub-shape (2022,
+  ~$8.8M); Sysvar typed as `AccountInfo` (recurring Anchor variant of
+  the spoof shape). For the field-level forgery sub-class where the
+  typed wrapper passes but a stored `Pubkey` field is unanchored, see
+  `field_chain_missing_root_anchor` (the mint-trust-chain underlying
+  shape).
 
 ### `missing_owner_check` — CRITICAL
 Spec-less only — handler reads or trusts data from an account
@@ -651,7 +648,8 @@ finding class — see `token_account_role_anchoring` below.
 - **Native:** any `account.data.borrow()` or struct deserialize
   without first verifying `account.owner == &expected_program_id`.
 - Corpus: typed-account-with-untyped-owner pattern (widely-documented
-  Solana-native primitive; named publicly by Neodyme among others).
+  Solana-native primitive; named publicly in multiple security
+  write-ups).
   Scope-pair clarifier: this category is about the SOLANA-RUNTIME
   `account.owner` field; the SPL token-account internal `owner`
   byte-range is `token_account_role_anchoring` (above).
@@ -887,7 +885,7 @@ no one whose signature is required has a reason to invoke.
   Fixed in PR #35 by adding a permissionless path once
   `claimed == total`.
 
-### `field_chain_missing_root_anchor` — CRITICAL (Cashio shape)
+### `field_chain_missing_root_anchor` — CRITICAL (forged-collateral-chain shape)
 Spec-less only. **Distinct from `missing_owner_check`** — Anchor's
 typed wrappers (`Account<T>`) close the runtime-owner question for
 an incoming account, but **the *fields* on that typed account
@@ -900,7 +898,7 @@ validator pins it back to the bank's stored value.
 A fresh auditor walking the catalog from `missing_owner_check`
 will see "Anchor types this account, owner check enforced — no
 finding" and move on. That's correct for the owner check, wrong
-for field-level forgery. The Cashio exploit is exactly this gap.
+for field-level forgery. The forged-collateral-chain class is exactly this gap.
 
 - **Anchor:** for every `Validate::validate()` (or per-handler
   validation block) and for each passed-in account A and field F
@@ -915,10 +913,11 @@ for field-level forgery. The Cashio exploit is exactly this gap.
 - **Native:** same shape; walk every `key()` / `pubkey ==`
   comparison. If neither side is `<trusted-state>.<field>`, the
   comparison only proves consistency, not anchoring.
-- Corpus: Cashio fake-account chain — the canonical example
-  (`crate_token` / `crate_mint` / `crate_collateral_tokens` form
-  an internally-consistent chain that's never anchored to
-  `bank.crate_token` / `bank.crate_mint`). $52.8M in 2022.
+- Corpus: the fake-account collateral-chain class — the canonical
+  example is a stablecoin bank where the deposit-token / mint /
+  collateral accounts form an internally-consistent chain that's
+  never anchored to the bank's stored token/mint fields (~$52.8M,
+  2022).
 
 ### `close_account_redirection` — HIGH
 Anchor `close = <destination>` field, or manual close via lamport
@@ -930,8 +929,8 @@ and not validated against an expected wallet (creator, treasury, etc.).
   **to.try_borrow_mut_lamports()? += x;` with no destination check.
 - Pair with `missing_signer` or `permissionless` marker → drain rent
   from any closable PDA.
-- Corpus: Jet Protocol C-ratio close-account bypass (2022, $25M
-  near-miss; private disclosure / publicly-discussed post-mortem);
+- Corpus: a lending-protocol collateral-ratio close-account bypass
+  (2022, ~$25M near-miss; publicly-discussed post-mortem);
   token-account close to wrong destination is the Anchor
   `close = receiver` variant of the same shape.
 
@@ -1004,22 +1003,23 @@ balance/votes/whatever.
   of init handlers; or the init handler accepts an existing account
   and overwrites in place.
 - Corpus: recurring audit-firm primitive; the canonical
-  Cashio-shape kill-chain pairs init-without-is-initialized with
-  `pda_lifecycle_reuse_after_close` for full account replay.
+  forged-collateral-chain kill-chain pairs init-without-is-initialized
+  with `pda_lifecycle_reuse_after_close` for full account replay.
 
 ### `oracle_staleness` — HIGH (DeFi-specific)
 Spec-less only — handler reads a price/rate-shaped field from an
 oracle account without verifying freshness (timestamp window) or
 confidence (deviation bound).
-- **Anchor / Native:** `pyth::load_price_feed(...)` followed by
-  immediate use without `get_price_no_older_than` or equivalent.
-  Switchboard: `AggregatorAccountData::get_result()` without a
-  staleness check on `latest_confirmed_round.round_open_timestamp`.
-- Corpus: Mango Markets oracle manipulation (2022, $114M); Solend
-  USDH (2022, $1.26M); Nirvana flash-loan oracle pump (2022,
-  $3.5M); Loopscale RateX collateral mispricing (2025, $5.8M). For
-  the short-TWAP-window sub-shape (fresh oracle, gameable in one
-  block) see `twap_gameable_single_block`.
+- **Anchor / Native:** an oracle price-load call (e.g.
+  `load_price_feed(...)`) followed by immediate use without a
+  `get_price_no_older_than`-style staleness gate; or an aggregator
+  read (e.g. `get_result()`) with no staleness check on the
+  round-open timestamp.
+- Corpus: cross-margin oracle manipulation (2022, ~$114M); a stablecoin
+  oracle mispricing (2022, ~$1.26M); a flash-loan oracle pump (2022,
+  ~$3.5M); collateral mispricing from a stale derived rate (2025,
+  ~$5.8M). For the short-TWAP-window sub-shape (fresh oracle, gameable
+  in one block) see `twap_gameable_single_block`.
 
 ### `frontrunnable_no_slippage` — HIGH (DeFi-specific)
 Permissionless swap-shape handler accepts no `min_amount_out` /
@@ -1031,7 +1031,7 @@ Sandwich-bot bait.
 - **Anchor / Native:** `swap`-shape handler signature with no
   `min_*` parameter, or with one that's ignored in the body.
 - Corpus: sandwich / MEV against AMM swap is the recurring shape;
-  the Mango perp-market manipulation (2022, $114M) is the same
+  the cross-margin perp-market manipulation (2022, ~$114M) is the same
   primitive applied to a thin spot oracle rather than to a swap
   router. "Frontrun the permissionless `claim` / `crank`" is the
   same primitive on rate-limited cleanup handlers.
@@ -1043,8 +1043,8 @@ or rent-exempt account silently, can also bypass ownership checks
 the runtime would otherwise enforce.
 - **Native / Anchor (rare):** any direct mutation of
   `*account.lamports.borrow_mut()` outside a close path.
-- Corpus: "King of the SOL" lamport-transfer freeze
-  (OtterSec public blog post). Same primitive turns up across
+- Corpus: the lamport-transfer-freeze class (documented in public
+  security-research write-ups). Same primitive turns up across
   audit-firm reports as "manual lamport mutation freezes
   rent-exempt / executable accounts."
 
@@ -1163,8 +1163,8 @@ swap pairs per transaction and drains the pool over hours.
   gets fewer underlying) — the asymmetric pair.
 - Compose-with-what: low-fee bulk transactions (Solana's 5000-lamport
   flat tx cost makes hundreds of round-trip swaps per tx economical).
-- Corpus: Saber / SPL token-swap stable-swap rounding (2022, ~$700M
-  at risk; Neodyme public disclosure pre-exploit). Same-class
+- Corpus: the canonical stable-swap rounding class (2022, ~$700M
+  at risk; public disclosure pre-exploit). Same-class
   generalization of bidirectional rounding on any stable-swap or
   two-leg conversion pair; also recurs as "loss of precision / wrong
   rounding direction" across audit-firm reports.
@@ -1238,7 +1238,7 @@ returned in same transaction.
   same chain (Solana has multiple lending protocols routinely used as
   flash sources); permissionless vote submission.
 - Corpus: same shape as the cross-margin oracle manipulations
-  (Mango 2022) when applied to governance rather than collateral —
+  (2022) when applied to governance rather than collateral —
   the live-balance read at decision time is the gap in both.
 
 ### `authority_transfer_missing_nominate_accept` — MEDIUM (operational hardening)
@@ -1332,12 +1332,10 @@ can grief the future creation by pre-funding the PDA address with
 - **Native:** look for `invoke_signed(&system_instruction::create_account(...), ...)`
   with seeds derived from caller-supplied or deterministically-public
   inputs (e.g. `[b"seat", market_key, trader_key]`).
-- Corpus: pre-audit `phoenix-v1` (commit `85b9158`,
-  `src/program/processor/manage_seat.rs:75-85` for seat PDAs and
-  `src/program/processor/initialize.rs:170-189` for market vault PDAs)
-  used raw `system_instruction::create_account` against deterministic
-  PDA addresses. Subsequently fixed via a `system_utils::create_account`
-  helper that does transfer+allocate+assign.
+- Corpus: a pre-audit order-book program used raw
+  `system_instruction::create_account` against deterministic PDA
+  addresses (seat PDAs and market-vault PDAs). Subsequently fixed via a
+  `create_account` helper that does transfer+allocate+assign.
 
 ### `execution_order_state_before_check` — MEDIUM
 Spec-less only. A handler mutates state field X in an early branch,
@@ -1349,13 +1347,12 @@ Detection cue: an early-return / early-mutation arm of an `if let` /
 `match` that zeroes / freezes a field that a later condition tests
 for being nonzero / unmodified.
 
-- Corpus: pre-audit `phoenix-v1` (commit `85b9158`,
-  `src/state/markets/fifo.rs::place_order_inner`) — the no-deposit-mode
-  branch (lines 782-796) zeroes `num_*_lots_out` and moves the matched
-  amount into trader free funds. The later FOK check (line 819)
-  compares those fields against `min_*_to_fill` — but they were just
-  zeroed, so FOK in no-deposit mode always fails the minimum-fill
-  check. Subsequently fixed by reordering the branches.
+- Corpus: a pre-audit order-book program — in the place-order path, the
+  no-deposit-mode branch zeroes `num_*_lots_out` and moves the matched
+  amount into trader free funds. The later FOK check compares those
+  fields against `min_*_to_fill` — but they were just zeroed, so FOK in
+  no-deposit mode always fails the minimum-fill check. Subsequently
+  fixed by reordering the branches.
 
 ### `flag_branch_no_op` — MEDIUM
 Spec-less only. A `match` / `if-else` arm distinguishes two variants
@@ -1367,14 +1364,12 @@ Detection cue: `A | B => { primary_effect(); if variant == B {
 secondary(); } }` where `primary_effect` is load-bearing and
 `secondary` is local-only.
 
-- Corpus: pre-audit `phoenix-v1` (commit `85b9158`,
-  `src/state/markets/fifo.rs::match_order` lines 1019-1051) — the
-  `SelfTradeBehavior::CancelProvide | DecrementTake` arm calls the
-  same `reduce_order_inner(..., None, ...)` (which removes the full
-  resting order) for both variants. The post-branch only adjusts the
-  inflight budget bookkeeping, never reduces the cancellation amount.
-  `DecrementTake` is documented as a *partial* reduction but is
-  implemented identically to `CancelProvide`.
+- Corpus: a pre-audit order-book program — in the order-matching path,
+  a self-trade-behavior arm calls the same full-order-reduction helper
+  for two variants. The post-branch only adjusts the inflight budget
+  bookkeeping, never reduces the cancellation amount. One variant is
+  documented as a *partial* reduction but is implemented identically to
+  the full-cancel variant.
 
 ## qedgen-codegen runtime
 
@@ -1562,7 +1557,7 @@ exhaustive; use as a thinking primer, not a checklist.
 | transfer_hook_reentrancy | + | mid-transfer state read | = | classic reentrancy (Solana-native, HIGH→CRIT) |
 | permissionless marker | + | unbounded amount param | = | griefing / draining via repeated calls (HIGH) |
 | permissionless init | + | unchecked authority field on init | = | attacker bakes their own pubkey as `mint_authority` / `withdraw_authority` / `admin` at init time → privileged CPI authority on every later operation (CRIT) |
-| field_chain_missing_root_anchor | + | typed-but-unanchored CPI authority field | = | forge a fake collateral chain that the validator accepts as internally-consistent → invoke privileged CPI (mint, withdraw) under the real authority (CRIT, Cashio shape) |
+| field_chain_missing_root_anchor | + | typed-but-unanchored CPI authority field | = | forge a fake collateral chain that the validator accepts as internally-consistent → invoke privileged CPI (mint, withdraw) under the real authority (CRIT, forged-collateral-chain shape) |
 | init_config_field_unanchored | + | permissionless_state_writer init | = | frontrun legitimate init, bake attacker pubkey as stored "creator" / "authority" field, capture every fee/yield/withdraw routed through it (CRIT, DAMM-v2 OOD shape) |
 | bounty_intent_drift (mode flag accepted but unbranched) | + | permissionless caller | = | invoke the "forbidden" mode the bounty claimed it didn't allow, every time (HIGH→CRIT depending on what the mode controls) |
 | bounty_intent_drift (spec docstring claims behavior the spec body doesn't enforce) | + | qedgen-codegen mechanization | = | formal-verification artifacts (Lean / Kani / proptest) faithfully translate the broken spec — `lake build` green proves the broken behavior, **giving false confidence that the program is correct** (HIGH-CRIT depending on what the docstring claimed) |
@@ -1792,9 +1787,9 @@ case the pattern shouldn't have been flagged at CRIT/HIGH).
 - 30–60s for native-Rust programs of similar size — multi-file call
   chains (e.g., `try_deposit` → `maybe_invoke_deposit` →
   `spl_token::instruction::transfer`) cost more roundtrips.
-- For large programs (Drift / Mango scale), warn the user up front
-  that a full audit may take several minutes; offer a `programs/`
-  subset cut.
+- For large programs (multi-thousand-line, many-handler scale), warn
+  the user up front that a full audit may take several minutes; offer a
+  `programs/` subset cut.
 
 ## Responsible disclosure (third-party programs)
 

--- a/skills/qedgen-auditor/references/data_structure_dep_invariants.md
+++ b/skills/qedgen-auditor/references/data_structure_dep_invariants.md
@@ -151,8 +151,8 @@ suite, check whether it runs under Miri.
 
 ## Corpus
 
-**sokoban red-black-tree `DoubleEndedIterator` (pre-fix).** Ellipsis
-Labs' zero-copy data-structures crate. The `iter_mut` method exposed a
+**Zero-copy red-black-tree `DoubleEndedIterator` (pre-fix).** A
+widely-used zero-copy data-structures crate. The `iter_mut` method exposed a
 `DoubleEndedIterator` whose `next` and `next_back` tracked separate
 cursors with no shared termination check. Once the cursors crossed,
 the same value was reachable from both ends within a single
@@ -164,10 +164,10 @@ iteration. Discovery shape: trust-surface walk of a matching engine
 using `iter_mut` on the RB-tree for in-place price-level updates —
 auditor reads the iterator `impl`, spots the absent shared
 termination, fires a Mollusk repro by replaying two adjacent fills
-through the program's API path. The Phoenix empirical study
-(`audits/phoenix-v1/`) walked past this bug because the v2.19 §3c
-gate only triggered on crypto verbs (`sign`, `verify`, `prove`,
-`commit`) — sokoban is the gap §S3.5 closes.
+through the program's API path. An internal empirical study walked
+past this bug because the v2.19 §3c gate only triggered on crypto
+verbs (`sign`, `verify`, `prove`, `commit`) — the zero-copy
+data-structure dep is the gap §S3.5 closes.
 
 ---
 

--- a/skills/qedgen-auditor/references/trust_surface_primitives.md
+++ b/skills/qedgen-auditor/references/trust_surface_primitives.md
@@ -40,8 +40,8 @@ attack (EU-CMA) given one observed signature per keypair.
    signed in its own chains. Attacker observes `sig` on `m1`, grinds
    `m2` with `digest(m2) ≤ digest(m1)` pointwise, walks each chain
    forward by `(d1[i] - d2[i])`. Polynomial-time, no hash-function
-   break needed. (See `audits/pinocchio-wild-2026-05/
-   solana-winternitz-vault/` for a fired reproducer.)
+   break needed. (A WOTS-shape vault program in our audit corpus
+   had a fired reproducer for exactly this.)
 2. **Key reuse beyond one signature.** Even with checksum, a second
    signature with the same keypair reveals enough chain positions to
    forge any third message. The program must enforce one-shot


### PR DESCRIPTION
Two changes to the auditor skill + security primer:

## 1. Default model → Opus 4.8
The recommended-model section defaults to **Claude Opus 4.8** with extended thinking (was 4.7). GPT-5.5-high stays as the alt-harness path. The "smaller models collapse to surface pattern-matching" caveat is unchanged.

## 2. Scrub every named protocol / program / audit target / firm
Per the directive that the audit must never name a specific protocol or program, removed all named entities from the auditor's **loaded surface** (`SKILL.md` + `references/`) and the **security primer** (`docs/security-primer.md`), replacing each with its generic vulnerability class + rough year/loss:

- Corpus lines, `account_type_confusion` / `field_chain_missing_root_anchor` / oracle / rounding / close-account / sentinel categories — now describe the *shape*, not the incident.
- The primer's "Part 1 — Named on-chain exploits" → "Part 1 — On-chain exploit classes"; each section retitled to its class; all mechanics, attack flows, and grep cues preserved.
- Eval/corpus targets (the order-book program + commit, the zero-copy RB-tree crate, the WOTS-vault) and audit-firm attributions dropped.

**Kept (intentionally):**
- Crypto *primitive* names (Winternitz/WOTS/Lamport/Pedersen/Merkle, RFC 8391) — these are schemes, not protocols.
- Framework names (Anchor/Quasar/Pinocchio) — first-class integration/audit targets, named freely by project convention.
- Oracle SDK detection cues as generic API shapes (`load_price_feed` / `get_result`) without the vendor label.

Verified: a full name-sweep over `skills/qedgen-auditor/` + the primer returns zero hits.