### PR TITLE
fix(crucible): brownfield Anchor fuzz fires end-to-end; auditor preflight

### DIFF
--- a/crates/qedgen/src/codegen/crucible_gen.rs
+++ b/crates/qedgen/src/codegen/crucible_gen.rs
@@ -596,12 +596,14 @@ fn emit_action_fn(
     op: &ParsedHandler,
     mode: InvariantMode,
 ) -> Result<()> {
-    out.push_str(&format!(
-        "    /// {} → action variant. Bodies for non-trivial\n",
-        op.name
-    ));
-    out.push_str("    /// `accounts::X { ... }` literals fall through as todo!() — fill\n");
-    out.push_str("    /// via `qedgen codegen --fill` once that hook lands for Crucible.\n");
+    out.push_str(&format!("    /// {} → action variant.\n", op.name));
+    if op.accounts.is_empty() {
+        // No IDL/spec accounts to render → the `.accounts(...)` literal is
+        // left as a `todo!()` for the agent to fill.
+        out.push_str("    /// No account list resolved — the `accounts::X { ... }` literal\n");
+        out.push_str("    /// falls through as todo!() for the agent to fill (drop an IDL\n");
+        out.push_str("    /// at the project root to auto-fill it).\n");
+    }
 
     // Pubkey-typed args are NOT exposed as action params: #[fuzz_fixture]
     // can't derive Arbitrary for Pubkey (no Arbitrary on its `Address`

--- a/crates/qedgen/src/probe/crucible_brownfield.rs
+++ b/crates/qedgen/src/probe/crucible_brownfield.rs
@@ -105,13 +105,25 @@ fn empty_handler(name: String) -> ParsedHandler {
 }
 
 fn synthesize_anchor_family(project_root: &Path) -> Result<BrownfieldSynthesis> {
+    // Prefer a committed / `anchor build` IDL: it carries per-account
+    // `signer`/`writable` flags, so the emitter fills real `accounts::X
+    // { ... }` literals (no `todo!()`) and the §S1.2 lamport-inflation
+    // guard gets a tracked signer set to check. Without an IDL we fall back
+    // to a source scan that yields handler names only (empty accounts →
+    // agent-fill `todo!()`), preserving the v2.21 behaviour.
+    if let Some(idl_text) = discover_pinocchio_idl(project_root)? {
+        if !handlers_with_args_from_idl(&idl_text).is_empty() {
+            return synthesize_from_idl(project_root, idl_text);
+        }
+    }
     let program_name = program_name_from_root(project_root)?;
     let handlers = scan_anchor_handlers(project_root)?;
     if handlers.is_empty() {
         bail!(
-            "No `pub fn <name>(ctx: Context<X>, ...)` handlers found under {}. \
-             Brownfield mode needs at least one Anchor handler to fuzz; \
-             confirm `--root` points at the program crate (e.g. `programs/my_prog/`).",
+            "No `pub fn <name>(ctx: Context<X>, ...)` handlers found under {}, \
+             and no IDL on disk. Brownfield mode needs at least one Anchor \
+             handler to fuzz; confirm `--root` points at the program crate \
+             (e.g. `programs/my_prog/`), or drop an `idl.json` at the root.",
             project_root.display()
         );
     }
@@ -123,6 +135,42 @@ fn synthesize_anchor_family(project_root: &Path) -> Result<BrownfieldSynthesis> 
     Ok(BrownfieldSynthesis {
         spec,
         idl_json: None,
+    })
+}
+
+/// Build a brownfield [`BrownfieldSynthesis`] from a parsed IDL — handler
+/// args + per-account signer/writable/address flags. Shared by the Anchor
+/// (IDL-present) and Pinocchio paths.
+fn synthesize_from_idl(project_root: &Path, idl_text: String) -> Result<BrownfieldSynthesis> {
+    let handlers_with_args = handlers_with_args_from_idl(&idl_text);
+    let accounts_per_handler = accounts_per_handler_from_idl(&idl_text);
+    if handlers_with_args.is_empty() {
+        bail!(
+            "IDL at {} parsed but has no `instructions[]` entries. \
+             Brownfield fuzz needs at least one instruction to dispatch.",
+            project_root.display()
+        );
+    }
+    let program_name = program_name_from_idl(&idl_text)
+        .or_else(|| program_name_from_root(project_root).ok())
+        .unwrap_or_else(|| "program".to_string());
+    let handlers = handlers_with_args
+        .into_iter()
+        .map(|(name, args)| {
+            let mut h = empty_handler(name.clone());
+            h.takes_params = args;
+            h.accounts = accounts_per_handler.get(&name).cloned().unwrap_or_default();
+            h
+        })
+        .collect();
+    let spec = ParsedSpec {
+        program_name,
+        handlers,
+        ..Default::default()
+    };
+    Ok(BrownfieldSynthesis {
+        spec,
+        idl_json: Some(idl_text),
     })
 }
 
@@ -147,42 +195,11 @@ fn synthesize_pinocchio(project_root: &Path) -> Result<BrownfieldSynthesis> {
         )
     })?;
 
