### PR TITLE
feat(crucible): brownfield demo fixture models a real PDA-vault drain

### DIFF
--- a/crates/qedgen/src/codegen/crucible_gen.rs
+++ b/crates/qedgen/src/codegen/crucible_gen.rs
@@ -552,6 +552,22 @@ fn emit_fixture_impl(
             ));
         }
     }
+    // PDA-derived accounts (e.g. a program-owned vault) are created owned
+    // by *the program* + funded, so the program can debit them — the
+    // realistic drain shape. The brownfield placeholder derives every PDA
+    // from empty seeds (`find_program_address(&[], program_id)`), so they
+    // collapse to a single address; create it once. Matches the per-action
+    // `accounts(...)` literal, which derives the same address.
+    let has_pda_account = spec
+        .handlers
+        .iter()
+        .any(|h| h.accounts.iter().any(|a| a.pda_seeds.is_some()));
+    if is_brownfield && has_pda_account {
+        out.push_str("        let __pda = Pubkey::find_program_address(&[], &program_id).0;\n");
+        out.push_str(
+            "        ctx.create_account()\n            .pubkey(__pda)\n            .lamports(100_000_000_000)\n            .owner(program_id)\n            .create()\n            .unwrap();\n",
+        );
+    }
 
     let state_fields = rust_codegen_util::resolve_state_fields(spec);
     let mutable_fields = rust_codegen_util::mutable_fields(state_fields);

