### PR TITLE
feat(kani,mir): per-arm conformance harnesses + Mir.hooks lift (#66 follow-ups)

### DIFF
--- a/crates/qedgen/src/kani_mir.rs
+++ b/crates/qedgen/src/kani_mir.rs
@@ -579,10 +579,7 @@ fn emit_account_section_structural(out: &mut String, mir: &Mir, parsed: &ParsedS
         "// ============================================================================\n\n",
     );
     for op in &handlers {
-        let body = mir
-            .handler_block(&op.name)
-            .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
-        util::emit_transition_fn_for_kani(out, body, op, parsed, false, |t| map_type(t, parsed))?;
+        util::emit_transition_fn_for_kani(out, mir, op, parsed, false, |t| map_type(t, parsed))?;
     }
 
     // 8. Reference implementations (v2.25 — pure-expression fns
@@ -1717,7 +1714,7 @@ fn emit_effect_conformance_harnesses(
     mir: &Mir,
     parsed: &ParsedSpec,
 ) -> Result<()> {
-    use crate::codegen_shared::{map_type, sanitize_ident};
+    use crate::codegen_shared::sanitize_ident;
     use crate::rust_codegen_util as util;
 
     let handlers: Vec<&crate::check::ParsedHandler> = parsed.handlers.iter().collect();
@@ -1770,153 +1767,273 @@ fn emit_effect_conformance_harnesses(
         .collect();
 
     for op in &effect_ops {
-        let is_init = op.pre_status.as_deref() == Some("Uninitialized");
-
         // #66 — the per-effect harness loop iterates the handler's
         // lowered MIR body (projected back onto triples by the shared
         // adaptor), not `op.effects`. Same order/content; the sibling-
-        // frame check below reads the same triple list.
+        // frame check reads the same triple list.
         let body = mir
             .handler_block(&op.name)
             .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
         let triples = util::block_effect_triples(body);
         for (field, op_kind, value) in triples.iter().cloned() {
-            let base = util::effect_target_base(&field);
-            if !field_type_lookup.contains_key(base) {
-                continue;
-            }
-
-            let field_type = field_type_lookup.get(field.as_str()).copied().unwrap_or("");
-            let solver = util::pick_kani_solver_for_effect(field_type, value, op);
-
-            out.push_str("#[kani::proof]\n");
-            out.push_str("#[kani::unwind(2)]\n");
-            out.push_str(&format!("#[kani::solver({})]\n", solver));
-            out.push_str(&format!(
-                "fn verify_{}_effect_{}() {{\n",
-                op.name,
-                sanitize_ident(&field)
-            ));
-
-            if is_init {
-                util::emit_state_init_zeroed(out, &mutable, lifecycle, parsed);
-            } else {
-                util::emit_state_init_symbolic(out, &mutable, lifecycle);
-                util::emit_pre_status_assume(out, op, lifecycle);
-            }
-
-            for (pname, ptype) in &op.takes_params {
-                out.push_str(&format!(
-                    "    let {}: {} = kani::any();\n",
-                    pname,
-                    map_type(ptype, parsed)?
-                ));
-            }
-            util::emit_abstract_binders(out, op, "    ", "kani::any()", |t| map_type(t, parsed))?;
-
-            // Bounds assumptions for arithmetic safety (non-init only).
-            if !is_init {
-                if !parsed.constants.is_empty() {
-                    for (cname, _) in &parsed.constants {
-                        let upper = cname.to_uppercase();
-                        if upper.contains("MAX") || upper.contains("MEMBER") {
-                            if mutable.iter().any(|(f, _)| f == "member_count") {
-                                out.push_str(&format!(
-                                    "    kani::assume(s.member_count <= {});\n",
-                                    upper
-                                ));
-                            }
-                            break;
-                        }
-                    }
-                }
-                let owned_props: Vec<crate::check::ParsedProperty> =
-                    properties.iter().map(|p| (*p).clone()).collect();
-                util::emit_add_strict_bounds(
-                    out,
-                    op,
-                    &owned_props,
-                    "    kani::assume(s.{field} < s.{bound}); // strict bound: {field} increments\n",
-                );
-            }
-
-            // Pre-state snapshot — every mutable field except the
-            // set-target.
-            let needs_pre_for: Vec<&&(String, String)> = mutable
-                .iter()
-                .filter(|(fname, _)| !(fname.as_str() == field && op_kind == "set"))
-                .collect();
-            for (fname, _) in &needs_pre_for {
-                out.push_str(&format!("    let pre_{} = s.{};\n", fname, fname));
-            }
-
-            // Call transition + assertion dispatch.
-            emit_kani_account_env_binding(out, op, "accounts", "    ");
-            let args = transition_call_args(
-                op,
-                util::handler_needs_account_env(op).then_some("accounts"),
-            );
-            out.push_str(&format!("    if {}(&mut s{}) {{\n", op.name, args));
-
-            let resolved = util::resolve_value_with_account_env(
-                value,
-                op,
+            let harness_name = format!("verify_{}_effect_{}", op.name, sanitize_ident(&field));
+            emit_one_conformance_harness(
+                out,
                 parsed,
-                Some("pre_"),
-                util::handler_needs_account_env(op).then_some("accounts"),
-            );
-            match op_kind {
-                "set" => {
-                    let assertion = util::rewrite_kani_pubkey_comparisons(
-                        &format!("s.{field} == {resolved}"),
-                        op,
-                        parsed,
+                op,
+                &mutable,
+                lifecycle,
+                &properties,
+                &field_type_lookup,
+                &harness_name,
+                &[],
+                (&field, op_kind, value),
+                &triples,
+            )?;
+        }
+
+        // #42 — conditional effects: one harness per (arm, effect)
+        // under a `kani::assume(<scrutinee> == <pattern>)` pin, so the
+        // post-state assertions hold under match semantics (exactly one
+        // arm fires). The sibling-frame check is scoped to the arm's
+        // own effects: with the arm pinned, no other arm can mutate.
+        // The wildcard arm pins via negated assumes over every literal
+        // pattern.
+        let branch = body.stmts.iter().find_map(|st| match st {
+            crate::mir::Stmt::Branch {
+                scrutinee,
+                arms,
+                default,
+            } => Some((scrutinee, arms, default)),
+            _ => None,
+        });
+        if let Some((scrutinee, arms, default)) = branch {
+            let scrut = match scrutinee {
+                crate::mir::BranchScrutinee::Match(e) => e.rust.as_str(),
+                crate::mir::BranchScrutinee::Predicate(p) => p.0.rust.as_str(),
+            };
+            let patterns: Vec<&str> = arms
+                .iter()
+                .filter_map(|a| a.pattern.as_ref().map(|p| p.rust.as_str()))
+                .collect();
+            for (idx, arm) in arms.iter().enumerate() {
+                let Some(pattern) = arm.pattern.as_ref().map(|p| p.rust.as_str()) else {
+                    continue;
+                };
+                let assume = vec![format!("    kani::assume({} == {});\n", scrut, pattern)];
+                let arm_triples = util::block_effect_triples(&arm.block);
+                for (field, op_kind, value) in arm_triples.iter().cloned() {
+                    let harness_name = format!(
+                        "verify_{}_arm{}_effect_{}",
+                        op.name,
+                        idx,
+                        sanitize_ident(&field)
                     );
-                    out.push_str(&format!(
-                        "        assert!({}, \"{} must equal {}\");\n",
-                        assertion, field, resolved
-                    ));
-                }
-                "add" => {
-                    out.push_str(&format!(
-                        "        assert!(s.{} == pre_{}.wrapping_add({}), \"{} must increment by {}\");\n",
-                        field, field, resolved, field, resolved
-                    ));
-                }
-                "sub" => {
-                    out.push_str(&format!(
-                        "        assert!(s.{} == pre_{}.wrapping_sub({}), \"{} must decrement by {}\");\n",
-                        field, field, resolved, field, resolved
-                    ));
-                }
-                _ => {}
-            }
-
-            // Assert sibling fields unchanged (unless mutated by another
-            // effect in the same handler).
-            for (fname, _) in &mutable {
-                if fname.as_str() != field {
-                    let sibling_mutated =
-                        triples.iter().any(|(f, _, _)| f.as_str() == fname.as_str());
-                    if !sibling_mutated {
-                        let assertion = util::rewrite_kani_pubkey_comparisons(
-                            &format!("s.{fname} == pre_{fname}"),
-                            op,
-                            parsed,
-                        );
-                        out.push_str(&format!(
-                            "        assert!({}, \"{} must not change\");\n",
-                            assertion, fname
-                        ));
-                    }
+                    emit_one_conformance_harness(
+                        out,
+                        parsed,
+                        op,
+                        &mutable,
+                        lifecycle,
+                        &properties,
+                        &field_type_lookup,
+                        &harness_name,
+                        &assume,
+                        (&field, op_kind, value),
+                        &arm_triples,
+                    )?;
                 }
             }
-
-            out.push_str("    }\n");
-            out.push_str("}\n\n");
+            if let Some(default_block) = default {
+                let assumes: Vec<String> = patterns
+                    .iter()
+                    .map(|p| format!("    kani::assume({} != {});\n", scrut, p))
+                    .collect();
+                let default_triples = util::block_effect_triples(default_block);
+                for (field, op_kind, value) in default_triples.iter().cloned() {
+                    let harness_name = format!(
+                        "verify_{}_default_effect_{}",
+                        op.name,
+                        sanitize_ident(&field)
+                    );
+                    emit_one_conformance_harness(
+                        out,
+                        parsed,
+                        op,
+                        &mutable,
+                        lifecycle,
+                        &properties,
+                        &field_type_lookup,
+                        &harness_name,
+                        &assumes,
+                        (&field, op_kind, value),
+                        &default_triples,
+                    )?;
+                }
+            }
         }
     }
 
+    Ok(())
+}
+
+/// One effect-conformance harness: symbolic (or zeroed-init) state,
+/// symbolic params, optional scrutinee-pin assumes (#42 per-arm sites),
+/// transition call, post-state assertion for the target effect, and the
+/// frame check over `sibling_triples` (the effect set that can legally
+/// fire alongside the target — the whole flat body, or one Branch arm).
+#[allow(clippy::too_many_arguments)]
+fn emit_one_conformance_harness(
+    out: &mut String,
+    parsed: &ParsedSpec,
+    op: &crate::check::ParsedHandler,
+    mutable: &[&(String, String)],
+    lifecycle: &[String],
+    properties: &[&crate::check::ParsedProperty],
+    field_type_lookup: &std::collections::HashMap<&str, &str>,
+    harness_name: &str,
+    assume_lines: &[String],
+    (field, op_kind, value): (&str, &str, &str),
+    sibling_triples: &[(String, &'static str, &str)],
+) -> Result<()> {
+    use crate::codegen_shared::map_type;
+    use crate::rust_codegen_util as util;
+
+    let is_init = op.pre_status.as_deref() == Some("Uninitialized");
+
+    let base = util::effect_target_base(field);
+    if !field_type_lookup.contains_key(base) {
+        return Ok(());
+    }
+
+    let field_type = field_type_lookup.get(field).copied().unwrap_or("");
+    let solver = util::pick_kani_solver_for_effect(field_type, value, op);
+
+    out.push_str("#[kani::proof]\n");
+    out.push_str("#[kani::unwind(2)]\n");
+    out.push_str(&format!("#[kani::solver({})]\n", solver));
+    out.push_str(&format!("fn {}() {{\n", harness_name));
+
+    if is_init {
+        util::emit_state_init_zeroed(out, mutable, lifecycle, parsed);
+    } else {
+        util::emit_state_init_symbolic(out, mutable, lifecycle);
+        util::emit_pre_status_assume(out, op, lifecycle);
+    }
+
+    for (pname, ptype) in &op.takes_params {
+        out.push_str(&format!(
+            "    let {}: {} = kani::any();\n",
+            pname,
+            map_type(ptype, parsed)?
+        ));
+    }
+    util::emit_abstract_binders(out, op, "    ", "kani::any()", |t| map_type(t, parsed))?;
+
+    // #42 — pin the scrutinee to this arm (or away from every literal
+    // pattern, for the wildcard arm) before any state is read.
+    for line in assume_lines {
+        out.push_str(line);
+    }
+
+    // Bounds assumptions for arithmetic safety (non-init only).
+    if !is_init {
+        if !parsed.constants.is_empty() {
+            for (cname, _) in &parsed.constants {
+                let upper = cname.to_uppercase();
+                if upper.contains("MAX") || upper.contains("MEMBER") {
+                    if mutable.iter().any(|(f, _)| f == "member_count") {
+                        out.push_str(&format!("    kani::assume(s.member_count <= {});\n", upper));
+                    }
+                    break;
+                }
+            }
+        }
+        let owned_props: Vec<crate::check::ParsedProperty> =
+            properties.iter().map(|p| (*p).clone()).collect();
+        util::emit_add_strict_bounds(
+            out,
+            op,
+            &owned_props,
+            "    kani::assume(s.{field} < s.{bound}); // strict bound: {field} increments\n",
+        );
+    }
+
+    // Pre-state snapshot — every mutable field except the
+    // set-target.
+    let needs_pre_for: Vec<&&(String, String)> = mutable
+        .iter()
+        .filter(|(fname, _)| !(fname.as_str() == field && op_kind == "set"))
+        .collect();
+    for (fname, _) in &needs_pre_for {
+        out.push_str(&format!("    let pre_{} = s.{};\n", fname, fname));
+    }
+
+    // Call transition + assertion dispatch.
+    emit_kani_account_env_binding(out, op, "accounts", "    ");
+    let args = transition_call_args(
+        op,
+        util::handler_needs_account_env(op).then_some("accounts"),
+    );
+    out.push_str(&format!("    if {}(&mut s{}) {{\n", op.name, args));
+
+    let resolved = util::resolve_value_with_account_env(
+        value,
+        op,
+        parsed,
+        Some("pre_"),
+        util::handler_needs_account_env(op).then_some("accounts"),
+    );
+    match op_kind {
+        "set" => {
+            let assertion = util::rewrite_kani_pubkey_comparisons(
+                &format!("s.{field} == {resolved}"),
+                op,
+                parsed,
+            );
+            out.push_str(&format!(
+                "        assert!({}, \"{} must equal {}\");\n",
+                assertion, field, resolved
+            ));
+        }
+        "add" => {
+            out.push_str(&format!(
+                "        assert!(s.{} == pre_{}.wrapping_add({}), \"{} must increment by {}\");\n",
+                field, field, resolved, field, resolved
+            ));
+        }
+        "sub" => {
+            out.push_str(&format!(
+                "        assert!(s.{} == pre_{}.wrapping_sub({}), \"{} must decrement by {}\");\n",
+                field, field, resolved, field, resolved
+            ));
+        }
+        _ => {}
+    }
+
+    // Assert sibling fields unchanged (unless mutated by another
+    // effect in the same frame — the flat body, or this arm).
+    for (fname, _) in mutable {
+        if fname.as_str() != field {
+            let sibling_mutated = sibling_triples
+                .iter()
+                .any(|(f, _, _)| f.as_str() == fname.as_str());
+            if !sibling_mutated {
+                let assertion = util::rewrite_kani_pubkey_comparisons(
+                    &format!("s.{fname} == pre_{fname}"),
+                    op,
+                    parsed,
+                );
+                out.push_str(&format!(
+                    "        assert!({}, \"{} must not change\");\n",
+                    assertion, fname
+                ));
+            }
+        }
+    }
+
+    out.push_str("    }\n");
+    out.push_str("}\n\n");
     Ok(())
 }
 
@@ -2285,6 +2402,66 @@ mod tests {
     use super::*;
     use crate::check;
     use std::path::Path;
+
+    /// #42 — conditional-effect handlers get per-arm conformance
+    /// harnesses: each arm pinned via `kani::assume(<scrutinee> ==
+    /// <pattern>)` with the frame check scoped to that arm's effects;
+    /// the wildcard arm pins via negated assumes over every literal
+    /// pattern. (Flat per-effect harnesses self-skip for Branch
+    /// handlers — their unconditional assertions are invalid under
+    /// match semantics.)
+    #[test]
+    fn branch_handlers_get_per_arm_conformance_harnesses() {
+        let (mir, parsed) = lower_fixture(
+            "crates/qedgen/tests/fixtures/regressions/issue-42-conditional/fee_router.qedspec",
+        );
+        let out = render(&mir, &parsed);
+
+        // Per-arm harnesses with scrutinee pins.
+        assert!(
+            out.contains("fn verify_collect_fees_arm0_effect_fees_a_withdrawn()"),
+            "arm-0 harness missing:\n{out}"
+        );
+        assert!(
+            out.contains("    kani::assume(fee_type == 0);"),
+            "arm-0 scrutinee pin missing:\n{out}"
+        );
+        // Wildcard arm: negated pins + the set-effect assertion.
+        assert!(
+            out.contains("fn verify_collect_fees_default_effect_fees_d_accumulated()"),
+            "default-arm harness missing:\n{out}"
+        );
+        for pin in [
+            "    kani::assume(fee_type != 0);",
+            "    kani::assume(fee_type != 1);",
+            "    kani::assume(fee_type != 2);",
+        ] {
+            assert!(out.contains(pin), "default pin `{pin}` missing:\n{out}");
+        }
+        // Frame scoped to the arm: under the arm-0 pin, every other
+        // field must be asserted unchanged (including the other arms'
+        // targets).
+        let arm0 = out
+            .split("fn verify_collect_fees_arm0_effect_fees_a_withdrawn()")
+            .nth(1)
+            .and_then(|rest| rest.split("#[kani::proof]").next())
+            .expect("arm-0 harness body");
+        for sibling in [
+            "fees_b_withdrawn must not change",
+            "fees_c_accumulated must not change",
+            "fees_d_accumulated must not change",
+        ] {
+            assert!(
+                arm0.contains(sibling),
+                "frame check `{sibling}` missing:\n{arm0}"
+            );
+        }
+        // No unconditional flat harness for a Branch handler.
+        assert!(
+            !out.contains("fn verify_collect_fees_effect_"),
+            "flat per-effect harness must self-skip for Branch handlers:\n{out}"
+        );
+    }
 
     fn lower_fixture(rel_path: &str) -> (Mir, ParsedSpec) {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/qedgen/src/lean_gen_mir.rs
+++ b/crates/qedgen/src/lean_gen_mir.rs
@@ -2292,7 +2292,8 @@ fn scope_mir_to_account(mir: &Mir, acct: &crate::mir::AccountStateMir) -> Mir {
         handlers,
         invariants: Vec::new(), // emit_invariants_as_comments handles
         events: mir.events.clone(),
-        constants: Vec::new(),             // already emitted at top
+        constants: Vec::new(), // already emitted at top
+        hooks: mir.hooks.clone(),
         uninterpreted_helpers: Vec::new(), // already emitted
         ref_impls: Vec::new(),             // already emitted
         properties: Vec::new(),            // emit_properties_multi handles
@@ -6223,6 +6224,7 @@ handler route (fee_type : U8) (amount : U64) : State.Active -> State.Active {
             invariants: vec![],
             events: vec![],
             constants: vec![],
+            hooks: vec![],
             uninterpreted_helpers: vec![crate::mir::UninterpretedHelper {
                 name: "is_valid".to_string(),
                 arg_types: vec!["Nat".to_string()],
@@ -6260,6 +6262,7 @@ handler route (fee_type : U8) (amount : U64) : State.Active -> State.Active {
             invariants: vec![],
             events: vec![],
             constants: vec![],
+            hooks: vec![],
             uninterpreted_helpers: vec![],
             ref_impls: vec![crate::mir::RefImpl {
                 name: "scale".to_string(),

--- a/crates/qedgen/src/mir.rs
+++ b/crates/qedgen/src/mir.rs
@@ -170,6 +170,12 @@ pub struct Mir {
     /// mutations. Each property × environment cross emits a
     /// preservation theorem.
     pub environments: Vec<EnvironmentMir>,
+    /// Issue #67 item 4 — `hook after_store(<field>)` / `hook
+    /// before_cpi` assertion blocks, lifted from `ParsedSpec.hooks`.
+    /// The Kani/proptest transition emitter injects `AfterStore`
+    /// asserts after each matching field store; Lean ignores hooks
+    /// (enforcement deferred to the qedsvm path).
+    pub hooks: Vec<HookMir>,
     /// Issue #67 item 3 — `ghost` spec-only auxiliary state. Lowered to
     /// extra verification-State fields (Lean / proptest / Kani) plus a
     /// per-handler new-value expression; the on-chain codegen ignores
@@ -201,6 +207,22 @@ pub struct Mir {
     /// variant. `lean_gen_mir::is_multi_variant_adt` reads this; the
     /// `ParsedSpec`-based codegens read `state_repr_is_adt()` directly.
     pub adt_state: bool,
+}
+
+/// Issue #67 item 4 — a `hook … { assert <expr>, … }` block. Mirrors
+/// `ParsedHook`; asserts carry both Lean and Rust renderings.
+#[derive(Debug, Clone)]
+pub struct HookMir {
+    pub kind: HookKind,
+    pub asserts: Vec<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookKind {
+    /// Fires after any store to the named state field.
+    AfterStore(Symbol),
+    /// Fires before a CPI (optionally only to the named callee namespace).
+    BeforeCpi(Option<Symbol>),
 }
 
 impl Mir {
@@ -1093,6 +1115,27 @@ pub fn lower(parsed: &ParsedSpec) -> Mir {
         invariants: lower_invariants(parsed),
         events: lower_events(parsed),
         constants: parsed.constants.clone(),
+        hooks: parsed
+            .hooks
+            .iter()
+            .map(|h| HookMir {
+                kind: match &h.kind {
+                    crate::check::ParsedHookKind::AfterStore(f) => HookKind::AfterStore(f.clone()),
+                    crate::check::ParsedHookKind::BeforeCpi(ns) => HookKind::BeforeCpi(ns.clone()),
+                },
+                asserts: h
+                    .asserts
+                    .iter()
+                    .map(|a| Expr {
+                        lean: a.lean.clone(),
+                        rust: a.rust.clone(),
+                        rust_pod: a.rust.clone(),
+                        rust_binary: String::new(),
+                        source_span: None,
+                    })
+                    .collect(),
+            })
+            .collect(),
         uninterpreted_helpers: parsed
             .uninterpreted_helpers
             .iter()
@@ -1957,6 +2000,7 @@ handler route (fee_type : U8) (amount : U64) : State.Active -> State.Active {
             invariants: vec![],
             events: vec![],
             constants: vec![],
+            hooks: vec![],
             uninterpreted_helpers: vec![],
             ref_impls: vec![],
             properties: vec![],

--- a/crates/qedgen/src/proptest_gen_mir.rs
+++ b/crates/qedgen/src/proptest_gen_mir.rs
@@ -842,7 +842,7 @@ fn emit_account_section(
     // #67 item 4) — the sequence harness drives random op sequences from
     // `init`, which is what exercises the `after_store` assertions injected
     // into the transitions (without a driver the hooks would never fire).
-    let want_sequence = (!owned_props.is_empty() && handlers.len() > 1) || !spec.hooks.is_empty();
+    let want_sequence = (!owned_props.is_empty() && handlers.len() > 1) || !mir.hooks.is_empty();
     if want_sequence && !handlers.is_empty() {
         emit_sequence_test_for(
             out,
@@ -967,10 +967,7 @@ fn emit_transition_functions_for(
     spec: &ParsedSpec,
 ) -> Result<()> {
     for op in handlers {
-        let body = mir
-            .handler_block(&op.name)
-            .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
-        rust_codegen_util::emit_transition_fn(out, body, op, spec, true, |t| map_type(t, spec))?;
+        rust_codegen_util::emit_transition_fn(out, mir, op, spec, true, |t| map_type(t, spec))?;
     }
     Ok(())
 }

--- a/crates/qedgen/src/rust_codegen_util.rs
+++ b/crates/qedgen/src/rust_codegen_util.rs
@@ -1939,10 +1939,15 @@ pub fn emit_property_predicates_with(
 /// failed assertion panics, which both the proptest and Kani harnesses
 /// surface as a failure / verification violation. On-chain codegen doesn't
 /// use this transition emitter, so hooks never reach the program.
-fn emit_after_store_hooks(out: &mut String, spec: &ParsedSpec, field: &str, indent: &str) {
+fn emit_after_store_hooks(
+    out: &mut String,
+    hooks: &[crate::mir::HookMir],
+    field: &str,
+    indent: &str,
+) {
     let base = effect_target_base(field);
-    for hook in &spec.hooks {
-        if let crate::check::ParsedHookKind::AfterStore(f) = &hook.kind {
+    for hook in hooks {
+        if let crate::mir::HookKind::AfterStore(f) = &hook.kind {
             if f == base {
                 for a in &hook.asserts {
                     out.push_str(&format!(
@@ -1964,18 +1969,18 @@ fn emit_after_store_hooks(out: &mut String, spec: &ParsedSpec, field: &str, inde
 /// surface, same boundary as `codegen_mir`'s guards.
 pub fn emit_transition_fn(
     out: &mut String,
-    body: &crate::mir::Block,
+    mir: &crate::mir::Mir,
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) -> anyhow::Result<()> {
-    emit_transition_fn_inner(out, body, op, spec, wrapping, None, false, map_type_fn)
+    emit_transition_fn_inner(out, mir, op, spec, wrapping, None, false, map_type_fn)
 }
 
 pub fn emit_transition_fn_for_kani(
     out: &mut String,
-    body: &crate::mir::Block,
+    mir: &crate::mir::Mir,
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
@@ -1985,7 +1990,7 @@ pub fn emit_transition_fn_for_kani(
         handler_needs_account_env(op).then(|| handler_account_env_struct_name(&op.name));
     emit_transition_fn_inner(
         out,
-        body,
+        mir,
         op,
         spec,
         wrapping,
@@ -1998,7 +2003,7 @@ pub fn emit_transition_fn_for_kani(
 #[allow(clippy::too_many_arguments)]
 fn emit_transition_fn_inner(
     out: &mut String,
-    body: &crate::mir::Block,
+    mir: &crate::mir::Mir,
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
@@ -2006,6 +2011,9 @@ fn emit_transition_fn_inner(
     rewrite_pubkey_comparisons: bool,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) -> anyhow::Result<()> {
+    let body = mir
+        .handler_block(&op.name)
+        .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
     if let Some(ref doc) = op.doc {
         out.push_str(&format!("/// {}\n", doc.trim()));
     }
@@ -2160,7 +2168,7 @@ fn emit_transition_fn_inner(
                         "            ",
                     );
                 }
-                emit_after_store_hooks(out, spec, field, "            ");
+                emit_after_store_hooks(out, &mir.hooks, field, "            ");
             }
         };
         for arm in arms {
@@ -2205,7 +2213,7 @@ fn emit_transition_fn_inner(
             } else {
                 emit_one_effect(out, op, spec, wrapping, field, op_kind, value, "    ");
             }
-            emit_after_store_hooks(out, spec, field, "    ");
+            emit_after_store_hooks(out, &mir.hooks, field, "    ");
         }
     }
 
@@ -2331,9 +2339,8 @@ handler route (fee_type : U8) (amount : U64) : State.Active -> State.Active {
         let spec = parse_str(src).expect("parse");
         let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
-        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2462,9 +2469,8 @@ handler buy (amount : U64) { effect { pool += amount } }
         let spec = parse_str(src).expect("parse");
         let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
-        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2491,9 +2497,8 @@ handler buy (amount : U64) { effect { pool +=! amount } }
         let spec = parse_str(src).expect("parse");
         let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
-        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2516,9 +2521,8 @@ handler buy (amount : U64) { effect { pool +=? amount } }
         let spec = parse_str(src).expect("parse");
         let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
-        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2546,9 +2550,8 @@ handler buy (amount : U64) { effect { pool +=? amount } }
             let spec = parse_str(&src).expect("parse");
             let mir = crate::mir::lower(&spec);
             let op = &spec.handlers[0];
-            let body = mir.handler_block(&op.name).expect("mir body");
             let mut out = String::new();
-            emit_transition_fn(&mut out, body, op, &spec, false, |t| {
+            emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
                 crate::codegen_shared::map_type(t, &spec)
             })
             .expect("emit");
@@ -2576,9 +2579,8 @@ handler close : State.Open -> State.Closed { effect { x := 0 } }
         let spec = parse_str(src).expect("parse");
         let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
-        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -2604,9 +2606,8 @@ handler deposit (amount : U64) { effect { balance += amount } }
         let spec = parse_str(src).expect("parse");
         let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
-        let body = mir.handler_block(&op.name).expect("mir body");
         let mut out = String::new();
-        emit_transition_fn(&mut out, body, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");


### PR DESCRIPTION
Two follow-ups from the Phase-5 Branch lowering (#96), closing the coverage hole it left and the last transitional `ParsedSpec` read.

## 1. Per-arm effect-conformance harnesses (#42)

Branch handlers previously got **no conformance coverage at all** — the flat per-effect harnesses self-skip because their unconditional post-state assertions are invalid under match semantics. Now each (arm, effect) site emits its own harness pinned with `kani::assume(<scrutinee> == <pattern>)`; the wildcard arm pins via negated assumes over every literal pattern:

```rust
fn verify_collect_fees_arm0_effect_fees_a_withdrawn() {
    ...
    kani::assume(fee_type == 0);
    ...
    if collect_fees(&mut s, fee_type, amount) {
        assert!(s.fees_b_withdrawn == pre_fees_b_withdrawn, "fees_b_withdrawn must not change");
        ...
    }
}
```

The sibling-frame check is scoped to the arm's own effects — with the arm pinned, no other arm can fire, so every other mutable field must be unchanged. The shared harness body is factored into `emit_one_conformance_harness`; the flat path emits through the same helper **byte-identically** (kani snapshots untouched).

## 2. `Mir.hooks` lift (#67 item 4)

`hook after_store(<field>)` asserts now lower onto `Mir.hooks` (`HookMir`/`HookKind`) and the transition emitter reads them from the IR — the last documented transitional `ParsedSpec` read in the effect-emission path is gone. The `emit_transition_fn*` wrappers take `&Mir` (body + hooks) instead of a bare `&Block`, which also simplifies every call site (no per-call `handler_block` lookup).

## Validation

- New test pins the per-arm harness shape against the issue-42 fee-router fixture (scrutinee pins, negated wildcard pins, arm-scoped frame, no unconditional flat harness).
- 1065 unit tests + all suites green; **every snapshot suite passes byte-identical**; fmt + clippy clean.