### PR TITLE
feat(mir): port Kani/proptest effect lowering onto Stmt (#66 frontier)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -24,7 +24,7 @@ The UX is **agent-first**: the user interacts with the SKILL (`SKILL.md`) and ag
 - Codegen mechanizes only deterministic translation; business logic (transfers, CPI authority, events, PDA creation) stays agent-filled `todo!()`.
 - When a template can't close a case, emit `sorry` with a comment — never bury it in tactics that might spuriously close.
 - Don't pre-shell to Leanstral/Aristotle for what a local LLM can do. Escalation is for *after* you've tried, not when you expect to need to.
-- The typed MIR (`mir.rs`) exists for bug-class elimination, not LoC: matches over the closed `Stmt` enum are exhaustive by discipline (no `_` arms — see the enum doc in `mir.rs`), so a new statement kind is a compile error at every `Stmt` consumer (Lean codegen + Rust scaffold), not silent drift. Kani/proptest still lower effects from `ParsedSpec` via `rust_codegen_util`. Measure intrinsics by bugs eliminated, not lines saved.
+- The typed MIR (`mir.rs`) exists for bug-class elimination, not LoC: matches over the closed `Stmt` enum are exhaustive by discipline (no `_` arms — see the enum doc in `mir.rs`), so a new statement kind is a compile error at every `Stmt` consumer (Lean codegen, Rust scaffold, and the Kani/proptest effect lowering via `rust_codegen_util::stmt_effect_triple`), not silent drift. Conditional `effect { match … }` bodies still render from `ParsedHandler.effect_branches` pending the Phase-5 `Branch` lowering. Measure intrinsics by bugs eliminated, not lines saved.
 
 ## Build and test
 

--- a/crates/qedgen/src/kani_mir.rs
+++ b/crates/qedgen/src/kani_mir.rs
@@ -93,13 +93,16 @@ fn render_inner(mir: &Mir, parsed: &ParsedSpec, progress: bool, skip_guard_proof
         // File-level features (covers / liveness / environment) are
         // skipped — per-ADT lifting is v2.22 scope per the legacy
         // comment; spec-level emit only happens in single-mode.
-        if let Err(e) = emit_multi_account_sections(&mut out, parsed, progress, skip_guard_proofs) {
+        if let Err(e) =
+            emit_multi_account_sections(&mut out, mir, parsed, progress, skip_guard_proofs)
+        {
             out.push_str(&format!("// MIR-ERROR: multi-account emit failed: {}\n", e));
         }
     } else {
         // Single-account path — every section consumes the parsed
         // ParsedSpec directly.
-        if let Err(e) = emit_single_account_sections(&mut out, parsed, progress, skip_guard_proofs)
+        if let Err(e) =
+            emit_single_account_sections(&mut out, mir, parsed, progress, skip_guard_proofs)
         {
             out.push_str(&format!(
                 "// MIR-ERROR: single-account emit failed: {}\n",
@@ -125,6 +128,7 @@ fn skip_guard_proofs_from_env() -> bool {
 /// legacy order against the parsed spec directly.
 fn emit_single_account_sections(
     out: &mut String,
+    mir: &Mir,
     parsed: &ParsedSpec,
     progress: bool,
     skip_guard_proofs: bool,
@@ -132,7 +136,7 @@ fn emit_single_account_sections(
     if progress {
         eprintln!("Rendering Kani section: state model");
     }
-    emit_account_section_structural(out, parsed)?;
+    emit_account_section_structural(out, mir, parsed)?;
     if skip_guard_proofs {
         if progress {
             eprintln!(
@@ -167,11 +171,11 @@ fn emit_single_account_sections(
     if progress {
         eprintln!("Rendering Kani section: effect conformance proofs");
     }
-    emit_effect_conformance_harnesses(out, parsed)?;
+    emit_effect_conformance_harnesses(out, mir, parsed)?;
     if progress {
         eprintln!("Rendering Kani section: overflow proofs");
     }
-    emit_overflow_detection_harnesses(out, parsed)?;
+    emit_overflow_detection_harnesses(out, mir, parsed)?;
     // File-level features (covers / liveness / environment) —
     // single-mode only. Multi-account specs skip these entirely
     // (per-ADT lifting is v2.22 scope per the legacy comment).
@@ -206,6 +210,7 @@ fn emit_single_account_sections(
 /// and aren't emitted in multi-mode at all.
 fn emit_multi_account_sections(
     out: &mut String,
+    mir: &Mir,
     parsed: &ParsedSpec,
     progress: bool,
     skip_guard_proofs: bool,
@@ -235,7 +240,7 @@ fn emit_multi_account_sections(
         out.push_str(&format!("mod {} {{\n", mod_name));
         out.push_str("    use super::*;\n\n");
 
-        emit_account_section_structural(out, &scoped)?;
+        emit_account_section_structural(out, mir, &scoped)?;
         if skip_guard_proofs {
             if progress {
                 eprintln!(
@@ -249,8 +254,8 @@ fn emit_multi_account_sections(
         emit_property_preservation_harnesses(out, &scoped)?;
         emit_ensures_preservation_harnesses(out, &scoped)?;
         emit_invariant_preservation_harnesses(out, &scoped)?;
-        emit_effect_conformance_harnesses(out, &scoped)?;
-        emit_overflow_detection_harnesses(out, &scoped)?;
+        emit_effect_conformance_harnesses(out, mir, &scoped)?;
+        emit_overflow_detection_harnesses(out, mir, &scoped)?;
 
         out.push_str(&format!("}} // mod {}\n\n", mod_name));
     }
@@ -448,7 +453,7 @@ fn emit_constants(out: &mut String, mir: &Mir) {
 /// Multi-account dispatch (`mod <lowercase>`) is Phase 3e — until
 /// then, multi-account specs emit only the primary account's view
 /// here, prefixed by a `MIR-TODO(phase-3e)` marker in `render()`.
-fn emit_account_section_structural(out: &mut String, parsed: &ParsedSpec) -> Result<()> {
+fn emit_account_section_structural(out: &mut String, mir: &Mir, parsed: &ParsedSpec) -> Result<()> {
     use crate::codegen_shared::map_type;
     use crate::rust_codegen_util as util;
 
@@ -574,7 +579,10 @@ fn emit_account_section_structural(out: &mut String, parsed: &ParsedSpec) -> Res
         "// ============================================================================\n\n",
     );
     for op in &handlers {
-        util::emit_transition_fn_for_kani(out, op, parsed, false, |t| map_type(t, parsed))?;
+        let body = mir
+            .handler_block(&op.name)
+            .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
+        util::emit_transition_fn_for_kani(out, body, op, parsed, false, |t| map_type(t, parsed))?;
     }
 
     // 8. Reference implementations (v2.25 — pure-expression fns
@@ -1704,7 +1712,11 @@ fn emit_invariant_preservation_harnesses(out: &mut String, parsed: &ParsedSpec) 
 ///     - sub → `s.F == pre_F.wrapping_sub(<resolved>)`
 ///   * Sibling fields assert `s.G == pre_G` unless another effect in
 ///     the same handler mutates them.
-fn emit_effect_conformance_harnesses(out: &mut String, parsed: &ParsedSpec) -> Result<()> {
+fn emit_effect_conformance_harnesses(
+    out: &mut String,
+    mir: &Mir,
+    parsed: &ParsedSpec,
+) -> Result<()> {
     use crate::codegen_shared::{map_type, sanitize_ident};
     use crate::rust_codegen_util as util;
 
@@ -1760,8 +1772,16 @@ fn emit_effect_conformance_harnesses(out: &mut String, parsed: &ParsedSpec) -> R
     for op in &effect_ops {
         let is_init = op.pre_status.as_deref() == Some("Uninitialized");
 
-        for (field, op_kind, value) in &op.effects {
-            let base = util::effect_target_base(field);
+        // #66 — the per-effect harness loop iterates the handler's
+        // lowered MIR body (projected back onto triples by the shared
+        // adaptor), not `op.effects`. Same order/content; the sibling-
+        // frame check below reads the same triple list.
+        let body = mir
+            .handler_block(&op.name)
+            .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
+        let triples = util::block_effect_triples(body);
+        for (field, op_kind, value) in triples.iter().cloned() {
+            let base = util::effect_target_base(&field);
             if !field_type_lookup.contains_key(base) {
                 continue;
             }
@@ -1775,7 +1795,7 @@ fn emit_effect_conformance_harnesses(out: &mut String, parsed: &ParsedSpec) -> R
             out.push_str(&format!(
                 "fn verify_{}_effect_{}() {{\n",
                 op.name,
-                sanitize_ident(field)
+                sanitize_ident(&field)
             ));
 
             if is_init {
@@ -1824,7 +1844,7 @@ fn emit_effect_conformance_harnesses(out: &mut String, parsed: &ParsedSpec) -> R
             // set-target.
             let needs_pre_for: Vec<&&(String, String)> = mutable
                 .iter()
-                .filter(|(fname, _)| !(fname.as_str() == field.as_str() && op_kind == "set"))
+                .filter(|(fname, _)| !(fname.as_str() == field && op_kind == "set"))
                 .collect();
             for (fname, _) in &needs_pre_for {
                 out.push_str(&format!("    let pre_{} = s.{};\n", fname, fname));
@@ -1845,7 +1865,7 @@ fn emit_effect_conformance_harnesses(out: &mut String, parsed: &ParsedSpec) -> R
                 Some("pre_"),
                 util::handler_needs_account_env(op).then_some("accounts"),
             );
-            match op_kind.as_str() {
+            match op_kind {
                 "set" => {
                     let assertion = util::rewrite_kani_pubkey_comparisons(
                         &format!("s.{field} == {resolved}"),
@@ -1875,11 +1895,9 @@ fn emit_effect_conformance_harnesses(out: &mut String, parsed: &ParsedSpec) -> R
             // Assert sibling fields unchanged (unless mutated by another
             // effect in the same handler).
             for (fname, _) in &mutable {
-                if fname.as_str() != field.as_str() {
-                    let sibling_mutated = op
-                        .effects
-                        .iter()
-                        .any(|(f, _, _)| f.as_str() == fname.as_str());
+                if fname.as_str() != field {
+                    let sibling_mutated =
+                        triples.iter().any(|(f, _, _)| f.as_str() == fname.as_str());
                     if !sibling_mutated {
                         let assertion = util::rewrite_kani_pubkey_comparisons(
                             &format!("s.{fname} == pre_{fname}"),
@@ -1911,16 +1929,28 @@ fn emit_effect_conformance_harnesses(out: &mut String, parsed: &ParsedSpec) -> R
 /// fires on `+=` inside the transition body — no explicit assert
 /// required; the proof exists to drive BMC across the parameter
 /// space. Mirrors `kani::emit_kani_account_section` lines ~1279–1330.
-fn emit_overflow_detection_harnesses(out: &mut String, parsed: &ParsedSpec) -> Result<()> {
+fn emit_overflow_detection_harnesses(
+    out: &mut String,
+    mir: &Mir,
+    parsed: &ParsedSpec,
+) -> Result<()> {
     use crate::codegen_shared::map_type;
     use crate::rust_codegen_util as util;
 
     let handlers: Vec<&crate::check::ParsedHandler> = parsed.handlers.iter().collect();
 
+    // #66 — the checked-add filter reads the lowered MIR body
+    // (`Stmt::CheckedAdd` projects to kind `"add"`), not `op.effects`.
     let overflow_ops: Vec<&crate::check::ParsedHandler> = handlers
         .iter()
         .copied()
-        .filter(|op| op.effects.iter().any(|(_, kind, _)| kind == "add"))
+        .filter(|op| {
+            mir.handler_block(&op.name).is_some_and(|body| {
+                util::block_effect_triples(body)
+                    .iter()
+                    .any(|(_, kind, _)| *kind == "add")
+            })
+        })
         .collect();
 
     if overflow_ops.is_empty() {

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -3239,7 +3239,7 @@ async fn dispatch(cmd: Commands) -> Result<()> {
                     // `proptest_gen_mir` is the sole proptest path since
                     // v2.32 deleted the legacy `proptest_gen`.
                     let mir = mir::lower(&parsed);
-                    proptest_gen_mir::generate(&mir, &parsed, &spec, &proptest_output)?;
+                    proptest_gen_mir::generate(&mir, &parsed, &proptest_output)?;
                 }
             }
             if crucible || all {

--- a/crates/qedgen/src/mir.rs
+++ b/crates/qedgen/src/mir.rs
@@ -203,6 +203,21 @@ pub struct Mir {
     pub adt_state: bool,
 }
 
+impl Mir {
+    /// Look up a handler's lowered body by name. Handler names are
+    /// unique (spec validation rejects duplicates), and the per-account
+    /// scoped `ParsedSpec` views the Kani/proptest emitters build only
+    /// *filter* the handler set — they never rewrite handler content —
+    /// so a name-keyed lookup against the unscoped `Mir` stays valid
+    /// inside scoped sections.
+    pub fn handler_block(&self, name: &str) -> Option<&Block> {
+        self.handlers
+            .iter()
+            .find(|h| h.name == name)
+            .map(|h| &h.body)
+    }
+}
+
 // ----------------------------------------------------------------------
 // State
 // ----------------------------------------------------------------------
@@ -490,7 +505,9 @@ pub enum Stmt {
         err: ErrorRef,
     },
 
-    /// `field +=!` — wrapping arithmetic, no error. v2.24 explicit marker.
+    /// `field +=?` — wrapping arithmetic, no error. v2.24 explicit marker
+    /// (parser op_kind `add_wrap`; see the tier table in
+    /// `rust_codegen_util::emit_transition_fn_inner`).
     WrapAdd {
         path: Path,
         delta: Expr,
@@ -500,7 +517,8 @@ pub enum Stmt {
         delta: Expr,
     },
 
-    /// `field +=?` — saturating arithmetic, no error. v2.24 explicit marker.
+    /// `field +=!` — saturating arithmetic, no error. v2.24 explicit marker
+    /// (parser op_kind `add_sat`).
     SatAdd {
         path: Path,
         delta: Expr,

--- a/crates/qedgen/src/proptest_gen_mir.rs
+++ b/crates/qedgen/src/proptest_gen_mir.rs
@@ -5,35 +5,30 @@
 //! counterexamples; lighter-weight than Kani BMC). Gated by
 //! `tests/proptest_snapshot.rs`.
 //!
-//! The harness emission (`generate_impl` + its per-handler arb_state /
-//! preservation / invariant / guard / overflow / sequence sub-emitters)
-//! reads `ParsedSpec` directly — those harnesses derive from account /
-//! property / requires surface, not the effect-body `Stmt` IR. The
-//! public `generate` takes the lowered `Mir` on its signature for
-//! dispatch-site uniformity with the other codegens.
+//! Effect-body lowering is MIR-driven (#66): the transition functions
+//! and the overflow filters/tests iterate the handler's lowered `Stmt`
+//! body via the shared `rust_codegen_util::stmt_effect_triple` adaptor,
+//! so a new `Stmt` variant is a compile error at this backend. The
+//! surrounding harness emission (arb_state strategies / preservation /
+//! invariant / guard / sequence sub-emitters) reads `ParsedSpec`
+//! directly — those derive from account / property / requires surface,
+//! not effect-body IR, the same boundary as `codegen_mir`'s guards.
 
 use anyhow::Result;
 use std::path::Path;
 
-use crate::check::{self, ParsedHandler, ParsedInvariant, ParsedProperty, ParsedSpec};
+use crate::check::{ParsedHandler, ParsedInvariant, ParsedProperty, ParsedSpec};
 use crate::codegen_shared::map_type;
 use crate::mir::Mir;
 use crate::rust_codegen_util;
 
 /// Generate the proptest harness file at `output_path`, consuming a
-/// pre-lowered `Mir` + `ParsedSpec` + the originating spec path (the
-/// harness emitter re-parses from the path for its drift-stamp logic).
-pub fn generate(
-    mir: &Mir,
-    parsed: &ParsedSpec,
-    spec_path: &Path,
-    output_path: &Path,
-) -> Result<()> {
-    let _ = mir;
+/// pre-lowered `Mir` + its originating `ParsedSpec`.
+pub fn generate(mir: &Mir, parsed: &ParsedSpec, output_path: &Path) -> Result<()> {
     if parsed.handlers.is_empty() {
         anyhow::bail!("No operations found in the spec — is this a valid qedspec file?");
     }
-    generate_impl(spec_path, output_path)
+    generate_impl(mir, parsed, output_path)
 }
 
 /// Return the proptest strategy string for a DSL primitive type. For compound
@@ -400,28 +395,19 @@ fn extract_field_upper_bounds(
     bounds
 }
 
-/// Generate proptest harnesses from a spec file (.qedspec).
+/// Generate proptest harnesses from a pre-lowered `Mir` + `ParsedSpec`.
 ///
 /// Produces property-based tests that exercise the spec's state machine with
 /// random inputs, checking invariants after every transition. Finds
 /// counterexamples in milliseconds — the first tier of the verification waterfall.
-fn generate_impl(spec_path: &Path, output_path: &Path) -> Result<()> {
-    let spec = check::parse_spec_file(spec_path)?;
-
-    if spec.handlers.is_empty() {
-        anyhow::bail!(
-            "No operations found in {}. Is this a valid qedspec file?",
-            spec_path.display()
-        );
-    }
-
-    rust_codegen_util::check_effect_targets(&spec)?;
+fn generate_impl(mir: &Mir, spec: &ParsedSpec, output_path: &Path) -> Result<()> {
+    rust_codegen_util::check_effect_targets(spec)?;
 
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    let fp = crate::fingerprint::compute_fingerprint(&spec);
+    let fp = crate::fingerprint::compute_fingerprint(spec);
     let hash = fp
         .file_hashes
         .get("tests/proptest.rs")
@@ -491,7 +477,7 @@ fn generate_impl(spec_path: &Path, output_path: &Path) -> Result<()> {
     //
     // Detection reuses `codegen::guards_use_math_helpers` so this gate
     // tracks the same predicate as the `--all` math.rs emission.
-    if crate::codegen_shared::guards_use_math_helpers(&spec) {
+    if crate::codegen_shared::guards_use_math_helpers(spec) {
         out.push_str(
             "#[allow(dead_code)]\n\
 #[inline]\n\
@@ -549,13 +535,14 @@ fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {\n\
             // Build a minimal ParsedSpec view for this account
             emit_account_section(
                 &mut out,
+                mir,
                 &acct.name,
                 &acct_fields,
                 &acct.fields,
                 &acct_handlers,
                 &acct_props,
                 &acct.lifecycle,
-                &spec,
+                spec,
             )?;
 
             out.push_str(&format!("}} // mod {}\n\n", mod_name));
@@ -579,13 +566,14 @@ fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {\n\
         let all_props: Vec<&ParsedProperty> = spec.properties.iter().collect();
         emit_account_section(
             &mut out,
+            mir,
             &spec.program_name,
             &mutable_fields,
             state_fields,
             &all_handlers,
             &all_props,
             &spec.lifecycle_states,
-            &spec,
+            spec,
         )?;
     }
 
@@ -598,6 +586,7 @@ fn mul_div_ceil_u128(a: u128, b: u128, d: u128) -> u128 {\n\
 #[allow(clippy::too_many_arguments)]
 fn emit_account_section(
     out: &mut String,
+    mir: &Mir,
     _acct_name: &str,
     mutable_fields: &[&(String, String)],
     all_fields: &[(String, String)],
@@ -781,7 +770,7 @@ fn emit_account_section(
     rust_codegen_util::emit_invariant_predicates(out, &linked_invs);
 
     // Transition functions
-    emit_transition_functions_for(out, handlers, spec)?;
+    emit_transition_functions_for(out, mir, handlers, spec)?;
 
     // Clone properties once for sections that need owned copies
     let owned_props: Vec<ParsedProperty> = properties.iter().map(|p| (*p).clone()).collect();
@@ -821,14 +810,22 @@ fn emit_account_section(
     }
 
     // Overflow detection tests
+    // #66 — checked-add filter reads the lowered MIR body, not `op.effects`.
     let overflow_ops: Vec<&&ParsedHandler> = handlers
         .iter()
-        .filter(|op| op.effects.iter().any(|(_, k, _)| k == "add"))
+        .filter(|op| {
+            mir.handler_block(&op.name).is_some_and(|body| {
+                rust_codegen_util::block_effect_triples(body)
+                    .iter()
+                    .any(|(_, k, _)| *k == "add")
+            })
+        })
         .collect();
     if !overflow_ops.is_empty() {
         let overflow_refs: Vec<&ParsedHandler> = overflow_ops.iter().map(|op| **op).collect();
         emit_overflow_tests_for(
             out,
+            mir,
             &overflow_refs,
             mutable_fields,
             all_fields,
@@ -957,14 +954,20 @@ fn emit_state_strategy_inner(
     Ok(())
 }
 
-/// Emit transition functions for a slice of handlers.
+/// Emit transition functions for a slice of handlers. #66 — the effect
+/// block inside each transition iterates the handler's lowered MIR body
+/// (see `rust_codegen_util::stmt_effect_triple`), not `op.effects`.
 fn emit_transition_functions_for(
     out: &mut String,
+    mir: &Mir,
     handlers: &[&ParsedHandler],
     spec: &ParsedSpec,
 ) -> Result<()> {
     for op in handlers {
-        rust_codegen_util::emit_transition_fn(out, op, spec, true, |t| map_type(t, spec))?;
+        let body = mir
+            .handler_block(&op.name)
+            .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
+        rust_codegen_util::emit_transition_fn(out, body, op, spec, true, |t| map_type(t, spec))?;
     }
     Ok(())
 }
@@ -1384,8 +1387,10 @@ fn emit_guard_tests(
 }
 
 /// Emit overflow detection tests for add effects.
+#[allow(clippy::too_many_arguments)]
 fn emit_overflow_tests_for(
     out: &mut String,
+    mir: &Mir,
     overflow_ops: &[&ParsedHandler],
     mutable_fields: &[&(String, String)],
     all_fields: &[(String, String)],
@@ -1393,7 +1398,10 @@ fn emit_overflow_tests_for(
     properties: &[ParsedProperty],
 ) -> Result<()> {
     for op in overflow_ops {
-        for (field_raw, kind, _value) in &op.effects {
+        let body = mir
+            .handler_block(&op.name)
+            .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
+        for (field_raw, kind, _value) in rust_codegen_util::block_effect_triples(body) {
             if kind != "add" {
                 continue;
             }
@@ -1402,7 +1410,7 @@ fn emit_overflow_tests_for(
             // (both in the generated function name and the field
             // lookup).
             let field_owned =
-                rust_codegen_util::strip_variant_prefix_for_flat_state(field_raw, spec);
+                rust_codegen_util::strip_variant_prefix_for_flat_state(&field_raw, spec);
             let field = field_owned.as_str();
 
             let dsl_type = all_fields
@@ -1819,14 +1827,14 @@ property balance_nonneg :
   state.balance >= 0
   preserved_by all
 "#;
-        let spec = crate::chumsky_adapter::parse_str(src).expect("parse");
         let dir = tempfile::tempdir().unwrap();
         let spec_path = dir.path().join("vault.qedspec");
         let out_path = dir.path().join("tests/proptest.rs");
         std::fs::write(&spec_path, src).unwrap();
-        generate_impl(&spec_path, &out_path).unwrap();
+        let spec = crate::check::parse_spec_file(&spec_path).expect("parse");
+        let mir = crate::mir::lower(&spec);
+        generate_impl(&mir, &spec, &out_path).unwrap();
         let body = std::fs::read_to_string(&out_path).unwrap();
-        let _ = spec; // suppress unused
 
         // Function names land as bare-field, not variant-prefixed.
         assert!(
@@ -2011,6 +2019,7 @@ handler noop { }
     /// Used by Slice 3 tests to verify the generated harness shape.
     fn emit_test_section(src: &str) -> String {
         let spec = crate::chumsky_adapter::parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&spec);
         let mutable_fields: Vec<&(String, String)> = spec.state_fields.iter().collect();
         let all_fields: Vec<(String, String)> = spec.state_fields.clone();
         let handlers: Vec<&ParsedHandler> = spec.handlers.iter().collect();
@@ -2018,6 +2027,7 @@ handler noop { }
         let mut out = String::new();
         emit_account_section(
             &mut out,
+            &mir,
             "TestAccount",
             &mutable_fields,
             &all_fields,

--- a/crates/qedgen/src/regen_drift.rs
+++ b/crates/qedgen/src/regen_drift.rs
@@ -404,18 +404,12 @@ fn generate_existing_artifacts(root: &Path, temp_root: &Path, spec_path: &Path) 
         let parsed = crate::check::parse_spec_file(spec_path)?;
         let mir = crate::mir::lower(&parsed);
         if root.join("tests/proptest.rs").is_file() {
-            crate::proptest_gen_mir::generate(
-                &mir,
-                &parsed,
-                spec_path,
-                &temp_root.join("tests/proptest.rs"),
-            )?;
+            crate::proptest_gen_mir::generate(&mir, &parsed, &temp_root.join("tests/proptest.rs"))?;
         }
         if root.join("programs/tests/proptest.rs").is_file() {
             crate::proptest_gen_mir::generate(
                 &mir,
                 &parsed,
-                spec_path,
                 &temp_root.join("programs/tests/proptest.rs"),
             )?;
         }

--- a/crates/qedgen/src/rust_codegen_util.rs
+++ b/crates/qedgen/src/rust_codegen_util.rs
@@ -1058,6 +1058,73 @@ pub fn strip_variant_prefix_for_flat_state(path: &str, spec: &ParsedSpec) -> Str
     path.to_string()
 }
 
+/// Project an effect-shaped MIR `Stmt` back onto the `(field, op_kind,
+/// value)` triple the string templates below consume. This is the #66
+/// adaptor that makes `Stmt` the iteration source for the Kani/proptest
+/// transition bodies while keeping their output byte-identical:
+/// `mir::lower_body` builds effect stmts from `ParsedHandler.effects` in
+/// order, `Path` round-trips the dotted field via `split('.')`/`join(".")`,
+/// and `Expr::from_raw` carries the RHS string verbatim in `.rust`.
+///
+/// Returns `None` for every non-effect variant — each with the reason it
+/// renders as *nothing* in the pure spec-model transition. The match is
+/// exhaustive by discipline (no `_` arm; see the `Stmt` enum doc): a new
+/// `Stmt` variant is a compile error here, forcing an explicit decision
+/// for the Kani/proptest backends.
+pub fn stmt_effect_triple(stmt: &crate::mir::Stmt) -> Option<(String, &'static str, &str)> {
+    use crate::mir::Stmt;
+    match stmt {
+        Stmt::Assign { path, rhs } => Some((path.segments.join("."), "set", rhs.rust.as_str())),
+        Stmt::CheckedAdd { path, delta, .. } => {
+            // The lowered per-site error name is Lean/scaffold surface;
+            // the pure model signals overflow via `return false`.
+            Some((path.segments.join("."), "add", delta.rust.as_str()))
+        }
+        Stmt::CheckedSub { path, delta, .. } => {
+            Some((path.segments.join("."), "sub", delta.rust.as_str()))
+        }
+        Stmt::SatAdd { path, delta } => {
+            Some((path.segments.join("."), "add_sat", delta.rust.as_str()))
+        }
+        Stmt::SatSub { path, delta } => {
+            Some((path.segments.join("."), "sub_sat", delta.rust.as_str()))
+        }
+        Stmt::WrapAdd { path, delta } => {
+            Some((path.segments.join("."), "add_wrap", delta.rust.as_str()))
+        }
+        Stmt::WrapSub { path, delta } => {
+            Some((path.segments.join("."), "sub_wrap", delta.rust.as_str()))
+        }
+        // Guard surface: `requires X else Err` folds into the guard
+        // conjunction via `collect_full_guard*`, not the body.
+        Stmt::RequireOrAbort { .. } => None,
+        // CPI surface: no state mutation in the pure model; the Kani
+        // CPI-fact harnesses read the call sites separately.
+        Stmt::TokenTransfer { .. } => None,
+        Stmt::Cpi { .. } => None,
+        // Lifecycle surface: the transition body drives variant changes
+        // through the pre/post-status writes, not a promote statement.
+        Stmt::VariantPromote { .. } => None,
+        // Conditional effects render from `op.effect_branches` until the
+        // Phase-5 Branch lowering lands (`lower_body` step 7 emits a
+        // stub `Abort` and the *union* of arm effects today — walking
+        // arms here would double-emit against the branch path).
+        Stmt::Branch { .. } => None,
+        // Abort clauses are harnessed from the `aborts_if` predicate
+        // surface; in the body they carry no state mutation.
+        Stmt::Abort(_) => None,
+        // Events: auxiliary, no state mutation in the pure model.
+        Stmt::Emit { .. } => None,
+    }
+}
+
+/// All effect triples of a lowered handler body, in spec order. The
+/// shared iteration source for the Kani/proptest transition emitters,
+/// conformance harnesses, and overflow filters.
+pub fn block_effect_triples(body: &crate::mir::Block) -> Vec<(String, &'static str, &str)> {
+    body.stmts.iter().filter_map(stmt_effect_triple).collect()
+}
+
 /// Render a single `(field, op_kind, value)` triple into Rust at the given
 /// indent. Shared between unconditional effect lowering and v2.20's
 /// match-arm lowering. The helper writes the trailing newline; the caller
@@ -1861,18 +1928,27 @@ fn emit_after_store_hooks(out: &mut String, spec: &ParsedSpec, field: &str, inde
     }
 }
 
+/// Both transition emitters require the handler's lowered MIR body —
+/// the effect block iterates `Stmt` (via `stmt_effect_triple`), not
+/// `ParsedHandler.effects` (#66: a new `Stmt` variant is a compile
+/// error at the adaptor, covering the Kani + proptest backends). The
+/// guard / status / let-binding / ghost scaffold around the effects
+/// stays `ParsedHandler`-fed by design — that's predicate/account
+/// surface, same boundary as `codegen_mir`'s guards.
 pub fn emit_transition_fn(
     out: &mut String,
+    body: &crate::mir::Block,
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) -> anyhow::Result<()> {
-    emit_transition_fn_inner(out, op, spec, wrapping, None, false, map_type_fn)
+    emit_transition_fn_inner(out, body, op, spec, wrapping, None, false, map_type_fn)
 }
 
 pub fn emit_transition_fn_for_kani(
     out: &mut String,
+    body: &crate::mir::Block,
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
@@ -1882,6 +1958,7 @@ pub fn emit_transition_fn_for_kani(
         handler_needs_account_env(op).then(|| handler_account_env_struct_name(&op.name));
     emit_transition_fn_inner(
         out,
+        body,
         op,
         spec,
         wrapping,
@@ -1891,8 +1968,10 @@ pub fn emit_transition_fn_for_kani(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_transition_fn_inner(
     out: &mut String,
+    body: &crate::mir::Block,
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
@@ -2062,7 +2141,14 @@ fn emit_transition_fn_inner(
         // via `resolve_value(..., Some("s."))` so a bare state-field RHS
         // (e.g. `bid_buyer := state.rfp_buyer` after upstream strips
         // `state.`) renders as `s.rfp_buyer` in the proptest body.
-        for (field, op_kind, value) in &op.effects {
+        //
+        // #66 — iterate the handler's lowered MIR body, not
+        // `op.effects`: `stmt_effect_triple` projects each effect-shaped
+        // `Stmt` back onto the triple these templates consume
+        // (byte-identical; see its doc) and skips the non-effect
+        // variants in-stream without reordering.
+        for (field, op_kind, value) in block_effect_triples(body) {
+            let field = field.as_str();
             if account_env_struct.is_none() && field_type_is_pubkey(field, op, spec) {
                 continue;
             }
@@ -2112,6 +2198,123 @@ mod tests {
     use super::*;
     use crate::chumsky_adapter::parse_str;
 
+    /// #66 adaptor invariant — for every handler, the effect triples
+    /// projected from the lowered MIR body must equal
+    /// `ParsedHandler.effects` exactly (order + content). This is what
+    /// makes the `Stmt`-driven Kani/proptest emission byte-identical to
+    /// the former `op.effects` iteration. Checked over a synthetic spec
+    /// covering all seven op kinds plus the non-effect statement shapes.
+    #[test]
+    fn stmt_effect_triples_round_trip_parsed_effects() {
+        let src = r#"spec RoundTrip
+state {
+  pool : U64,
+  fees : U64,
+  spent : U64,
+  cap : U64,
+  owner : Pubkey,
+}
+type Error | Overflow | Unauthorized
+handler churn (amount : U64) (who : Pubkey) {
+  requires amount > 0 else Unauthorized
+  effect {
+    pool += amount,
+    fees +=! amount,
+    spent +=? amount,
+    cap -= amount,
+    pool -=! amount,
+    fees -=? amount,
+    owner := who,
+  }
+}
+"#;
+        let spec = parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&spec);
+        for op in &spec.handlers {
+            let body = mir.handler_block(&op.name).expect("mir body");
+            let got: Vec<(String, String, String)> = block_effect_triples(body)
+                .into_iter()
+                .map(|(f, k, v)| (f, k.to_string(), v.to_string()))
+                .collect();
+            let want: Vec<(String, String, String)> = op
+                .effects
+                .iter()
+                .map(|(f, k, v)| (f.clone(), k.clone(), v.clone()))
+                .collect();
+            assert_eq!(
+                got, want,
+                "MIR effect triples diverge from op.effects for `{}`",
+                op.name
+            );
+        }
+        // Sanity: the seven kinds all round-tripped (not vacuous).
+        let kinds: Vec<&str> = block_effect_triples(mir.handler_block("churn").expect("mir body"))
+            .iter()
+            .map(|(_, k, _)| *k)
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["add", "add_sat", "add_wrap", "sub", "sub_sat", "sub_wrap", "set"]
+        );
+    }
+
+    /// Same invariant over every bundled example spec — the real-world
+    /// shapes (indexed records, variant prefixes, match-arm expansion,
+    /// transfers/CPI/emit interleaving).
+    #[test]
+    fn stmt_effect_triples_round_trip_bundled_examples() {
+        let examples = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("repo root")
+            .join("examples/rust");
+        let mut checked = 0usize;
+        for entry in std::fs::read_dir(&examples).expect("examples/rust") {
+            let dir = entry.expect("dir entry").path();
+            if !dir.is_dir() {
+                continue;
+            }
+            let Some(spec_path) = std::fs::read_dir(&dir)
+                .expect("example dir")
+                .filter_map(|e| Some(e.ok()?.path()))
+                .find(|p| p.extension().is_some_and(|x| x == "qedspec"))
+            else {
+                continue;
+            };
+            let spec = match crate::check::parse_spec_file(&spec_path) {
+                Ok(s) => s,
+                // Brownfield onboarding fixtures may be intentionally
+                // partial — the invariant only applies to parseable specs.
+                Err(_) => continue,
+            };
+            let mir = crate::mir::lower(&spec);
+            for op in &spec.handlers {
+                let body = mir
+                    .handler_block(&op.name)
+                    .unwrap_or_else(|| panic!("MIR missing `{}` in {:?}", op.name, spec_path));
+                let got: Vec<(String, String, String)> = block_effect_triples(body)
+                    .into_iter()
+                    .map(|(f, k, v)| (f, k.to_string(), v.to_string()))
+                    .collect();
+                let want: Vec<(String, String, String)> = op
+                    .effects
+                    .iter()
+                    .map(|(f, k, v)| (f.clone(), k.clone(), v.clone()))
+                    .collect();
+                assert_eq!(
+                    got, want,
+                    "MIR effect triples diverge from op.effects for `{}` in {:?}",
+                    op.name, spec_path
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked > 10,
+            "expected to check many handlers, got {checked}"
+        );
+    }
+
     #[test]
     fn effect_target_base_strips_subscripts_and_dots() {
         assert_eq!(effect_target_base("plain"), "plain");
@@ -2152,9 +2355,11 @@ state { pool : U64 }
 handler buy (amount : U64) { effect { pool += amount } }
 "#;
         let spec = parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
+        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2179,9 +2384,11 @@ state { pool : U64 }
 handler buy (amount : U64) { effect { pool +=! amount } }
 "#;
         let spec = parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
+        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2202,9 +2409,11 @@ state { pool : U64 }
 handler buy (amount : U64) { effect { pool +=? amount } }
 "#;
         let spec = parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
+        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2230,9 +2439,11 @@ handler buy (amount : U64) { effect { pool +=? amount } }
                 "spec T\nstate {{ pool : U64 }}\nhandler buy (amount : U64) {{ effect {{ pool {op_str} amount }} }}\n"
             );
             let spec = parse_str(&src).expect("parse");
+            let mir = crate::mir::lower(&spec);
             let op = &spec.handlers[0];
+            let body = mir.handler_block(&op.name).expect("mir body");
             let mut out = String::new();
-            emit_transition_fn(&mut out, op, &spec, false, |t| {
+            emit_transition_fn(&mut out, body, op, &spec, false, |t| {
                 crate::codegen_shared::map_type(t, &spec)
             })
             .expect("emit");
@@ -2258,9 +2469,11 @@ type State
 handler close : State.Open -> State.Closed { effect { x := 0 } }
 "#;
         let spec = parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
+        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2284,9 +2497,11 @@ state { balance : U64 }
 handler deposit (amount : U64) { effect { balance += amount } }
 "#;
         let spec = parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
+        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");


### PR DESCRIPTION
Closes out the Kani/proptest half of the #66 remaining frontier: both backends now iterate the typed MIR `Stmt` body for effect lowering, so a new `Stmt` variant is a compile error at **all four** codegens (previously only the Lean codegen and the Rust scaffold).

## Before

- `kani_mir.rs` and `proptest_gen_mir.rs` had zero `Stmt` matches — effect bodies lowered from `ParsedHandler.effects` via `rust_codegen_util::emit_transition_fn*`.
- proptest's `generate` literally did `let _ = mir;` and re-parsed the spec from disk, ignoring both passed arguments.

## Design: adaptor, not rewrite

`rust_codegen_util::stmt_effect_triple` projects each effect-shaped `Stmt` back onto the `(field, op_kind, value)` triple the existing string templates consume — byte-identical output by construction (`lower_body` preserves `op.effects` order/content, `Path` round-trips the dotted field, `Expr::from_raw` carries the RHS verbatim). The match is exhaustive with no `_` arm; every non-effect variant returns `None` with a comment stating why it renders as nothing in the pure spec model.

What moved onto the MIR body:
- both transition-fn emitters (the wrappers now *require* a `mir::Block` — no fallback path to drift),
- Kani's effect-conformance harness loop (incl. the sibling-frame check) and overflow-detection filter,
- proptest's transition fns, overflow filter, and overflow tests; `generate` consumes the passed `(mir, parsed)` and drops the `spec_path` re-parse.

What stays `ParsedSpec`-fed **by design** (same boundary as `codegen_mir`'s guards): guard conjunctions, status writes, let-bindings, ghosts, `aborts_if`, strategies, properties. Conditional `effect { match … }` bodies still render from `op.effect_branches` pending the Phase-5 `Branch` lowering (today `lower_body` lowers the union flat + a stub — walking arms would double-emit); CLAUDE.md records this as the remaining piece.

Also: `Mir::handler_block` lookup helper (with the documented invariant that multi-account scoped views only *filter* handlers, never rewrite them, so name-keyed lookups stay valid), and fixed the flipped `+=!`/`+=?` doc comments on `SatAdd`/`WrapAdd` in `mir.rs`.

## Tests

Two new round-trip tests pin the adaptor invariant (`triples == op.effects`, order + content): a synthetic spec covering all seven op kinds, and a sweep over every bundled example handler.

## Validation

- 990 unit tests + all integration suites green.
- **kani / proptest / codegen / mir snapshot suites pass byte-identical — zero drift** (re-verified against a freshly rebuilt binary).
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.