### PR TITLE
Doc-comment fixes + wire check --explain into the --json data layer

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -265,6 +265,8 @@ Use Leanstral for routine sorry filling and Aristotle for harder long-running pr
 
 Always run `lake build` after editing Lean and run `qedgen check` after proofs compile so orphan or missing obligations are reported.
 
+For a verification summary, run `qedgen check --spec <s> --explain --json` and render the report yourself from the structured payload (`summary` counts + per-`properties` status/intent/suggestion). The bare `--explain` Markdown is a human fallback; the agent owns the narrative.
+
 ## Invariants vs Properties
 
 Two related but distinct constructs in `.qedspec`:

--- a/crates/qedgen/src/check/model.rs
+++ b/crates/qedgen/src/check/model.rs
@@ -1,7 +1,7 @@
 //! Parsed-spec data model: the `Parsed*` AST types, their impls, and the
 //! report/diagnostic types shared across the check submodules.
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub struct PropertyStatus {
     pub name: String,
     pub status: Status,
@@ -10,7 +10,8 @@ pub struct PropertyStatus {
     pub suggestion: Option<String>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Status {
     Proven,
     Sorry,

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -1076,10 +1076,6 @@ enum AristotleCommands {
     },
 }
 
-/// Walk up from `start` looking for a `.git` directory. Returns true if one
-/// is found before hitting the filesystem root. qedgen refuses to write
-/// scaffolding unless the user has a git repo — the safety net for
-/// regeneration is a clean working tree.
 /// Redirect a `…/tests/kani_impl.rs` path to a sibling `…/src/kani_impl.rs`.
 /// Pinocchio Kani harnesses must live in the lib (`src/`) because
 /// `cargo kani` only discovers `#[kani::proof]` there, not in `tests/`
@@ -1100,6 +1096,10 @@ fn redirect_kani_impl_to_src(path: &std::path::Path) -> PathBuf {
     }
 }
 
+/// Walk up from `start` looking for a `.git` directory. Returns true if one
+/// is found before hitting the filesystem root. qedgen refuses to write
+/// scaffolding unless the user has a git repo — the safety net for
+/// regeneration is a clean working tree.
 fn has_git_repo(start: &std::path::Path) -> bool {
     let mut cur = match start.canonicalize() {
         Ok(p) => p,

--- a/crates/qedgen/src/main.rs
+++ b/crates/qedgen/src/main.rs
@@ -451,7 +451,8 @@ enum Commands {
     /// Validate a spec — lint, coverage, drift, and verification report
     ///
     /// Default (no flags): runs lint + coverage.
-    /// With --explain: generates a Markdown verification report.
+    /// With --explain: generates a Markdown verification report (add --json
+    /// for the structured verification-status payload the agent renders from).
     /// With --drift: detects code drift in #[qed(verified)] functions.
     Check {
         /// Path to the spec file (.qedspec or a directory of fragments).
@@ -2479,7 +2480,9 @@ async fn dispatch(cmd: Commands) -> Result<()> {
                 }
             }
 
-            // Explain report (--explain) — inline markdown generation
+            // Verification report (--explain). `--json` emits the
+            // verification-status data layer for the agent to render; without
+            // it the CLI prints the inline Markdown human fallback.
             if explain {
                 let results = check::check(&spec, &proofs)?;
                 let proven = results
@@ -2496,37 +2499,52 @@ async fn dispatch(cmd: Commands) -> Result<()> {
                     .count();
                 let total = results.len();
 
-                let mut md = format!("# {} Verification Report\n\n", spec_name);
-                md.push_str(&format!(
-                    "**{}/{} properties verified** ({} sorry, {} missing)\n\n",
-                    proven, total, sorry, missing
-                ));
-                if proven == total {
-                    md.push_str("> All properties verified (sorry-free).\n\n");
-                }
-                md.push_str("## Properties\n\n");
-                for r in &results {
-                    let (icon, label) = match r.status {
-                        check::Status::Proven => ("✓", "PROVEN"),
-                        check::Status::Sorry => ("✗", "SORRY"),
-                        check::Status::Missing => ("✗", "MISSING"),
-                    };
-                    md.push_str(&format!("### {} {} — {}\n\n", icon, r.name, label));
-                    if let Some(ref intent) = r.intent {
-                        md.push_str(&format!("**Intent:** {}\n\n", intent));
+                let (rendered, what) = if json {
+                    let payload = serde_json::json!({
+                        "spec": spec_name,
+                        "summary": {
+                            "proven": proven,
+                            "sorry": sorry,
+                            "missing": missing,
+                            "total": total,
+                        },
+                        "properties": results,
+                    });
+                    (serde_json::to_string_pretty(&payload)?, "report (JSON)")
+                } else {
+                    let mut md = format!("# {} Verification Report\n\n", spec_name);
+                    md.push_str(&format!(
+                        "**{}/{} properties verified** ({} sorry, {} missing)\n\n",
+                        proven, total, sorry, missing
+                    ));
+                    if proven == total {
+                        md.push_str("> All properties verified (sorry-free).\n\n");
                     }
-                    if r.status != check::Status::Proven {
-                        if let Some(ref suggestion) = r.suggestion {
-                            md.push_str(&format!("**Suggestion:** {}\n\n", suggestion));
+                    md.push_str("## Properties\n\n");
+                    for r in &results {
+                        let (icon, label) = match r.status {
+                            check::Status::Proven => ("✓", "PROVEN"),
+                            check::Status::Sorry => ("✗", "SORRY"),
+                            check::Status::Missing => ("✗", "MISSING"),
+                        };
+                        md.push_str(&format!("### {} {} — {}\n\n", icon, r.name, label));
+                        if let Some(ref intent) = r.intent {
+                            md.push_str(&format!("**Intent:** {}\n\n", intent));
+                        }
+                        if r.status != check::Status::Proven {
+                            if let Some(ref suggestion) = r.suggestion {
+                                md.push_str(&format!("**Suggestion:** {}\n\n", suggestion));
+                            }
                         }
                     }
-                }
+                    (md, "report")
+                };
 
                 if let Some(ref path) = output {
-                    std::fs::write(path, &md)?;
-                    eprintln!("Wrote verification report to {}", path.display());
+                    std::fs::write(path, &rendered)?;
+                    eprintln!("Wrote verification {} to {}", what, path.display());
                 } else {
-                    print!("{}", md);
+                    print!("{}", rendered);
                 }
             }
 

--- a/crates/qedgen/src/probe/cluster.rs
+++ b/crates/qedgen/src/probe/cluster.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// findings, presented as a single interview question.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Cluster {
-    /// Deterministic hash of `(kind, scope, normalized_clause_text)`,
+    /// Deterministic hash of `(kind, scope)`,
     /// stable across runs on an unchanged program. Suppression rules and
     /// resumed-interview state key off this.
     pub id: String,

--- a/crates/qedgen/src/spec/ast.rs
+++ b/crates/qedgen/src/spec/ast.rs
@@ -52,11 +52,12 @@ pub enum TopItem {
     },
     /// `type T = { f : Type, ... }` — plain record.
     Record(RecordDecl),
-    /// `type State | Active of { ... } | Draining | ...` — ADT.
-    Adt(AdtDecl),
-    /// `type Error | Foo | Bar = 42 "desc"` — flat enum for error codes.
-    /// Represented as an ADT with variants with no payload; the name
+    /// `type State | Active of { ... } | Draining | ...` — ADT. Flat error
+    /// enums (`type Error | Foo | Bar = 42 "desc"`) are the no-payload case,
+    /// represented as an ADT with variants with no payload; the name
     /// "Error" is conventional.
+    Adt(AdtDecl),
+    /// `handler name (args) { requires / effect / … }` — an instruction handler.
     Handler(HandlerDecl),
     Property(PropertyDecl),
     Cover(CoverDecl),


### PR DESCRIPTION
Two small, independent commits closing out cleanup-track loose ends.

## 1. Fix three misplaced doc comments (carry-overs from PR #102)
- `ast.rs` — the `type Error` doc sat on `TopItem::Handler`; moved the error-as-ADT note onto `Adt`, gave `Handler` its own doc.
- `main.rs` — `has_git_repo`'s doc was stranded above `redirect_kani_impl_to_src`; re-attached to `has_git_repo`.
- `cluster.rs` — `Cluster::id` doc claimed `(kind, scope, clause_text)` but `compute_cluster_id` hashes only `(kind, scope)`; corrected.

Doc-only, no behavior change.

## 2. Wire `check --explain` into the `--json` data layer
`check --explain` generated a Markdown report inline — the only `check` sub-mode without a `--json` branch, so property verification status (proven/sorry/missing + intent/suggestion) was the one piece of check data not exposed to the agent.

- `check --explain --json` now emits a structured payload (`summary` counts + per-`properties` list); `Status`/`PropertyStatus` derive `Serialize`.
- Bare `--explain` keeps Markdown as a human fallback.
- SKILL.md documents the contract: the agent renders the report from the JSON (narrative → agent, the v3 compartmentalization direction).

Consistent with the existing per-sub-mode `--json` convention (same shape as `--coverage --json`). Additive — no change to existing flags.

## Tests
- build clean · 1006 unit tests + all snapshot suites green · `cargo fmt --check` · `clippy --bin qedgen --tests -D warnings`