### PR TITLE
refactor(check): privatize check_map_and_subscript to pub(super)

### DIFF
--- a/crates/qedgen/src/check/lints/arithmetic.rs
+++ b/crates/qedgen/src/check/lints/arithmetic.rs
@@ -201,7 +201,7 @@ pub(super) fn check_wrapping_arithmetic_opt_in(spec: &ParsedSpec) -> Vec<Complet
 ///   - `N` must be a declared `const`
 ///   - `T` must be either a declared record or a well-known primitive
 ///   - Effect LHS of form `field[i].x` must reference a Map-typed state field
-pub(crate) fn check_map_and_subscript(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
+pub(super) fn check_map_and_subscript(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
     use std::collections::{HashMap, HashSet};
 
     let mut warnings = Vec::new();

--- a/crates/qedgen/src/check/lints/mod.rs
+++ b/crates/qedgen/src/check/lints/mod.rs
@@ -14,7 +14,7 @@ mod shared;
 mod state;
 mod structural;
 
-pub(crate) use arithmetic::*;
+pub(in crate::check::lints) use arithmetic::*;
 pub(in crate::check::lints) use auth::*;
 pub(crate) use cpi::*;
 pub(crate) use shared::*;


### PR DESCRIPTION
Tiny follow-up to #109's lint-helper privatization.

That PR kept `check_map_and_subscript` `pub(crate)` believing `spec/chumsky_adapter.rs` called it — but the only reference there is a **prose comment** (`chumsky_adapter.rs:2999`), not a call. Real callers are `check_completeness` (`lints/mod.rs`) + its colocated test, both reachable at `pub(super)`.

- Lowers the fn to `pub(super)`.
- Scopes `arithmetic`'s glob re-export to `pub(in crate::check::lints)` (matching auth/state/structural), since the module no longer exposes a `pub(crate)` item.

Visibility-only, no logic change. Gate: build + test (1006 unit + all snapshots) + fmt + clippy `-D warnings` — green locally.