### PR TITLE
Release v2.37.0 — qedsvm discharge seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.36.0"
+version = "2.37.0"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.36.0"
+version = "2.37.0"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/lending.codegen.txt
+++ b/crates/qedgen/tests/snapshots/lending.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 anchor-lang = "0.32.1"
 

--- a/crates/qedgen/tests/snapshots/percolator.codegen.txt
+++ b/crates/qedgen/tests/snapshots/percolator.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 anchor-lang = "0.32.1"
 

--- a/docs/prds/RELEASE-v2.37.0.md
+++ b/docs/prds/RELEASE-v2.37.0.md
@@ -1,0 +1,76 @@
+# QEDGen v2.37.0 — the qedsvm discharge seam (sBPF bridge `.refines` proven against pinned bytes)
+
+**Status:** release-prep (on `chore/release-v2.37.0`). **Theme:** close the
+"qedgen names the bytes but doesn't prove them" gap for the first handler shape —
+the spec→byte-level proof chain now runs end to end and the generated sBPF-bridge
+`.refines` is sorry-free.
+
+Everything since v2.36.0 (#119–#134). Headline is the discharge seam; the rest is
+codegen-refactor + lint follow-ups.
+
+## What shipped
+
+### 1. The qedsvm discharge seam — spec → pinned bytes (Slice A)
+
+The bundled CPI-callee `ensures` and the sBPF refinement bridge were *axiomatized
+against a `binary_hash` pin* — qedgen named the bytes, but didn't prove they honor
+the contract. Slice A closes that for a single-field constant-increment handler
+(`field += <int literal>`), end to end:
+
+- **Descriptor producer** (#125–#127) — `qedgen descriptor` emits a name-level
+  refinement descriptor (JSON); `qedgen discharge` chains it through qedsvm's
+  `qedlift` and reports a verdict against the decoded program bytes (offsets
+  resolved IDL-side). Schema v1 (`add_const`) + v2 (`add_param`, arbitrary literals).
+- **A1 — ELF cache** (#130, `verify/upstream_check.rs`) — a verified
+  `--check-upstream` match content-addresses + stashes the program bytes so the
+  discharge tactic has them without a second fetch.
+- **A2a — discharge persist** (#132) — `qedgen discharge --out-dir` writes the
+  discharged `<Module>Refinement.lean` + `<Module>TracedLifted.lean` into the
+  project instead of a temp dir.
+- **A2b — the Bridge↔qedlift adapter** (#134) — the `qedbridge` `.refines`
+  elaborator now emits the *provable* shape (threads the discharge
+  `AsmRefinesFieldUpdate` + the `cr.SatisfiedBy` program constraint as hypotheses
+  instead of quantifying over a free `progAt`), discharges the halt through a
+  proven execution adapter (`BridgeAdapter.lean`), and closes the post
+  `codecCoarse → encodeState` leg via qedsvm#48's `CodecRead.lean` family. The
+  generated `Vault.Bridge.increment.refines` is **sorry-free** (`#print axioms`
+  = `propext / Classical.choice / Quot.sound`, no `sorryAx`).
+- **qedsvm pin** — `v0.6.0 → v0.7.0` (#133) → `v0.8.0` (this release, ships #48's
+  `CodecRead.lean`), in `lean_solana/lakefile.lean` + both manifests.
+
+Boundary (still axiomatized / `sorry`, by design): the abort path (`.rejects`,
+gated on qedsvm#40), `decode_encode` (codec round-trip), and any handler shape
+beyond single-field constant-increment. Design: `docs/design/qedsvm-discharge.md`,
+`docs/design/a2b-handoff.md`.
+
+### 2. Codegen + lint follow-ups
+
+- `lean_gen_mir.rs` split into a per-concern directory module (#122); `anchor_adapt.rs`
+  likewise (#120) — continues the v3.0-prep monolith breakup.
+- Per-arm ADT branch rendering on the Lean side (#121) — unparks the #66 Lean follow-up.
+- `check`: exclude import-dependency subtrees from the multi-file sibling sweep
+  (#119, fixes #100).
+- Dep bump `quinn-proto 0.11.14 → 0.11.15` (RUSTSEC-2026-0185).
+
+## New CLI
+
+- `qedgen descriptor` / `qedgen discharge` — the producer + driver of the seam
+  (experimental). Documented in [`references/cli.md`](../../references/cli.md#discharge-experimental--the-qedgen--qedsvm-seam).
+
+## Compatibility notes
+
+- qedsvm pin moves to **v0.8.0**. Programs whose `formal_verification/` vendors an
+  older qedsvm are unaffected (examples pin their own version); only the top-level
+  `lean_solana` / `lean_solana_mathlib` packages bump.
+- `descriptor` / `discharge` are additive and experimental — no change to existing
+  commands or generated output beyond the version-tag re-stamp.
+
+## Gates (RELEASING.md)
+
+- Version bumped in `Cargo.toml` + `package.json`; `check-version-consistency.sh` clean (2.37.0).
+- Version-pinned artifacts re-stamped (`UPDATE_SNAPSHOTS codegen_snapshot` + `qedgen check --regen-drift --write`); diff is **tag-line-only** across the 6 snapshots + 8 example `Cargo.toml`.
+- `cargo fmt --check` ✅ · `cargo clippy -- -D warnings` ✅ · `cargo test` ✅ (1022+ unit/integration; mir/kani/codegen/proptest snapshot suites green).
+- `check-readme-drift.sh` ✅ (21 commands) · `qedgen check --regen-drift` clean · `qedgen check --frozen` clean (no stale locks).
+- Zero unintended `sorry` in generated example proofs (the only matches are codegen-helper occurrences in the vendored support lib — `mkSorryTheorem`, Bridge DSL — identical to v2.36.0).
+- Supply-chain (`cargo audit` / `cargo deny`) green on the merged seam PRs; deps unchanged by the version bump (CI re-runs on the release PR).
+- Example `lake build` (`check-lake-build.sh`) unchanged from v2.36.0 — the examples are independent of the top-level `lean_solana` bump (their `formal_verification/` vendors its own pinned qedsvm); CI gate re-runs on the release PR.

--- a/examples/rust/cross-program-vault/programs/Cargo.toml
+++ b/examples/rust/cross-program-vault/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/examples/rust/lending/Cargo.toml
+++ b/examples/rust/lending/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/examples/rust/multisig/Cargo.toml
+++ b/examples/rust/multisig/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.36.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
 
 [workspace]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.36.0",
+  "version": "2.37.0",
   "description": "Agent skill for spec-driven verification and audit of Solana programs \u2014 .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",

--- a/references/cli.md
+++ b/references/cli.md
@@ -774,6 +774,54 @@ $QEDGEN check-upgrade --list-rules
 | `--list-rules` | bool | false | Print the catalog of R-rules applied and exit |
 | `--json` | bool | false | Machine-readable output |
 
+## Discharge (experimental — the qedgen ↔ qedsvm seam)
+
+Hands a name-level refinement obligation to qedsvm's `qedlift`, which proves it
+against the decoded program bytes (field offsets resolved from the IDL on the
+qedsvm side). Today's scope is a single-field constant-increment handler
+(`field += <int literal>`); the bundled CPI-callee `ensures` and the sBPF bridge
+are otherwise axiomatized against a `binary_hash` pin. See
+[`docs/design/qedsvm-discharge.md`](../docs/design/qedsvm-discharge.md).
+
+### `descriptor`
+Emit the name-level refinement descriptor (JSON, to stdout) — the producer half
+of the seam. Carries only semantics (which named field a handler mutates, by how
+much); offsets are resolved IDL-side. Schema: qedsvm `docs/REFINEMENT_DESCRIPTOR.md`.
+
+```bash
+$QEDGEN descriptor --spec vault.qedspec --handler increment
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--spec` | Path | required | Path to the `.qedspec` |
+| `--handler` | String | required | Handler to inspect (single-field `+= <int literal>` effect) |
+| `--account` | String | first account type / program name | Account name for the descriptor — use the IDL account name so qedsvm resolves offsets |
+
+### `discharge`
+The one-command driver over the seam: build the descriptor from the `.qedspec`,
+then discharge it against the compiled `.so` via a built `qedlift`. Reports
+whether the handler's effect is proven against the bytes. No meaning crosses the
+boundary — `discharge` reads only qedlift's exit status and whether it emitted a
+sorry-free proof.
+
+```bash
+$QEDGEN discharge --spec vault.qedspec --handler increment \
+  --so vault.so --idl vault.codama.json --qedlift /path/to/qedlift \
+  --out-dir formal_verification/discharge
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--spec` | Path | required | Path to the `.qedspec` |
+| `--handler` | String | required | Handler to discharge (single-field `+= <int literal>` effect) |
+| `--account` | String | first account type / program name | Account name — use the IDL account name so qedlift resolves offsets |
+| `--so` | Path | required | Compiled program to discharge against |
+| `--idl` | Path | required | Codama IDL (`.json`) supplying the account shape (offsets) |
+| `--qedlift` | Path | required | Built qedsvm `qedlift` binary (built with `--features qedrecover`) |
+| `--module` | String | `<Account><Handler>` | Lean module name for the emitted proof |
+| `--out-dir` | Path | temp dir (artifacts discarded) | Persist `<Module>TracedLifted.lean` + `<Module>Refinement.lean` into this directory |
+
 ## Utility
 
 ### `consolidate`


### PR DESCRIPTION
Cuts **v2.37.0**. Bundles everything since v2.36.0 (#119–#134); headline is the **qedsvm discharge seam** — the spec→byte-level proof chain now runs end to end and the generated sBPF-bridge `.refines` is sorry-free for the first handler shape.

Full notes: [`docs/prds/RELEASE-v2.37.0.md`](docs/prds/RELEASE-v2.37.0.md).

## Highlights

- **Discharge seam (Slice A)** — `qedgen descriptor` (producer) + `qedgen discharge` (driver) over the qedgen↔qedsvm boundary; A1 ELF cache (#130); A2a discharge persist (#132); A2b Bridge↔qedlift adapter (#134). Generated `Vault.Bridge.increment.refines` is **sorry-free** (`#print axioms` = `propext / Classical.choice / Quot.sound`) for single-field constant-increment handlers, via qedsvm **v0.8.0**'s `CodecRead.lean` (#48). Boundary still axiomatized: `.rejects` (qedsvm#40), `decode_encode`, non-increment shapes.
- **Follow-ups** — `lean_gen_mir` + `anchor_adapt` dir-module splits (#120/#122); per-arm ADT branch Lean rendering (#121, #66); import-subtree sibling-sweep fix (#119, #100); `quinn-proto` RUSTSEC-2026-0185 bump.

## New CLI

`qedgen descriptor` / `qedgen discharge` (experimental) — documented in `references/cli.md`.

## Release-prep (RELEASING.md)

- Version 2.36.0 → 2.37.0 (`Cargo.toml` + `package.json` + `Cargo.lock`); consistency check clean.
- Version-pinned artifacts re-stamped — 6 codegen snapshots + 8 example `Cargo.toml`, **diff tag-line-only**.
- `references/cli.md` gains `descriptor`/`discharge` sections (step-9 drift).
- Gates green locally: fmt, clippy `-D warnings`, `cargo test` (1022+ incl. all snapshot suites), readme-drift (21 cmds), regen-drift clean, frozen (no stale locks), zero unintended example `sorry`. Supply-chain + example `lake build` re-run by CI (unchanged from v2.36.0).

Tag `v2.37.0` after merge.