### PR TITLE
feat(codegen): Quasar System.transfer CPI + exhaustive Stmt matches (#66 / #83 tail)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -24,7 +24,7 @@ The UX is **agent-first**: the user interacts with the SKILL (`SKILL.md`) and ag
 - Codegen mechanizes only deterministic translation; business logic (transfers, CPI authority, events, PDA creation) stays agent-filled `todo!()`.
 - When a template can't close a case, emit `sorry` with a comment — never bury it in tactics that might spuriously close.
 - Don't pre-shell to Leanstral/Aristotle for what a local LLM can do. Escalation is for *after* you've tried, not when you expect to need to.
-- The typed MIR (`mir.rs`) exists for bug-class elimination, not LoC: every codegen matches its closed `Stmt` enum, so a missing backend is a compile error, not silent drift. Measure intrinsics by bugs eliminated, not lines saved.
+- The typed MIR (`mir.rs`) exists for bug-class elimination, not LoC: matches over the closed `Stmt` enum are exhaustive by discipline (no `_` arms — see the enum doc in `mir.rs`), so a new statement kind is a compile error at every `Stmt` consumer (Lean codegen + Rust scaffold), not silent drift. Kani/proptest still lower effects from `ParsedSpec` via `rust_codegen_util`. Measure intrinsics by bugs eliminated, not lines saved.
 
 ## Build and test
 

--- a/crates/qedgen/src/codegen_mir.rs
+++ b/crates/qedgen/src/codegen_mir.rs
@@ -1486,7 +1486,19 @@ fn mir_needs_spl(mir: &Mir) -> bool {
             match stmt {
                 Stmt::TokenTransfer { .. } => return true,
                 Stmt::Cpi { target, .. } if target.0 == "Token" => return true,
-                _ => {}
+                Stmt::Cpi { .. }
+                | Stmt::RequireOrAbort { .. }
+                | Stmt::VariantPromote { .. }
+                | Stmt::Assign { .. }
+                | Stmt::CheckedAdd { .. }
+                | Stmt::CheckedSub { .. }
+                | Stmt::WrapAdd { .. }
+                | Stmt::WrapSub { .. }
+                | Stmt::SatAdd { .. }
+                | Stmt::SatSub { .. }
+                | Stmt::Branch { .. }
+                | Stmt::Abort(_)
+                | Stmt::Emit { .. } => {}
             }
         }
     }

--- a/crates/qedgen/src/codegen_shared.rs
+++ b/crates/qedgen/src/codegen_shared.rs
@@ -1949,10 +1949,13 @@ const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
 /// `(target, is_spl_token)`.
 ///
 /// - Anchor    + SPL Token → `anchor_spl::token::*` builder shape
+/// - Anchor    + System    → `anchor_lang::system_program::*` builder shape
 /// - Anchor    + generic   → `solana_program::program::invoke` shape
 /// - Quasar    + SPL Token → `quasar_spl::TokenCpi` method chain
+/// - Quasar    + System    → `Program<SystemProgram>` method chain
 /// - Quasar    + generic   → not implemented (spike scope; §8 slice 3)
 /// - Pinocchio + SPL Token → `pinocchio_token::instructions::*` struct + invoke
+/// - Pinocchio + System    → `pinocchio_system::instructions::*` struct + invoke
 /// - Pinocchio + generic   → not implemented (spike scope; §8 slice 7)
 ///
 /// Returns `None` for any branch that isn't implemented yet — the