-    let handlers_with_args = handlers_with_args_from_idl(&idl_text);
-    let accounts_per_handler = accounts_per_handler_from_idl(&idl_text);
-    if handlers_with_args.is_empty() {
-        bail!(
-            "Codama IDL at {} parsed but has no `instructions[]` entries. \
-             Brownfield fuzz needs at least one instruction to dispatch.",
-            project_root.display()
-        );
-    }
-    // Program name must come from the IDL when present: declare_fuzz_program!
-    // derives the generated module name from the IDL's `program.name`
-    // (Codama IR) or `metadata.name` (Anchor 0.30), and the harness's
-    // `use {prog}::instruction;` must line up with that — not the Cargo
-    // workspace's leaf dir. Cargo / leaf-dir fallback is rare (Anchor IDLs
-    // always carry a name; Codama IR carries `program.name`).
-    let program_name = program_name_from_idl(&idl_text)
-        .or_else(|| program_name_from_root(project_root).ok())
-        .unwrap_or_else(|| "program".to_string());
-    let handlers = handlers_with_args
-        .into_iter()
-        .map(|(name, args)| {
-            let mut h = empty_handler(name.clone());
-            h.takes_params = args;
-            h.accounts = accounts_per_handler.get(&name).cloned().unwrap_or_default();
-            h
-        })
-        .collect();
-    let spec = ParsedSpec {
-        program_name,
-        handlers,
-        ..Default::default()
-    };
-    Ok(BrownfieldSynthesis {
-        spec,
-        idl_json: Some(idl_text),
-    })
+    // Program name comes from the IDL inside `synthesize_from_idl`:
+    // declare_fuzz_program! derives the generated module name from the
+    // IDL's `program.name` (Codama IR) or `metadata.name` (Anchor 0.30),
+    // and the harness's `use {prog}::instruction;` must line up with that.
+    synthesize_from_idl(project_root, idl_text)
 }
 
 /// Program name from an Anchor 0.30 IDL (`metadata.name`) or Codama IR