--- a/crates/qedgen/src/probe/crucible_brownfield.rs
+++ b/crates/qedgen/src/probe/crucible_brownfield.rs
@@ -380,26 +380,36 @@ fn accounts_per_handler_from_idl(
                     .unwrap_or(false);
                 let default = a.get("defaultValue");
                 let default_kind = default.and_then(|d| d.get("kind")).and_then(|k| k.as_str());
-                let (default_pubkey, pda_seeds, is_program) = match default_kind {
-                    Some("publicKeyValueNode") => {
-                        let pk = default
-                            .and_then(|d| d.get("publicKey"))
-                            .and_then(|k| k.as_str())
-                            .map(|s| s.to_string());
-                        // For our scope, a publicKeyValueNode pointing at a
-                        // fixed pubkey is effectively a program/sysvar
-                        // account.
-                        (pk, None, true)
+                let (default_pubkey, pda_seeds, is_program) = if a.get("pda").is_some() {
+                    // Anchor ≥0.30 marks a PDA account with a top-level
+                    // `"pda"` object (seeds live there). The emitter derives
+                    // it via `find_program_address` and the harness setup
+                    // creates it program-owned.
+                    (None, Some(vec![]), false)
+                } else {
+                    match default_kind {
+                        Some("publicKeyValueNode") => {
+                            let pk = default
+                                .and_then(|d| d.get("publicKey"))
+                                .and_then(|k| k.as_str())
+                                .map(|s| s.to_string());
+                            // For our scope, a publicKeyValueNode pointing at
+                            // a fixed pubkey is effectively a program/sysvar
+                            // account.
+                            (pk, None, true)
+                        }
+                        // Codama IR PDA node.
+                        Some("pdaValueNode") => (None, Some(vec![]), false),
+                        // Anchor ≥0.30 emits a fixed-address account (e.g.
+                        // `Program<System>`) as a top-level `"address"` field
+                        // rather than a `defaultValue` node — treat it the
+                        // same as a publicKeyValueNode so the emitter
+                        // auto-fills it.
+                        _ => match a.get("address").and_then(|k| k.as_str()) {
+                            Some(addr) => (Some(addr.to_string()), None, true),
+                            None => (None, None, false),
+                        },
                     }
-                    Some("pdaValueNode") => (None, Some(vec![]), false),
-                    // Anchor ≥0.30 emits a fixed-address account (e.g.
-                    // `Program<System>`) as a top-level `"address"` field
-                    // rather than a `defaultValue` node — treat it the same
-                    // as a publicKeyValueNode so the emitter auto-fills it.
-                    _ => match a.get("address").and_then(|k| k.as_str()) {
-                        Some(addr) => (Some(addr.to_string()), None, true),
-                        None => (None, None, false),
-                    },
                 };
                 Some(ParsedHandlerAccount {
                     name,

--- a/crates/qedgen/tests/crucible_brownfield_smoke.rs
+++ b/crates/qedgen/tests/crucible_brownfield_smoke.rs
@@ -215,8 +215,9 @@ fn fixture_buggy_anchor_drives_brownfield_emit() {
     // v2.21 §S1.2 — protocol-mode harness carries the lamport-conservation
     // helpers AND, now that buggy_anchor ships a committed idl.json, the
     // IDL-driven path fills the `accounts::*` literals and wires the
-    // per-action inflation check. `drain`'s `source`/`target` are signers,
-    // so they form the tracked set the guard snapshots and asserts on.
+    // per-action inflation check. `drain`'s `authority` is a signer (the
+    // tracked set the guard snapshots) and `vault` is a program-owned PDA
+    // the harness stages so the drain can actually debit it.
     assert!(
         body.contains("fn assert_no_signer_inflation"),
         "protocol-mode brownfield harness must emit assert_no_signer_inflation helper"
@@ -239,6 +240,12 @@ fn fixture_buggy_anchor_drives_brownfield_emit() {
     assert!(
         !body.contains("todo!("),
         "IDL-driven brownfield emit should leave no todo!() in the action bodies"
+    );
+    // The `vault` PDA must be staged program-owned + funded so the program
+    // can debit it — without this, drain errors and nothing fires.
+    assert!(
+        body.contains(".owner(program_id)"),
+        "vault PDA should be created program-owned in setup()"
     );
 }
 

--- a/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/README.md
+++ b/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/README.md
@@ -12,12 +12,14 @@ catch — see `run` / `maybe` below.
 
 A minimal Anchor program with three handlers:
 
-1. **`drain` — FIRES.** Transfers half of `source`'s lamports to an
-   arbitrary `target` (a System CPI transfer) with no authorization
-   policy. Both accounts are signers, so both are in the harness's tracked
-   set; `target` *gains* lamports, tripping the §S1.2
-   `assert_no_signer_inflation` guard. The fuzzer surfaces it as a HIGH
-   `invariant_violation` on `drain`, with no spec annotation.
+1. **`drain` — FIRES.** Empties a **program-owned `vault` PDA** into the
+   calling `authority` with **no check that the caller is the legitimate
+   admin** — a textbook missing-authority-check withdraw. A program may
+   freely debit accounts it owns, so the direct lamport move succeeds for
+   any signer. `authority` is a tracked signer; it *gains* the vault's
+   lamports (which come from **outside** the tracked set), tripping the
+   §S1.2 `assert_no_signer_inflation` guard. The fuzzer surfaces it as a
+   HIGH `invariant_violation` on `drain`, with no spec annotation.
 
 2. **`run` — does NOT fire.** Divides by a runtime zero. An in-program
    **SBF fault** surfaces as a transaction *error*, not a host-process
@@ -26,14 +28,20 @@ A minimal Anchor program with three handlers:
 3. **`maybe` — does NOT fire.** `Option::unwrap()` on `None`. Same story:
    a program-side abort, not a host crash.
 
-`run` / `maybe` are kept deliberately as controls. Crucible's "crash-
-first" detector catches host-process panics + `fuzz_assert!` invariant
-violations (like the §S1.2 guard) — **not** faults inside the sandboxed
-`.so`. The drain path is the one that fires because it trips a
+`run` / `maybe` are kept deliberately as controls (each takes the
+`authority` signer so it actually executes and faults in-program).
+Crucible's "crash-first" detector catches host-process panics +
+`fuzz_assert!` invariant violations (like the §S1.2 guard) — **not** faults
+inside the sandboxed `.so`. The drain path fires because it trips a
 *protocol invariant the harness checks in-process*, not a program panic.
 
-> Note on `run`'s divisor: it's runtime-derived (`stub.lamports() -
-> stub.lamports()`) rather than `let zero = 0`. rustc's
+The harness stages the realistic topology with no spec: `qedgen` reads the
+committed IDL, sees `vault`'s `pda` node, and emits setup that creates the
+vault **program-owned and funded** (so the program can debit it) at the
+same `find_program_address(&[], program_id)` address the handler derives.
+
+> Note on `run`'s divisor: it's runtime-derived (`authority.lamports() -
+> authority.lamports()`) rather than `let zero = 0`. rustc's
 > `unconditional_panic` lint const-folds the literal form into a *compile*
 > error, so the crate would never build and `cargo build-sbf` couldn't
 > emit a `.so`.
@@ -86,6 +94,9 @@ collapses that mismatch — the same committed-IDL convention the
 - **Brownfield handler + account discovery** — `run` / `maybe` / `drain`
   appear as `action_*`, and the IDL-driven path fills their
   `accounts::*` literals (and the drain signer set) — no `todo!()`.
+- **Program-owned PDA staging** — the IDL's `pda` node makes the harness
+  `setup()` create the `vault` program-owned + funded, so `drain` can
+  actually debit it (the realistic withdraw shape).
 - **Protocol-mode header** — the emitted `main.rs` carries the
   `Mode: PROTOCOL (no spec)` banner.
 - **§S1.2 guard wiring** — `assert_no_signer_inflation` +

--- a/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/idl.json
+++ b/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/idl.json
@@ -9,12 +9,10 @@
     {
       "name": "drain",
       "docs": [
-        "Sweeps half of `source`'s lamports into `target` with no check that",
-        "`target` is an authorized recipient. Implemented as a System CPI",
-        "transfer (so it works against the harness's system-owned, funded",
-        "accounts). Because `target` is a tracked signer that GAINS lamports,",
-        "the v2.21 §S1.2 lamport-inflation guard fires — surfacing the drain",
-        "shape with no spec annotation."
+        "Drains the program-owned `vault` PDA into `authority` with **no",
+        "authority check** — the vulnerability. A program may freely debit",
+        "accounts it owns, so this direct lamport move succeeds for any",
+        "caller, draining the vault to whoever signs."
       ],
       "discriminator": [
         239,
@@ -28,25 +26,25 @@
       ],
       "accounts": [
         {
-          "name": "source",
+          "name": "vault",
           "docs": [
-            "Funds the transfer; signs the CPI."
+            "Program-owned vault (PDA, empty seeds). The program may debit it.",
+            "for the direct lamport move."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": []
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The caller — receives the drained lamports. **Never checked against",
+            "a stored admin/authority** (the bug). A signer, so the harness",
+            "tracks it; gaining the vault's lamports trips the §S1.2 guard."
           ],
           "writable": true,
           "signer": true
-        },
-        {
-          "name": "target",
-          "docs": [
-            "Arbitrary recipient — no authorization policy (the bug). A signer",
-            "so the harness tracks it; gaining lamports trips the §S1.2 guard."
-          ],
-          "writable": true,
-          "signer": true
-        },
-        {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
         }
       ],
       "args": []
@@ -69,11 +67,13 @@
       ],
       "accounts": [
         {
-          "name": "stub",
+          "name": "authority",
           "docs": [
-            "Stand-in unchecked account; the bug fires before any account",
-            "access matters so the contents don't matter."
-          ]
+            "Pays the fee so the handler actually executes (and faults",
+            "in-program, demonstrating the crash-first limitation)."
+          ],
+          "writable": true,
+          "signer": true
         }
       ],
       "args": []
@@ -81,14 +81,13 @@
     {
       "name": "run",
       "docs": [
-        "Divides by a runtime zero. Does NOT fire under crash-first (see",
-        "the module doc): the SBF fault is a transaction error, not a host",
-        "panic.",
+        "Divides by a runtime zero. Does NOT fire under crash-first: the SBF",
+        "fault is a transaction error, not a host panic.",
         "",
-        "The divisor is runtime-derived (`stub.lamports() - stub.lamports()`)",
-        "rather than `let zero = 0`: rustc's `unconditional_panic` lint",
-        "const-folds the literal form into a *compile* error, so the program",
-        "would never build and `cargo build-sbf` couldn't emit the `.so`."
+        "The divisor is runtime-derived (`authority.lamports() -",
+        "authority.lamports()`) rather than `let zero = 0`: rustc's",
+        "`unconditional_panic` lint const-folds the literal form into a",
+        "*compile* error, so the crate would never build."
       ],
       "discriminator": [
         203,
@@ -102,11 +101,13 @@
       ],
       "accounts": [
         {
-          "name": "stub",
+          "name": "authority",
           "docs": [
-            "Stand-in unchecked account; the bug fires before any account",
-            "access matters so the contents don't matter."
-          ]
+            "Pays the fee so the handler actually executes (and faults",
+            "in-program, demonstrating the crash-first limitation)."
+          ],
+          "writable": true,
+          "signer": true
         }
       ],
       "args": []

--- a/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/src/lib.rs
+++ b/crates/qedgen/tests/fixtures/regressions/v2.21-crucible-crash-first/buggy_anchor/src/lib.rs
@@ -1,27 +1,28 @@
-//! Deliberately buggy Anchor program used by the v2.21 Slice §S1.2
-//! Crucible lamport-conservation regression fixture. See ../README.md.
+//! Deliberately buggy Anchor program for the v2.21 §S1.2 Crucible
+//! lamport-conservation regression fixture. See ../README.md.
 //!
-//! Three handlers, chosen to demonstrate BOTH what Crucible's brownfield
-//! crash-first harness catches and what it does *not*:
+//! Three handlers, demonstrating BOTH what Crucible's brownfield crash-
+//! first harness catches and what it does *not*:
 //!
-//!   * `drain`  — transfers `source`'s lamports to an arbitrary `target`
-//!                with no authorization policy. Both are signers, so both
-//!                are in the harness's tracked set; `target` GAINS lamports,
-//!                tripping the v2.21 §S1.2 `assert_no_signer_inflation`
-//!                guard. **This is the finding the fixture fires.**
+//!   * `drain`  — empties a **program-owned PDA vault** into the calling
+//!                `authority` with no check that the caller is the
+//!                legitimate admin. Any signer can drain the vault to
+//!                itself. `authority` is a tracked signer that GAINS the
+//!                vault's lamports (which come from outside the tracked
+//!                set), tripping the §S1.2 `assert_no_signer_inflation`
+//!                guard. **This is the finding the fixture fires** — a
+//!                textbook missing-authority-check withdraw.
 //!   * `run`    — divides by a runtime zero. **Does NOT fire**: an
 //!                in-program SBF fault surfaces as a transaction *error*,
 //!                not a host panic, so Crucible's intrinsic detector never
-//!                sees it. Kept as a control for the README's discussion.
-//!   * `maybe`  — `Option::unwrap` on `None`. Same story as `run`: a
-//!                program-side abort, not a host crash. Does NOT fire.
+//!                sees it. Kept as a control.
+//!   * `maybe`  — `Option::unwrap` on `None`. Same as `run`: a program-
+//!                side abort, not a host crash. Does NOT fire.
 //!
 //! The §S1.2 guard is a *protocol* invariant (lamport conservation), so it
-//! fires with no `.qedspec` — the brownfield value-add. The `run`/`maybe`
-//! controls document why "crash-first" alone can't catch in-program panics.
+//! fires with no `.qedspec` — the brownfield value-add.
 
 use anchor_lang::prelude::*;
-use anchor_lang::system_program;
 
 declare_id!("6bRRkRXokuEQs6sctPhSGjqEnEkPgbda16N1aajwH7bp");
 
@@ -29,16 +30,33 @@ declare_id!("6bRRkRXokuEQs6sctPhSGjqEnEkPgbda16N1aajwH7bp");
 pub mod buggy_anchor {
     use super::*;
 
-    /// Divides by a runtime zero. Does NOT fire under crash-first (see
-    /// the module doc): the SBF fault is a transaction error, not a host
-    /// panic.
+    /// Drains the program-owned `vault` PDA into `authority` with **no
+    /// authority check** — the vulnerability. A program may freely debit
+    /// accounts it owns, so this direct lamport move succeeds for any
+    /// caller, draining the vault to whoever signs.
+    pub fn drain(ctx: Context<DrainAccounts>) -> Result<()> {
+        let amount = ctx.accounts.vault.to_account_info().lamports();
+        **ctx.accounts.vault.try_borrow_mut_lamports()? = 0;
+        let credited = ctx
+            .accounts
+            .authority
+            .to_account_info()
+            .lamports()
+            .checked_add(amount)
+            .unwrap();
+        **ctx.accounts.authority.to_account_info().try_borrow_mut_lamports()? = credited;
+        Ok(())
+    }
+
+    /// Divides by a runtime zero. Does NOT fire under crash-first: the SBF
+    /// fault is a transaction error, not a host panic.
     ///
-    /// The divisor is runtime-derived (`stub.lamports() - stub.lamports()`)
-    /// rather than `let zero = 0`: rustc's `unconditional_panic` lint
-    /// const-folds the literal form into a *compile* error, so the program
-    /// would never build and `cargo build-sbf` couldn't emit the `.so`.
-    pub fn run(ctx: Context<Empty>) -> Result<()> {
-        let l = ctx.accounts.stub.lamports();
+    /// The divisor is runtime-derived (`authority.lamports() -
+    /// authority.lamports()`) rather than `let zero = 0`: rustc's
+    /// `unconditional_panic` lint const-folds the literal form into a
+    /// *compile* error, so the crate would never build.
+    pub fn run(ctx: Context<OneSigner>) -> Result<()> {
+        let l = ctx.accounts.authority.to_account_info().lamports();
         let zero: u32 = (l - l) as u32;
         let _ = 100u32 / zero;
         Ok(())
@@ -46,50 +64,32 @@ pub mod buggy_anchor {
 
     /// Unwraps a `None`. Does NOT fire under crash-first — program-side
     /// abort, not a host panic.
-    pub fn maybe(ctx: Context<Empty>) -> Result<()> {
+    pub fn maybe(ctx: Context<OneSigner>) -> Result<()> {
         let _ = ctx;
         let value: Option<u32> = None;
         let _ = value.unwrap();
         Ok(())
     }
-
-    /// Sweeps half of `source`'s lamports into `target` with no check that
-    /// `target` is an authorized recipient. Implemented as a System CPI
-    /// transfer (so it works against the harness's system-owned, funded
-    /// accounts). Because `target` is a tracked signer that GAINS lamports,
-    /// the v2.21 §S1.2 lamport-inflation guard fires — surfacing the drain
-    /// shape with no spec annotation.
-    pub fn drain(ctx: Context<DrainAccounts>) -> Result<()> {
-        let amount = ctx.accounts.source.to_account_info().lamports() / 2;
-        system_program::transfer(
-            CpiContext::new(
-                ctx.accounts.system_program.to_account_info(),
-                system_program::Transfer {
-                    from: ctx.accounts.source.to_account_info(),
-                    to: ctx.accounts.target.to_account_info(),
-                },
-            ),
-            amount,
-        )
-    }
 }
 
 #[derive(Accounts)]
-pub struct Empty<'info> {
-    /// Stand-in unchecked account; the bug fires before any account
-    /// access matters so the contents don't matter.
-    /// CHECK: not validated; brownfield demo only.
-    pub stub: AccountInfo<'info>,
+pub struct OneSigner<'info> {
+    /// Pays the fee so the handler actually executes (and faults
+    /// in-program, demonstrating the crash-first limitation).
+    #[account(mut)]
+    pub authority: Signer<'info>,
 }
 
 #[derive(Accounts)]
 pub struct DrainAccounts<'info> {
-    /// Funds the transfer; signs the CPI.
+    /// Program-owned vault (PDA, empty seeds). The program may debit it.
+    /// CHECK: address validated by the seeds constraint; raw AccountInfo
+    /// for the direct lamport move.
+    #[account(mut, seeds = [], bump)]
+    pub vault: AccountInfo<'info>,
+    /// The caller — receives the drained lamports. **Never checked against
+    /// a stored admin/authority** (the bug). A signer, so the harness
+    /// tracks it; gaining the vault's lamports trips the §S1.2 guard.
     #[account(mut)]
-    pub source: Signer<'info>,
-    /// Arbitrary recipient — no authorization policy (the bug). A signer
-    /// so the harness tracks it; gaining lamports trips the §S1.2 guard.
-    #[account(mut)]
-    pub target: Signer<'info>,
-    pub system_program: Program<'info, System>,
+    pub authority: Signer<'info>,
 }


### PR DESCRIPTION
## Why

Follow-up to #136. That PR made brownfield Anchor Crucible fire end-to-end, but the demo's `drain` was a coarse **signer→signer transfer** — it tripped §S1.2 only via the guard's per-signer asymmetric check (target gains), while the funds never actually left the tracked set. That reads as gaming the guard, not modelling a real bug.

This makes the demo a **textbook missing-authority-check withdraw**: `drain` empties a program-owned `vault` PDA into the calling `authority` with no admin check. A program may debit accounts it owns, so the move succeeds for *any* signer — the vault's lamports (from **outside** the tracked set) land on the tracked `authority`. That's exactly the shape §S1.2 exists to catch.

## What

**Engine** (to stage the realistic topology with no spec)
- `crucible_brownfield`: the IDL account parser now recognises Anchor ≥0.30 PDA accounts (top-level `"pda"` node), not just Codama `pdaValueNode`.
- `crucible_gen`: brownfield `setup()` creates PDA-derived accounts **program-owned + funded** (`owner(program_id)`) at the same `find_program_address(&[], program_id)` address the per-action literal derives — so the program can debit a vault it owns.

**Fixture** (`v2.21-crucible-crash-first/buggy_anchor`)
- `drain` → the PDA-vault drain above. `run`/`maybe` kept as controls (each now takes the `authority` signer so they actually execute and fault in-program — documenting that an SBF fault is a tx error, not a host panic crash-first can see).
- IDL regenerated; README updated to the realistic shape.
- Smoke test asserts the vault PDA is staged program-owned (`.owner(program_id)`).

## Verified

- `cargo test` — **1024 + integration tests pass**; `cargo fmt --check` clean; Pinocchio brownfield path unaffected.
- End-to-end: `cargo build-sbf` → `qedgen probe --fuzz 30` → **HIGH `invariant_violation` on `drain`** (506 crashes deduped to 1), spec-less, program executing (5.1% coverage). `run`/`maybe` execute and fault in-program → no finding, as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MViEfSYVDWHsSYntpcawov