@@ -1976,8 +1979,10 @@ fn try_emit_cpi(
         (Target::Anchor, false, true) => emit_system_cpi_anchor(call, handler, iface, spec),
         (Target::Anchor, false, false) => emit_generic_cpi_anchor(call, handler, iface, spec),
         (Target::Quasar, true, _) => emit_spl_token_cpi_quasar(call, handler, spec),
-        // Quasar generic / System CPI — follow-on slice (uses `BufCpiCall`).
-        (Target::Quasar, false, _) => None,
+        (Target::Quasar, false, true) => emit_system_cpi_quasar(call, handler, spec),
+        // Quasar generic (non-SPL, non-System) CPI — follow-on slice
+        // (uses `BufCpiCall`).
+        (Target::Quasar, false, false) => None,
         (Target::Pinocchio, true, _) => emit_spl_token_cpi_pinocchio(call, handler, spec),
         (Target::Pinocchio, false, true) => emit_system_cpi_pinocchio(call, handler, spec),
         // Pinocchio generic (non-SPL, non-System) CPI — follow-on slice
@@ -2516,7 +2521,7 @@ fn emit_system_anchor(
 /// `initialize_account` stays `None` — `quasar-spl` exposes only
 /// `initialize_account3`, whose `owner: &Address` positional is a raw key
 /// (not an account view) and which omits the rent sysvar, so it doesn't
-/// fit the uniform `emit_spl_quasar` helper (see the match arm).
+/// fit the uniform `emit_quasar_method_chain` helper (see the match arm).
 fn emit_spl_token_cpi_quasar(
     call: &crate::check::ParsedCall,
     handler: &ParsedHandler,
@@ -2526,7 +2531,7 @@ fn emit_spl_token_cpi_quasar(
     let prog_name = &token_program_acct.name;
 
     match call.target_handler.as_str() {
-        "transfer" => emit_spl_quasar(
+        "transfer" => emit_quasar_method_chain(
             call,
             handler,
             spec,
@@ -2538,7 +2543,7 @@ fn emit_spl_token_cpi_quasar(
             &["from", "to", "authority"],
             Some("amount"),
         ),
-        "mint_to" => emit_spl_quasar(
+        "mint_to" => emit_quasar_method_chain(
             call,
             handler,
             spec,
@@ -2551,7 +2556,7 @@ fn emit_spl_token_cpi_quasar(
             &["mint", "to", "mint_authority"],
             Some("amount"),
         ),
-        "burn" => emit_spl_quasar(
+        "burn" => emit_quasar_method_chain(
             call,
             handler,
             spec,
@@ -2561,7 +2566,7 @@ fn emit_spl_token_cpi_quasar(
             &["from", "mint", "authority"],
             Some("amount"),
         ),
-        "close_account" => emit_spl_quasar(
+        "close_account" => emit_quasar_method_chain(
             call,
             handler,
             spec,
@@ -2576,27 +2581,29 @@ fn emit_spl_token_cpi_quasar(
         // exposes only `initialize_account3`, whose third positional is
         // `owner: &Address` (a raw key, not an account view) and which
         // omits the rent sysvar. That divergent signature doesn't fit the
-        // positional-account-view `emit_spl_quasar` helper, so it falls
+        // positional-account-view `emit_quasar_method_chain` helper, so it falls
         // through to the caller's `todo!()`.
         _ => None,
     }
 }
 
-/// Emit one Quasar `quasar_spl::*` CPI as a single-line method chain on
-/// the token-program account: `self.<prog>.<method>(&self.<a>, …,
-/// scalar).invoke()?;`. The shape comes from `quasar-spl-0.0.0`'s
-/// `TokenCpi` trait (sibling shape to the Anchor builder).
+/// Emit one Quasar CPI as a single-line method chain on a program
+/// account: `self.<prog>.<method>(&self.<a>, …, scalar).invoke()?;`.
+/// The shape comes from `quasar-spl-0.0.0`'s `TokenCpi` trait (sibling
+/// shape to the Anchor builder); `quasar-lang`'s
+/// `Program<SystemProgram>` exposes the identical chain, so the System
+/// dispatcher (`emit_system_cpi_quasar`) reuses this emitter.
 ///
 /// `account_args_in_order` carries the call-site arg names in the order
-/// the Quasar trait method expects (e.g. `["from", "to", "authority"]`
+/// the Quasar method expects (e.g. `["from", "to", "authority"]`
 /// for `transfer`). The function looks each one up in `call.args` and
 /// resolves it to `&self.<rust_expr>`. Unrecognized arg names short-
 /// circuit to `None`.
-fn emit_spl_quasar(
+fn emit_quasar_method_chain(
     call: &crate::check::ParsedCall,
     handler: &ParsedHandler,
     spec: &ParsedSpec,
-    token_program: &str,
+    program_account: &str,
     method_name: &str,
     account_args_in_order: &[&str],
     scalar_arg: Option<&str>,
@@ -2612,10 +2619,41 @@ fn emit_spl_quasar(
     }
     Some(format!(
         "        self.{}.{}({}).invoke()?;\n",
-        token_program,
+        program_account,
         method_name,
         args.join(", ")
     ))
+}
+
+/// Dispatch a `call System.<handler>(...)` site to its Quasar
+/// `Program<SystemProgram>` method-chain shape
+/// (`self.<system_program>.transfer(&self.<from>, &self.<to>,
+/// <lamports>).invoke()?;`). Only `transfer` is mechanized — the same
+/// slice boundary as the Anchor / Pinocchio System emitters:
+/// `create_account` / `assign` take an `&Address` owner whose
+/// resolution from a spec `Pubkey` arg is a follow-on, so they return
+/// `None` and the caller keeps the breadcrumb.
+fn emit_system_cpi_quasar(
+    call: &crate::check::ParsedCall,
+    handler: &ParsedHandler,
+    spec: &ParsedSpec,
+) -> Option<String> {
+    let sys_prog = find_program_account_for_interface(handler, &call.target_interface)?;
+    let prog_name = &sys_prog.name;
+    match call.target_handler.as_str() {
+        // Program<SystemProgram>::transfer(from, to, lamports) — the
+        // spec's `amount` arg binds the `lamports` positional.
+        "transfer" => emit_quasar_method_chain(
+            call,
+            handler,
+            spec,
+            prog_name,
+            "transfer",
+            &["from", "to"],
+            Some("amount"),
+        ),
+        _ => None,
+    }
 }
 
 /// Pinocchio SPL Token dispatcher. Routes to the right
@@ -6592,14 +6630,10 @@ handler do_init : State.Active -> State.Active {
         );
     }
 
-    /// Pinocchio System Program `transfer` CPI. `call System.transfer(...)`
-    /// must lower to `pinocchio_system::instructions::Transfer { from, to,
-    /// lamports }.invoke()?` — the spec's `amount` arg binds the struct's
-    /// `lamports` field. Before this slice, System calls fell through to a
-    /// `todo!()` breadcrumb on Pinocchio (only SPL Token was mechanized).
-    #[test]
-    fn cpi_emits_pinocchio_system_transfer() {
-        let spec = crate::chumsky_adapter::parse_str(
+    /// Caller fixture for `System.transfer` (payer → pda lamport top-up).
+    /// Shared by the Anchor / Quasar / Pinocchio System transfer tests.
+    fn parse_system_transfer_caller_spec() -> ParsedSpec {
+        crate::chumsky_adapter::parse_str(
             r#"spec Caller
 program_id "11111111111111111111111111111111"
 
@@ -6630,7 +6664,17 @@ handler topup (n : U64) : State.Active -> State.Active {
 }
 "#,
         )
-        .unwrap();
+        .unwrap()
+    }
+
+    /// Pinocchio System Program `transfer` CPI. `call System.transfer(...)`
+    /// must lower to `pinocchio_system::instructions::Transfer { from, to,
+    /// lamports }.invoke()?` — the spec's `amount` arg binds the struct's
+    /// `lamports` field. Before this slice, System calls fell through to a
+    /// `todo!()` breadcrumb on Pinocchio (only SPL Token was mechanized).
+    #[test]
+    fn cpi_emits_pinocchio_system_transfer() {
+        let spec = parse_system_transfer_caller_spec();
         let handler = spec.handlers.iter().find(|h| h.name == "topup").unwrap();
         let call = handler.calls.first().unwrap();
         let rendered = try_emit_cpi(call, handler, &spec, Target::Pinocchio)
@@ -6673,13 +6717,10 @@ handler topup (n : U64) : State.Active -> State.Active {
         );
     }
 
-    /// System `create_account` / `assign` are not mechanized this slice
-    /// (their `owner: &Pubkey` resolution from a spec `Pubkey` arg is a
-    /// follow-on). `try_emit_cpi` must return `None` so the caller keeps
-    /// the breadcrumb rather than emit code that may not type-check.
-    #[test]
-    fn cpi_pinocchio_system_create_account_is_breadcrumb() {
-        let spec = crate::chumsky_adapter::parse_str(
+    /// Caller fixture for `System.create_account`. Shared by the
+    /// Quasar + Pinocchio breadcrumb tests.
+    fn parse_system_create_account_caller_spec() -> ParsedSpec {
+        crate::chumsky_adapter::parse_str(
             r#"spec Caller
 program_id "11111111111111111111111111111111"
 
@@ -6710,7 +6751,16 @@ handler make (l : U64) (s : U64) (o : Pubkey) : State.Active -> State.Active {
 }
 "#,
         )
-        .unwrap();
+        .unwrap()
+    }
+
+    /// System `create_account` / `assign` are not mechanized this slice
+    /// (their `owner: &Pubkey` resolution from a spec `Pubkey` arg is a
+    /// follow-on). `try_emit_cpi` must return `None` so the caller keeps
+    /// the breadcrumb rather than emit code that may not type-check.
+    #[test]
+    fn cpi_pinocchio_system_create_account_is_breadcrumb() {
+        let spec = parse_system_create_account_caller_spec();
         let handler = spec.handlers.iter().find(|h| h.name == "make").unwrap();
         let call = handler.calls.first().unwrap();
         assert!(
@@ -6726,38 +6776,7 @@ handler make (l : U64) (s : U64) (o : Pubkey) : State.Active -> State.Active {
     /// (which is what System fell through to on Anchor before this slice).
     #[test]
     fn cpi_emits_anchor_system_transfer() {
-        let spec = crate::chumsky_adapter::parse_str(
-            r#"spec Caller
-program_id "11111111111111111111111111111111"
-
-interface System {
-  program_id "11111111111111111111111111111111"
-  handler transfer (amount : U64) {
-    discriminant "0x02000000"
-    accounts {
-      from : signer, writable
-      to   : writable
-    }
-    requires amount > 0
-  }
-}
-
-type State | Active of { balance : U64 }
-type Error | E
-
-handler topup (n : U64) : State.Active -> State.Active {
-  permissionless
-  accounts {
-    state          : writable
-    payer          : signer, writable
-    pda            : writable
-    system_program : program
-  }
-  call System.transfer(from = payer, to = pda, amount = n)
-}
-"#,
-        )
-        .unwrap();
+        let spec = parse_system_transfer_caller_spec();
         let handler = spec.handlers.iter().find(|h| h.name == "topup").unwrap();
         let call = handler.calls.first().unwrap();
         let rendered = try_emit_cpi(call, handler, &spec, Target::Anchor)
@@ -6786,6 +6805,63 @@ handler topup (n : U64) : State.Active -> State.Active {
             !rendered.contains("solana_program::program::invoke")
                 && !rendered.contains("anchor_spl"),
             "System transfer must be idiomatic, not generic invoke / SPL; got:\n{rendered}"
+        );
+    }
+
+    /// Quasar System Program `transfer` CPI. `call System.transfer(...)`
+    /// must lower to the `Program<SystemProgram>` method chain
+    /// `self.system_program.transfer(&self.payer, &self.pda, n).invoke()?;`
+    /// — the spec's `amount` arg binds the `lamports` positional. Before
+    /// this slice, ALL non-SPL Quasar CPIs fell through to the `todo!()`
+    /// breadcrumb.
+    #[test]
+    fn cpi_emits_quasar_system_transfer() {
+        let spec = parse_system_transfer_caller_spec();
+        let handler = spec.handlers.iter().find(|h| h.name == "topup").unwrap();
+        let call = handler.calls.first().unwrap();
+        let rendered = try_emit_cpi(call, handler, &spec, Target::Quasar)
+            .expect("Quasar System transfer must emit");
+        assert!(
+            rendered.contains("self.system_program.transfer("),
+            "must invoke transfer on the system-program account; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("&self.payer"),
+            "from arg must resolve to &self.payer; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("&self.pda"),
+            "to arg must resolve to &self.pda; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains(", n)"),
+            "amount param `n` passes through bare as the lamports positional; got:\n{rendered}"
+        );
+        assert!(
+            rendered.trim_end().ends_with(".invoke()?;"),
+            "Quasar method chain must terminate with .invoke()?; got:\n{rendered}"
+        );
+        // Anti-regression: no Anchor / Pinocchio shape leakage.
+        assert!(
+            !rendered.contains("CpiContext")
+                && !rendered.contains("anchor")
+                && !rendered.contains("pinocchio_system"),
+            "Quasar emission must not leak Anchor / Pinocchio shape; got:\n{rendered}"
+        );
+    }
+
+    /// Quasar System `create_account` / `assign` are not mechanized this
+    /// slice (same `&Address` owner-resolution follow-on as the Anchor /
+    /// Pinocchio emitters). `try_emit_cpi` must return `None` so the
+    /// caller keeps the breadcrumb.
+    #[test]
+    fn cpi_quasar_system_create_account_is_breadcrumb() {
+        let spec = parse_system_create_account_caller_spec();
+        let handler = spec.handlers.iter().find(|h| h.name == "make").unwrap();
+        let call = handler.calls.first().unwrap();
+        assert!(
+            try_emit_cpi(call, handler, &spec, Target::Quasar).is_none(),
+            "Quasar create_account must stay a breadcrumb (None) this slice"
         );
     }
 

--- a/crates/qedgen/src/lean_gen_mir.rs
+++ b/crates/qedgen/src/lean_gen_mir.rs
@@ -502,7 +502,20 @@ fn emit_handler_transition_adt(out: &mut String, mir: &Mir, h: &crate::mir::Hand
                     }
                 }
             }
-            _ => {}
+            // `Wrap*` / `Sat*` handle the boundary without aborting;
+            // non-arithmetic stmts carry no bound to check.
+            Stmt::Assign { .. }
+            | Stmt::WrapAdd { .. }
+            | Stmt::WrapSub { .. }
+            | Stmt::SatAdd { .. }
+            | Stmt::SatSub { .. }
+            | Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => {}
         }
     }
 
@@ -529,7 +542,13 @@ fn emit_handler_transition_adt(out: &mut String, mir: &Mir, h: &crate::mir::Hand
             | Stmt::SatSub { path, delta } => {
                 effect_map.insert(strip_variant_prefix(path, mir), ("sub", delta.lean.clone()));
             }
-            _ => {}
+            Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => {}
         }
     }
 
@@ -1428,7 +1447,13 @@ fn infer_idx_promotions_mir(
             | Stmt::WrapSub { path, .. }
             | Stmt::SatAdd { path, .. }
             | Stmt::SatSub { path, .. } => path.segments.first().cloned().unwrap_or_default(),
-            _ => continue,
+            Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => continue,
         };
         if let Some((root, idx, _)) = parse_indexed_lhs(&lhs) {
             record(idx, root);
@@ -1645,7 +1670,13 @@ fn emit_indexed_transition(
             Stmt::CheckedSub { path, delta, .. }
             | Stmt::WrapSub { path, delta }
             | Stmt::SatSub { path, delta } => (path, "sub", delta.lean.as_str()),
-            _ => continue,
+            Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => continue,
         };
         // Drop `<field> := <account_binding>.pubkey` — no Lean scope
         // for account-binding pubkey refs.
@@ -2693,7 +2724,13 @@ fn emit_handler_transition(out: &mut String, mir: &Mir, h: &crate::mir::HandlerM
                 let d = effect_value_to_lean_mir(&delta.lean, &h.params);
                 with_parts.push(format!("{} := s.{} - {}", f, f, d));
             }
-            _ => {}
+            Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => {}
         }
     }
 
@@ -2781,7 +2818,17 @@ fn build_guard_cond_parts(mir: &Mir, h: &crate::mir::HandlerMir) -> Vec<String> 
             Stmt::CheckedSub { path, delta, .. }
             | Stmt::WrapSub { path, delta }
             | Stmt::SatSub { path, delta } => (path, delta),
-            _ => continue,
+            Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Assign { .. }
+            | Stmt::CheckedAdd { .. }
+            | Stmt::WrapAdd { .. }
+            | Stmt::SatAdd { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => continue,
         };
         let field = path_field_name(path);
         if let Some(ty) = state_fields
@@ -2810,7 +2857,17 @@ fn build_guard_cond_parts(mir: &Mir, h: &crate::mir::HandlerMir) -> Vec<String> 
             Stmt::CheckedAdd { path, delta, .. }
             | Stmt::WrapAdd { path, delta }
             | Stmt::SatAdd { path, delta } => (path, delta),
-            _ => continue,
+            Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Assign { .. }
+            | Stmt::CheckedSub { .. }
+            | Stmt::WrapSub { .. }
+            | Stmt::SatSub { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => continue,
         };
         let field = path_field_name(path);
         let ty = match state_fields
@@ -3426,7 +3483,13 @@ fn preservation_proof_script(
         | Stmt::WrapSub { path, .. }
         | Stmt::SatAdd { path, .. }
         | Stmt::SatSub { path, .. } => prop_fields.iter().any(|f| f == &path_field_name(path)),
-        _ => false,
+        Stmt::RequireOrAbort { .. }
+        | Stmt::TokenTransfer { .. }
+        | Stmt::VariantPromote { .. }
+        | Stmt::Branch { .. }
+        | Stmt::Abort(_)
+        | Stmt::Cpi { .. }
+        | Stmt::Emit { .. } => false,
     }) || (h.transition.is_some()
         && prop_fields.iter().any(|f| f == "status"));
 
@@ -3513,7 +3576,13 @@ fn master_inductive_proof_script(mir: &Mir, prop: &crate::mir::PropertyMir) -> S
                 | Stmt::SatSub { path, .. } => {
                     prop_fields.iter().any(|f| f == &path_field_name(path))
                 }
-                _ => false,
+                Stmt::RequireOrAbort { .. }
+                | Stmt::TokenTransfer { .. }
+                | Stmt::VariantPromote { .. }
+                | Stmt::Branch { .. }
+                | Stmt::Abort(_)
+                | Stmt::Cpi { .. }
+                | Stmt::Emit { .. } => false,
             });
             if !touches_prop_field {
                 proof.push_str(&format!(
@@ -4323,7 +4392,13 @@ impl WitnessState {
                         f.1 = cur.saturating_sub(sub).to_string();
                     }
                 }
-                _ => {}
+                Stmt::RequireOrAbort { .. }
+                | Stmt::TokenTransfer { .. }
+                | Stmt::VariantPromote { .. }
+                | Stmt::Branch { .. }
+                | Stmt::Abort(_)
+                | Stmt::Cpi { .. }
+                | Stmt::Emit { .. } => {}
             }
         }
         if let Some((_, post)) = &h.transition {
@@ -5273,7 +5348,21 @@ fn overflow_proof_script(
     let is_add_field = |field: &str| -> bool {
         h.body.stmts.iter().any(|s| match s {
             Stmt::CheckedAdd { path, .. } => path_field_name(path) == field,
-            _ => false,
+            // Only checked adds gate the overflow proof shape here;
+            // wrap/sat arithmetic and non-arithmetic stmts don't abort.
+            Stmt::RequireOrAbort { .. }
+            | Stmt::TokenTransfer { .. }
+            | Stmt::VariantPromote { .. }
+            | Stmt::Assign { .. }
+            | Stmt::CheckedSub { .. }
+            | Stmt::WrapAdd { .. }
+            | Stmt::WrapSub { .. }
+            | Stmt::SatAdd { .. }
+            | Stmt::SatSub { .. }
+            | Stmt::Branch { .. }
+            | Stmt::Abort(_)
+            | Stmt::Cpi { .. }
+            | Stmt::Emit { .. } => false,
         })
     };
 

--- a/crates/qedgen/src/mir.rs
+++ b/crates/qedgen/src/mir.rs
@@ -430,6 +430,13 @@ pub struct Block {
 /// Statement kinds. Total: 12 — 4 primary intrinsics + 7 effect/control +
 /// 1 escape hatch CPI. See `docs/design/intrinsic-fixture-map.md` for
 /// the fixture evidence per kind.
+///
+/// **Exhaustiveness discipline (#66):** matches over `Stmt` must list
+/// every variant explicitly — no `_` arms. The point of the closed enum
+/// is that adding a variant breaks every consumer at compile time, so
+/// each backend is forced to decide how the new statement kind renders
+/// (even if the decision is "nothing"). A wildcard arm silently opts the
+/// site out of that safety net.
 #[derive(Debug, Clone)]
 pub enum Stmt {
     // ---- Primary intrinsics (fixture-evidence anchored) ----


### PR DESCRIPTION
Closes out the two follow-ons from the #83 System-CPI slice (tracked under #66).

## 1. Quasar `System.transfer` mechanized

`try_emit_cpi` now routes `(Quasar, System)` to a new `emit_system_cpi_quasar`, emitting the `Program<SystemProgram>` method chain:

```rust
self.system_program.transfer(&self.payer, &self.pda, n).invoke()?;
```

- Verified against quasar-lang's CPI surface: `Program<SystemProgram>::transfer(from, to, lamports) -> CpiCall` exposes the identical chain shape as the `TokenCpi` trait, so the SPL emitter is generalized to `emit_quasar_method_chain` and shared by both dispatchers.
- `create_account` / `assign` stay `None` → breadcrumb on Quasar too — same boundary as the Anchor/Pinocchio emitters (PDA creation needs `invoke_signed` + seed assembly = CPI-authority business logic, agent-filled).
- Tests: `cpi_emits_quasar_system_transfer` + `cpi_quasar_system_create_account_is_breadcrumb`. The System spec text previously duplicated inline across the Anchor/Pinocchio tests is factored into shared `parse_system_{transfer,create_account}_caller_spec` fixtures.

## 2. Exhaustive `Stmt` matches

All 13 `_ =>` arms over `mir::Stmt` (12 in `lean_gen_mir.rs`, 1 in `codegen_mir::mir_needs_spl`) are replaced with explicit variant complements, so adding a `Stmt` variant is a compile error at every consumer site — the safety net #66 claimed but didn't have. The discipline is documented on the enum doc in `mir.rs`.

One honest scope correction that fell out: Kani/proptest never consume `Stmt` at all — their effect lowering reads `ParsedHandler` via `rust_codegen_util::emit_transition_fn`. The CLAUDE.md claim is corrected to its real scope (the guarantee covers the `Stmt` consumers: Lean codegen + Rust scaffold). Porting Kani/proptest onto `Stmt` remains future #66 work.

## Validation

- 990 unit tests + all snapshot suites green, zero snapshot drift (no bundled fixture uses `call System.*`, and the exhaustiveness edits are semantics-neutral).
- `cargo fmt --check` clean.