@@ -349,9 +366,16 @@ fn accounts_per_handler_from_idl(
             .iter()
             .filter_map(|a| {
                 let name = a.get("name").and_then(|n| n.as_str())?.to_string();
-                let is_signer = a.get("isSigner").and_then(|b| b.as_bool()).unwrap_or(false);
+                // Anchor ≥0.30 IDLs use `signer`/`writable`; legacy Anchor +
+                // Codama IRs use `isSigner`/`isWritable`. Accept either.
+                let is_signer = a
+                    .get("signer")
+                    .or_else(|| a.get("isSigner"))
+                    .and_then(|b| b.as_bool())
+                    .unwrap_or(false);
                 let is_writable = a
-                    .get("isWritable")
+                    .get("writable")
+                    .or_else(|| a.get("isWritable"))
                     .and_then(|b| b.as_bool())
                     .unwrap_or(false);
                 let default = a.get("defaultValue");
@@ -368,7 +392,14 @@ fn accounts_per_handler_from_idl(
                         (pk, None, true)
                     }
                     Some("pdaValueNode") => (None, Some(vec![]), false),
-                    _ => (None, None, false),
+                    // Anchor ≥0.30 emits a fixed-address account (e.g.
+                    // `Program<System>`) as a top-level `"address"` field
+                    // rather than a `defaultValue` node — treat it the same
+                    // as a publicKeyValueNode so the emitter auto-fills it.
+                    _ => match a.get("address").and_then(|k| k.as_str()) {
+                        Some(addr) => (Some(addr.to_string()), None, true),
+                        None => (None, None, false),
+                    },
                 };
                 Some(ParsedHandlerAccount {
                     name,

--- a/crates/qedgen/src/probe/crucible_probe.rs
+++ b/crates/qedgen/src/probe/crucible_probe.rs
@@ -333,21 +333,36 @@ fn stable_finding_id(
 // IO — shells crucible / cargo / fs
 // ============================================================================
 
-/// Symlink `target/idl/<prog>.json` into `<harness>/idls/<prog>.json` when
-/// present; `<prog>` is the harness dir leaf (= spec's snake-case
-/// program_name). Idempotent — a pre-existing IDL file is left alone.
+/// Wire the program IDL into `<harness>/idls/<prog>.json` when present;
+/// `<prog>` is the harness dir leaf (= spec's snake-case program_name).
+/// Idempotent — a pre-existing IDL file is left alone.
+///
+/// Source lookup (first match wins):
+/// 1. `<root>/target/idl/<prog>.json` — `anchor build` output.
+/// 2. `<root>/idl.json` — committed Codama-convention IDL.
+/// 3. `<root>/idl/<prog>.json` — committed Codama default output dir.
+///
+/// (2) and (3) let a brownfield crate ship a *static* IDL and skip the
+/// `anchor build` round-trip entirely — the same committed-IDL
+/// convention the Pinocchio path already honours
+/// (`crucible_brownfield::discover_pinocchio_idl`). Without it the Anchor
+/// path is hard-tied to the ephemeral, un-committable `target/idl/`.
 pub fn discover_idl(harness_dir: &Path, project_root: &Path) -> Result<()> {
     let prog = harness_dir
         .file_name()
         .and_then(|s| s.to_str())
         .ok_or_else(|| anyhow::anyhow!("harness_dir has no leaf name"))?;
-    let target_idl = project_root
-        .join("target")
-        .join("idl")
-        .join(format!("{prog}.json"));
-    if !target_idl.exists() {
+    let candidates = [
+        project_root
+            .join("target")
+            .join("idl")
+            .join(format!("{prog}.json")),
+        project_root.join("idl.json"),
+        project_root.join("idl").join(format!("{prog}.json")),
+    ];
+    let Some(src_idl) = candidates.iter().find(|p| p.exists()) else {
         return Ok(()); // nothing to discover; user wires manually
-    }
+    };
     let dest_dir = harness_dir.join("idls");
     std::fs::create_dir_all(&dest_dir)?;
     let dest = dest_dir.join(format!("{prog}.json"));
@@ -356,11 +371,11 @@ pub fn discover_idl(harness_dir: &Path, project_root: &Path) -> Result<()> {
     }
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(&target_idl, &dest)?;
+        std::os::unix::fs::symlink(src_idl, &dest)?;
     }
     #[cfg(not(unix))]
     {
-        std::fs::copy(&target_idl, &dest)?;
+        std::fs::copy(src_idl, &dest)?;
     }
     Ok(())
 }
@@ -735,6 +750,44 @@ mod tests {
         // The dest should resolve to the same content as the source.
         let read = std::fs::read_to_string(&dest).unwrap();
         assert!(read.contains("\"version\""));
+    }
+
+    #[test]
+    fn discover_idl_falls_back_to_committed_root_idl() {
+        // No `target/idl/` (no `anchor build`); a committed `<root>/idl.json`
+        // is wired in instead — the brownfield no-build path.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let harness = tmp.path().join("fuzz").join("myprog");
+        std::fs::create_dir_all(&harness).unwrap();
+        std::fs::write(tmp.path().join("idl.json"), r#"{"version":"0.30"}"#).unwrap();
+
+        discover_idl(&harness, tmp.path()).expect("discover");
+
+        let dest = harness.join("idls").join("myprog.json");
+        assert!(dest.exists(), "committed idl.json should be discovered");
+        let read = std::fs::read_to_string(&dest).unwrap();
+        assert!(read.contains("\"version\""));
+    }
+
+    #[test]
+    fn discover_idl_prefers_target_over_committed() {
+        // `anchor build` output wins over a committed copy when both exist.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let harness = tmp.path().join("fuzz").join("myprog");
+        std::fs::create_dir_all(&harness).unwrap();
+        let idl_dir = tmp.path().join("target").join("idl");
+        std::fs::create_dir_all(&idl_dir).unwrap();
+        std::fs::write(idl_dir.join("myprog.json"), r#"{"src":"target"}"#).unwrap();
+        std::fs::write(tmp.path().join("idl.json"), r#"{"src":"committed"}"#).unwrap();
+
+        discover_idl(&harness, tmp.path()).expect("discover");
+
+        let dest = harness.join("idls").join("myprog.json");
+        let read = std::fs::read_to_string(&dest).unwrap();
+        assert!(
+            read.contains("target"),
+            "target/idl should win over committed"
+        );
     }
 
     #[test]

--- a/crates/qedgen/tests/crucible_brownfield_smoke.rs
+++ b/crates/qedgen/tests/crucible_brownfield_smoke.rs
@@ -212,14 +212,11 @@ fn fixture_buggy_anchor_drives_brownfield_emit() {
     assert!(body.contains("pub fn action_maybe"));
     assert!(body.contains("pub fn action_drain"));
     assert!(body.contains("Mode: PROTOCOL"));
-    // v2.21 §S1.2 — protocol-mode harness must carry the lamport-
-    // conservation helpers and wire the inflation check around every
-    // action_*.send(). buggy_anchor has no `auth X` declarations
-    // (handlers all take `Context<Empty>` with no signer constraint), so
-    // collect_signer_idents returns an empty set and the per-action
-    // wrap is suppressed — but the helpers are still emitted, ready for
-    // the moment the agent fills the `.accounts(...)` literal and the
-    // generated harness picks up signer pubkeys from the fixture.
+    // v2.21 §S1.2 — protocol-mode harness carries the lamport-conservation
+    // helpers AND, now that buggy_anchor ships a committed idl.json, the
+    // IDL-driven path fills the `accounts::*` literals and wires the
+    // per-action inflation check. `drain`'s `source`/`target` are signers,
+    // so they form the tracked set the guard snapshots and asserts on.
     assert!(
         body.contains("fn assert_no_signer_inflation"),
         "protocol-mode brownfield harness must emit assert_no_signer_inflation helper"
@@ -227,6 +224,21 @@ fn fixture_buggy_anchor_drives_brownfield_emit() {
     assert!(
         body.contains("fn snapshot_lamports"),
         "protocol-mode brownfield harness must emit snapshot_lamports helper"
+    );
+    // IDL-driven account discovery: `drain` auto-fills its accounts literal
+    // (no `todo!()`) and the inflation guard wraps the send — this is what
+    // makes the fixture fire a real finding under `--fuzz <budget>`.
+    assert!(
+        body.contains("accounts(accounts::Drain {"),
+        "drain's accounts literal should be auto-filled from the IDL, not todo!()"
+    );
+    assert!(
+        body.contains("assert_no_signer_inflation(&self.ctx"),
+        "drain should wire the §S1.2 inflation check around .send()"
+    );
+    assert!(
+        !body.contains("todo!("),
+        "IDL-driven brownfield emit should leave no todo!() in the action bodies"
     );
 }
 

--- a/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/README.md
+++ b/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/README.md
@@ -1,78 +1,99 @@
-# v2.21 Slice 1 + §S1.2 — Crucible brownfield regression fixture
+# v2.21 §S1.2 — Crucible brownfield regression fixture
 
-This fixture pins two v2.21 PRD exit criteria: the §"Slice 1" crash-
-first bear-hug (intrinsic panic / unwrap-on-None detection on a
-brownfield Anchor program without a `.qedspec`) AND the §S1.2 lamport-
-conservation companion (protocol-invariant guard around every
-`.send()`).
+This fixture pins the v2.21 §S1.2 exit criterion: the **lamport-
+conservation protocol invariant** (`assert_no_signer_inflation`) firing on
+a brownfield Anchor program **without a `.qedspec`**, end to end —
+`cargo build-sbf` → `qedgen probe --fuzz` → a fired `Finding`.
+
+It also documents, by counter-example, what crash-first does **not**
+catch — see `run` / `maybe` below.
 
 ## What's in `buggy_anchor/`
 
-A minimal Anchor program with three deliberate bugs:
+A minimal Anchor program with three handlers:
 
-1. **`run` handler** — divides a constant by zero, panicking on the
-   first invocation. Demonstrates Crucible's intrinsic panic detector
-   firing on a brownfield protocol-mode harness with an empty
-   `invariant_test()` body.
+1. **`drain` — FIRES.** Transfers half of `source`'s lamports to an
+   arbitrary `target` (a System CPI transfer) with no authorization
+   policy. Both accounts are signers, so both are in the harness's tracked
+   set; `target` *gains* lamports, tripping the §S1.2
+   `assert_no_signer_inflation` guard. The fuzzer surfaces it as a HIGH
+   `invariant_violation` on `drain`, with no spec annotation.
 
-2. **`maybe` handler** — calls `.unwrap()` on a `None`-yielding helper.
-   Demonstrates the same intrinsic detector via the panic that
-   `Option::unwrap` raises on `None`.
+2. **`run` — does NOT fire.** Divides by a runtime zero. An in-program
+   **SBF fault** surfaces as a transaction *error*, not a host-process
+   panic, so Crucible's intrinsic crash detector never sees it.
 
-3. **`drain` handler** — sweeps all `source` lamports into `target`
-   with no authority check. When the fuzzer happens to pick a tracked
-   signer pubkey for `target`, qedgen's v2.21 §S1.2 lamport-inflation
-   guard (`assert_no_signer_inflation`) fires. Surfaces the drain
-   shape without any spec annotation.
+3. **`maybe` — does NOT fire.** `Option::unwrap()` on `None`. Same story:
+   a program-side abort, not a host crash.
 
-`run` and `maybe` are reachable on **every** invocation — a working
-Crucible run finds them on iteration 1. `drain` requires the fuzzer to
-land on a `target` that overlaps the tracked signer set; coverage-
-guided search reaches that case within a typical budget.
+`run` / `maybe` are kept deliberately as controls. Crucible's "crash-
+first" detector catches host-process panics + `fuzz_assert!` invariant
+violations (like the §S1.2 guard) — **not** faults inside the sandboxed
+`.so`. The drain path is the one that fires because it trips a
+*protocol invariant the harness checks in-process*, not a program panic.
+
+> Note on `run`'s divisor: it's runtime-derived (`stub.lamports() -
+> stub.lamports()`) rather than `let zero = 0`. rustc's
+> `unconditional_panic` lint const-folds the literal form into a *compile*
+> error, so the crate would never build and `cargo build-sbf` couldn't
+> emit a `.so`.
 
 ## Running the harness
 
-Out of the box this fixture is **not** part of the cargo workspace —
-the `Cargo.toml` would otherwise drag `anchor-lang` and the Solana
-toolchain into every `cargo build` of the qedgen workspace. To run
-the live demo:
+This fixture is a standalone single crate (deliberately **not** a member
+of the qedgen cargo workspace — its `Cargo.toml` would otherwise drag
+`anchor-lang` + the Solana toolchain into every `cargo build`). It ships a
+committed **`idl.json`**, so there's no `anchor build` round-trip — only
+the program `.so` is built locally.
 
 ```bash
 # 1. Copy the fixture out of the repo so it's a standalone crate.
 cp -r crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor /tmp/
+cd /tmp/buggy_anchor
 
-# 2. Generate the brownfield Crucible harness (no .qedspec).
-qedgen probe --fuzz 0 --root /tmp/buggy_anchor
+# 2. Build the program .so. No Anchor workspace needed — the committed
+#    idl.json supplies the schema the harness macro consumes.
+cargo build-sbf            # → target/deploy/buggy_anchor.so
 
-# 3. Confirm the harness was emitted with the PROTOCOL banner.
-head -20 /tmp/buggy_anchor/.qed/fuzz/buggy_anchor/src/main.rs
-
-# 4. Build the program (Anchor) so target/idl/buggy_anchor.json exists,
-#    then run the fuzz with a 60-second budget. qedgen symlinks the
-#    IDL into the harness automatically.
-cd /tmp/buggy_anchor && anchor build
-qedgen probe --fuzz 60 --root /tmp/buggy_anchor
+# 3. Fuzz (needs `crucible` on PATH). qedgen emits the brownfield harness,
+#    discovers the committed idl.json (auto-filling the `accounts::*`
+#    literals and the §S1.2 tracked-signer guard — no agent-fill), builds
+#    it, and runs Crucible.
+qedgen probe --fuzz 30 --root /tmp/buggy_anchor
 ```
 
-Expected output: at least one `Finding` with `category_tag =
-"runtime_panic"` (action `run` divide-by-zero) and ideally a second
-with `category_tag = "runtime_abort"` or `"runtime_panic"` for `maybe`.
+Expected output: one `Finding` with `category_tag =
+"invariant_violation"`, `severity = "high"`, `handler = "drain"`, and an
+`investigation_hint` pointing at `crucible show … --replay`. `run` /
+`maybe` execute and fail as transaction errors, producing **no** finding
+(by design — see above).
+
+### Why a committed IDL + `cargo build-sbf` (not `anchor build`)
+
+`anchor build` requires an Anchor *workspace* (`Anchor.toml` +
+`programs/<name>/` + `overflow-checks`), produces artifacts under the
+*workspace* `target/`, and refuses a bare crate. `qedgen probe --fuzz`
+wants a single-crate `--root` whose `src/`, IDL, and `.so` all sit
+together. Committing the IDL and building the `.so` with `cargo build-sbf`
+collapses that mismatch — the same committed-IDL convention the
+`buggy_pinocchio` fixture uses. `qedgen`'s `discover_idl` falls back to
+`<root>/idl.json` precisely for this case.
 
 ## What this fixture validates
 
 - **CLI gate lift** — `qedgen probe --fuzz 0 --root <path>` exits 0
   without a `.qedspec`.
-- **Brownfield handler discovery** — both `run` and `maybe` appear as
-  `action_*` stubs in the emitted harness.
+- **Brownfield handler + account discovery** — `run` / `maybe` / `drain`
+  appear as `action_*`, and the IDL-driven path fills their
+  `accounts::*` literals (and the drain signer set) — no `todo!()`.
 - **Protocol-mode header** — the emitted `main.rs` carries the
   `Mode: PROTOCOL (no spec)` banner.
-- **Empty `invariant_test()` body** — no spec-derived `fuzz_assert!`
-  calls; crashes fire only through Crucible's intrinsic detector.
-- **`.qed/fuzz/<prog>/` location** — the emitted harness lives under
-  the user's `.qed/` ephemeral namespace, not in the program crate's
-  `src/`.
+- **§S1.2 guard wiring** — `assert_no_signer_inflation` +
+  `snapshot_lamports` helpers are emitted and the per-action inflation
+  check wraps every `.send()` once a tracked signer set exists.
+- **`.qed/fuzz/<prog>/` location** — the emitted harness lives under the
+  user's `.qed/` ephemeral namespace, not in the program crate's `src/`.
 
-The first four are covered by the unit + integration tests in
-`crates/qedgen/tests/crucible_brownfield_smoke.rs`. The fifth — the
-live fuzz finding the bug — needs Crucible on PATH; this README
-documents the manual run.
+The emission criteria are covered by the unit + integration tests in
+`crates/qedgen/tests/crucible_brownfield_smoke.rs`. The live fuzz finding
+the bug needs `crucible` on PATH; this README documents that manual run.

--- a/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/Cargo.toml
+++ b/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/Cargo.toml
@@ -20,3 +20,8 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-lang = "0.30"
 
 [workspace]
+
+# `anchor build` (Anchor 1.x) refuses to build without this; `cargo
+# build-sbf` doesn't require it but we keep it so both build paths agree.
+[profile.release]
+overflow-checks = true

--- a/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/idl.json
+++ b/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/idl.json
@@ -1,0 +1,115 @@
+{
+  "address": "6bRRkRXokuEQs6sctPhSGjqEnEkPgbda16N1aajwH7bp",
+  "metadata": {
+    "name": "buggy_anchor",
+    "version": "0.1.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [
+    {
+      "name": "drain",
+      "docs": [
+        "Sweeps half of `source`'s lamports into `target` with no check that",
+        "`target` is an authorized recipient. Implemented as a System CPI",
+        "transfer (so it works against the harness's system-owned, funded",
+        "accounts). Because `target` is a tracked signer that GAINS lamports,",
+        "the v2.21 §S1.2 lamport-inflation guard fires — surfacing the drain",
+        "shape with no spec annotation."
+      ],
+      "discriminator": [
+        239,
+        19,
+        30,
+        120,
+        111,
+        252,
+        245,
+        74
+      ],
+      "accounts": [
+        {
+          "name": "source",
+          "docs": [
+            "Funds the transfer; signs the CPI."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "target",
+          "docs": [
+            "Arbitrary recipient — no authorization policy (the bug). A signer",
+            "so the harness tracks it; gaining lamports trips the §S1.2 guard."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "maybe",
+      "docs": [
+        "Unwraps a `None`. Does NOT fire under crash-first — program-side",
+        "abort, not a host panic."
+      ],
+      "discriminator": [
+        126,
+        159,
+        169,
+        102,
+        233,
+        21,
+        251,
+        166
+      ],
+      "accounts": [
+        {
+          "name": "stub",
+          "docs": [
+            "Stand-in unchecked account; the bug fires before any account",
+            "access matters so the contents don't matter."
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "run",
+      "docs": [
+        "Divides by a runtime zero. Does NOT fire under crash-first (see",
+        "the module doc): the SBF fault is a transaction error, not a host",
+        "panic.",
+        "",
+        "The divisor is runtime-derived (`stub.lamports() - stub.lamports()`)",
+        "rather than `let zero = 0`: rustc's `unconditional_panic` lint",
+        "const-folds the literal form into a *compile* error, so the program",
+        "would never build and `cargo build-sbf` couldn't emit the `.so`."
+      ],
+      "discriminator": [
+        203,
+        27,
+        228,
+        218,
+        208,
+        69,
+        35,
+        84
+      ],
+      "accounts": [
+        {
+          "name": "stub",
+          "docs": [
+            "Stand-in unchecked account; the bug fires before any account",
+            "access matters so the contents don't matter."
+          ]
+        }
+      ],
+      "args": []
+    }
+  ]
+}

--- a/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/src/lib.rs
+++ b/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/src/lib.rs
@@ -1,35 +1,51 @@
-//! Deliberately buggy Anchor program used by the v2.21 Slice 1
-//! Crucible-crash-first + Slice §S1.2 lamport-conservation regression
-//! fixtures. See ../README.md.
+//! Deliberately buggy Anchor program used by the v2.21 Slice §S1.2
+//! Crucible lamport-conservation regression fixture. See ../README.md.
 //!
-//! Three handlers, each demonstrating a different protocol-invariant
-//! violation that Crucible's brownfield harness surfaces without a
-//! `.qedspec` ever being written:
+//! Three handlers, chosen to demonstrate BOTH what Crucible's brownfield
+//! crash-first harness catches and what it does *not*:
 //!
-//!   * `run`   — divide-by-zero panic (intrinsic Crucible detector).
-//!   * `maybe` — `Option::unwrap` on `None` (same intrinsic detector).
-//!   * `drain` — routes all `source` lamports into `target` with no
-//!               authority check, triggering the v2.21 §S1.2 lamport-
-//!               inflation guard when the fuzzer picks `target` as a
-//!               tracked signer.
+//!   * `drain`  — transfers `source`'s lamports to an arbitrary `target`
+//!                with no authorization policy. Both are signers, so both
+//!                are in the harness's tracked set; `target` GAINS lamports,
+//!                tripping the v2.21 §S1.2 `assert_no_signer_inflation`
+//!                guard. **This is the finding the fixture fires.**
+//!   * `run`    — divides by a runtime zero. **Does NOT fire**: an
+//!                in-program SBF fault surfaces as a transaction *error*,
+//!                not a host panic, so Crucible's intrinsic detector never
+//!                sees it. Kept as a control for the README's discussion.
+//!   * `maybe`  — `Option::unwrap` on `None`. Same story as `run`: a
+//!                program-side abort, not a host crash. Does NOT fire.
+//!
+//! The §S1.2 guard is a *protocol* invariant (lamport conservation), so it
+//! fires with no `.qedspec` — the brownfield value-add. The `run`/`maybe`
+//! controls document why "crash-first" alone can't catch in-program panics.
 
 use anchor_lang::prelude::*;
+use anchor_lang::system_program;
 
-declare_id!("11111111111111111111111111111111");
+declare_id!("6bRRkRXokuEQs6sctPhSGjqEnEkPgbda16N1aajwH7bp");
 
 #[program]
 pub mod buggy_anchor {
     use super::*;
 
-    /// Divides a constant by zero — fires `runtime_panic` on iteration 1.
+    /// Divides by a runtime zero. Does NOT fire under crash-first (see
+    /// the module doc): the SBF fault is a transaction error, not a host
+    /// panic.
+    ///
+    /// The divisor is runtime-derived (`stub.lamports() - stub.lamports()`)
+    /// rather than `let zero = 0`: rustc's `unconditional_panic` lint
+    /// const-folds the literal form into a *compile* error, so the program
+    /// would never build and `cargo build-sbf` couldn't emit the `.so`.
     pub fn run(ctx: Context<Empty>) -> Result<()> {
-        let _ = ctx;
-        let zero: u32 = 0;
+        let l = ctx.accounts.stub.lamports();
+        let zero: u32 = (l - l) as u32;
         let _ = 100u32 / zero;
         Ok(())
     }
 
-    /// Unwraps a `None` — fires `runtime_panic` on iteration 1.
+    /// Unwraps a `None`. Does NOT fire under crash-first — program-side
+    /// abort, not a host panic.
     pub fn maybe(ctx: Context<Empty>) -> Result<()> {
         let _ = ctx;
         let value: Option<u32> = None;
@@ -37,37 +53,43 @@ pub mod buggy_anchor {
         Ok(())
     }
 
-    /// Sweeps every lamport from `source` into `target` with no
-    /// authority check. When Crucible's fuzzer happens to pick a
-    /// tracked signer for `target`, the brownfield harness's
-    /// `assert_no_signer_inflation` guard fires — surfacing a drain
-    /// shape (lamports appeared on a signer from outside the tracked
-    /// set) without any spec annotation.
+    /// Sweeps half of `source`'s lamports into `target` with no check that
+    /// `target` is an authorized recipient. Implemented as a System CPI
+    /// transfer (so it works against the harness's system-owned, funded
+    /// accounts). Because `target` is a tracked signer that GAINS lamports,
+    /// the v2.21 §S1.2 lamport-inflation guard fires — surfacing the drain
+    /// shape with no spec annotation.
     pub fn drain(ctx: Context<DrainAccounts>) -> Result<()> {
-        let source = &ctx.accounts.source;
-        let target = &ctx.accounts.target;
-        let credit = source.lamports();
-        **source.try_borrow_mut_lamports()? = 0;
-        **target.try_borrow_mut_lamports()? =
-            target.lamports().checked_add(credit).unwrap();
-        Ok(())
+        let amount = ctx.accounts.source.to_account_info().lamports() / 2;
+        system_program::transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.to_account_info(),
+                system_program::Transfer {
+                    from: ctx.accounts.source.to_account_info(),
+                    to: ctx.accounts.target.to_account_info(),
+                },
+            ),
+            amount,
+        )
     }
 }
 
 #[derive(Accounts)]
 pub struct Empty<'info> {
     /// Stand-in unchecked account; the bug fires before any account
-    /// access happens so the contents don't matter.
+    /// access matters so the contents don't matter.
     /// CHECK: not validated; brownfield demo only.
     pub stub: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
 pub struct DrainAccounts<'info> {
-    /// CHECK: source PDA; no validation, deliberate drain shape.
+    /// Funds the transfer; signs the CPI.
     #[account(mut)]
-    pub source: AccountInfo<'info>,
-    /// CHECK: target signer; no validation, deliberate drain shape.
+    pub source: Signer<'info>,
+    /// Arbitrary recipient — no authorization policy (the bug). A signer
+    /// so the harness tracks it; gaining lamports trips the §S1.2 guard.
     #[account(mut)]
-    pub target: AccountInfo<'info>,
+    pub target: Signer<'info>,
+    pub system_program: Program<'info, System>,
 }

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -154,6 +154,76 @@ Three outcomes per CRIT/HIGH:
 
 MEDIUM and below: a repro is encouraged but not required.
 
+## Preflight — environment + target readiness (run this first)
+
+Before Phase 1, run the **instant checks** (~2s: runtime, mode, tooling)
+and kick off the **compile gate in the background** (it dominates
+wall-clock on a real Solana program — dep-fetch + first build is
+minutes, not seconds, so never block on it). Report a single status line
+and proceed straight into Phase 1's read-driven work while the build
+runs. This is **non-blocking by design** (tactile tooling, no consent
+walls): report what's available, name what degrades, proceed. The audit's
+core path — read + hand-authored Mollusk repros — needs only `qedgen`,
+`cargo`, and a program that compiles; everything else widens coverage but
+is never a gate. The point is to convert *silent mid-run failures*
+("qedgen not found", "harness build failed", "fuzz lane never ran", "old
+qedgen missing a category") into one honest up-front line, so the user
+knows what coverage they're getting before they invest attention.
+
+**The one hard stop:** an sBPF / hand-written-assembly target (`.s`
+sources, no Rust handler source). Say so plainly and stop — see
+[When to use](#when-to-use). Don't run a thin audit that implies coverage
+it doesn't have.
+
+Run the checks together (they mirror the CLI's point-of-use dependency
+gates in `crates/qedgen/src/project/deps.rs`, surfaced all at once):
+
+```bash
+# --- Instant checks (~2s) ---
+find . -path ./target -prune -o -name '*.s' -print 2>/dev/null | head -1   # any hit → sBPF: STOP, redirect
+grep -lE 'anchor-lang|solana-program|pinocchio|quasar-lang' \
+  Cargo.toml */Cargo.toml programs/*/Cargo.toml 2>/dev/null                 # runtime detect
+test -f .qedspec && echo "mode: spec-aware" || echo "mode: spec-less (brownfield default)"
+qedgen --version || echo "MISSING qedgen — audit cannot run"               # NB: confirm this is recent;
+                                                                           # a stale on-PATH qedgen runs an
+                                                                           # older category catalog and
+                                                                           # silently under-reports.
+command -v crucible >/dev/null \
+  && echo "crucible: present" \
+  || echo "crucible: ABSENT — fast fuzz lane off; install: cargo install --git https://github.com/asymmetric-research/crucible crucible-fuzz-cli"
+cargo +nightly miri --version >/dev/null 2>&1 \
+  && echo "miri: present" \
+  || echo "miri: absent — Tier-2 UB repros skipped (Mollusk lane unaffected)"
+
+# --- Compile gate: background it, don't block (minutes on a real program) ---
+cargo check --quiet 2>&1 | tail -3 &    # repros can only build/fire once this is green;
+                                        # proceed with read-driven Phase 1 meanwhile.
+```
+
+Then emit **one** status line and proceed — e.g.:
+
+> Preflight: Anchor target, compiles clean. Spec-less mode. Repro lanes:
+> Mollusk ✓, Crucible ✗ (fuzz fast-path off — `cargo install … crucible-fuzz-cli`
+> to enable), Miri ✗. Entering Phase 1.
+
+What each gate affects — read this as the time-to-win impact, not a
+checklist to satisfy:
+
+| Check | If absent | Effect |
+|-------|-----------|--------|
+| `qedgen` on PATH | **hard blocker** | No probe work-list, no `verify --probe-repros`. Stop and print the install line. A *stale* qedgen is worse than missing — it runs silently with an older category catalog and under-reports; confirm the version is current. |
+| Program compiles | **hard blocker for fired repros** | Findings can only stay structural (nothing to build a repro against). Surface the build error; offer to continue read-only with all findings marked inconclusive. |
+| `crucible` on PATH | fast auto-reproducer lane off | Lose the ~5–10 min zero-authoring crash path (`qedgen probe --fuzz`); fall back to agent-authored Mollusk repros — slower and model-gated. Often the difference between a fast first win and a slow one. |
+| `qedgen-sandbox` resolvable | Mollusk repros can't build | CRIT/HIGH stay inconclusive. Verified when the first repro builds; if it fails, say so rather than reporting a silent drop. |
+| `cargo +nightly miri` | Tier-2 UB repros skipped | Mollusk (Tier-1) lane unaffected; only `unsafe`-touching findings lose their repro lane. |
+| `.qedspec` present | — (not a gate) | Spec-aware mode (faster, more precise). Absent → spec-less brownfield default. |
+
+Set the expectation in the same breath: recall is **probabilistic**, and
+a cold run can come up dry — that's Phase 2's cue ("Phase 1 didn't fire;
+give me intent and I'll deepen"), **not** a failure of the tool. Best
+recall is on the [recommended model + reasoning budget](#recommended-model--reasoning-budget);
+on a default budget, expect surface-level pattern matching only.
+
 ## How it works
 
 1. **Detect mode and runtime.**


### PR DESCRIPTION
## Why

Came out of an onboarding / time-to-win review of the auditor subagent. Driving the v2.21 "crash-first brownfield Anchor" fixture **end to end** (its own README's documented run) surfaced that the capability was never actually validated:

1. **The fixture never compiled** — `run`'s `let zero = 0; 100/zero` is a compile-time `unconditional_panic` error, so `anchor build` / `cargo build-sbf` could never emit a `.so`. CI only ever tested harness *emission* (`--fuzz 0`), never a fired crash.
2. **The Anchor brownfield path never read the IDL for accounts** — every action emitted `todo!()`, and the §S1.2 lamport-inflation guard had no tracked signers, so nothing could fire.
3. **The planted div-by-zero / unwrap bugs can't fire under crash-first at all** — in-program SBF faults surface as *transaction errors*, not *host-process panics*, which is what Crucible's intrinsic detector catches.

This PR makes brownfield Anchor Crucible genuinely fire, fixes the fixture, and adds an auditor preflight so these "silent until you run it" gaps surface up front.

## What

**Engine**
- `crucible_brownfield`: the Anchor path now reads a committed / built IDL when present (shared `synthesize_from_idl` with the Pinocchio path), populating per-handler accounts incl. signer/writable flags. The emitter fills real `accounts::X { … }` literals (no `todo!()`) and the §S1.2 guard gets a tracked signer set. Falls back to the source scan (handler names only) with no IDL.
- IDL account parser accepts Anchor ≥0.30 `signer`/`writable` + top-level `address`, not just legacy `isSigner`/`isWritable`.
- `crucible_probe::discover_idl`: falls back to a committed `<root>/idl.json` when `target/idl/` is absent — decouples brownfield Anchor from an `anchor build` round-trip (mirrors the Pinocchio convention). + unit tests.
- `crucible_gen`: per-action doc comment no longer claims a `todo!()` fall-through when the literal is auto-filled.

**Fixture** (`v2.21-crucible-crash-first/buggy_anchor`)
- Compiles now (runtime-derived divisor; real program id — was the all-zeros System Program id).
- `drain` redesigned to a System CPI transfer between two signer accounts → `target` gains lamports → `assert_no_signer_inflation` fires. `run`/`maybe` kept as controls documenting what crash-first does **not** catch.
- Ships a committed `idl.json`; build the `.so` with `cargo build-sbf` (no Anchor workspace). README rewritten to the working flow.
- Smoke test strengthened: asserts the drain accounts literal is auto-filled, the guard wraps `.send()`, and no `todo!()` remains.

**Auditor**
- `skills/qedgen-auditor`: a Preflight step (runtime/mode detection, sBPF hard-stop, `qedgen`/`crucible`/`miri` presence + version-staleness, backgrounded compile gate) reports one honest status line before Phase 1.

## Verified

- `cargo test` — **1024 + integration tests pass**; `cargo fmt --check` clean.
- End-to-end on the fixed fixture: `cargo build-sbf` → `qedgen probe --fuzz 30` → **1 fired finding**: HIGH `invariant_violation` on `drain` (1,450+ crashes deduped to 1), spec-less, with a `crucible show … --replay` reproducer. `run`/`maybe` execute and error (no finding), as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MViEfSYVDWHsSYntpcawov
