### PR TITLE
chore(release): v2.38.0 — Leanstral v1.5 + auditor model refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.37.0"
+version = "2.38.0"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.37.0"
+version = "2.38.0"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/src/dispatch/api.rs
+++ b/crates/qedgen/src/dispatch/api.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
 const API_URL: &str = "https://api.mistral.ai/v1/chat/completions";
-const MODEL: &str = "labs-leanstral-2603";
+const MODEL: &str = "labs-leanstral-1-5";
 const TIMEOUT_SECS: u64 = 180;
 const MAX_RETRIES: u32 = 3;
 const BACKOFF_BASE_MS: u64 = 2000;

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/lending.codegen.txt
+++ b/crates/qedgen/tests/snapshots/lending.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 anchor-lang = "0.32.1"
 

--- a/crates/qedgen/tests/snapshots/percolator.codegen.txt
+++ b/crates/qedgen/tests/snapshots/percolator.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 anchor-lang = "0.32.1"
 

--- a/docs/prds/RELEASE-v2.38.0.md
+++ b/docs/prds/RELEASE-v2.38.0.md
@@ -1,0 +1,67 @@
+# QEDGen v2.38.0 — model refresh (Leanstral v1.5, auditor Fable 5 / Opus 4.8 / GPT-5.5)
+
+**Status:** release-prep (on `chore/release-v2.38.0`). **Theme:** point the two
+external-model seams at their current-generation defaults, plus the brownfield
+crucible fixes already merged to `main` since v2.37.0.
+
+Everything since v2.37.0 (#136–#137 + the model-default updates below). This is a
+small config/maintenance release — no CLI surface change, no generated-output
+change beyond the version-tag re-stamp.
+
+## What shipped
+
+### 1. Leanstral default model → `labs-leanstral-1-5`
+
+`qedgen fill-sorry` / `generate` (the Lean sorry-filling dispatch) now target
+Mistral's **Leanstral v1.5** (`labs-leanstral-1-5`, released 2026-06-30 — 119B
+total / 6.5B active, 256k context), up from `labs-leanstral-2603`. Single
+constant in `crates/qedgen/src/dispatch/api.rs`; both the `fill-sorry` and
+`generate` paths consume it. Still a Labs-tier model (free), so the existing
+org-enablement error path (`api.rs`) is unchanged.
+
+### 2. Auditor default-model recommendation refresh
+
+`skills/qedgen-auditor/SKILL.md` "Recommended model + reasoning budget" now reads:
+
+- **Claude Fable 5** — preferred on Claude Code (newest flagship).
+- **Claude Opus 4.8 with extended thinking** — fallback on Claude Code when
+  Fable 5 isn't available. Both are lifted by the `ultrathink` UserPromptSubmit
+  hook installed alongside the skill.
+- **GPT-5.5 in high-reasoning mode** — Codex / Cursor / other agent-skills
+  harnesses (budget set manually).
+
+`hooks/README.md` updated to name Fable 5 / Opus 4.8 (was Opus 4.6 / 4.7) as the
+models the `ultrathink` keyword lifts. Hook mechanism itself is unchanged and
+model-agnostic. Supersedes the earlier Opus 4.7 xhigh recommendation.
+
+### 3. Brownfield crucible (merged to `main` since v2.37.0)
+
+- **#136** — brownfield Anchor fuzz fires end-to-end; the auditor gains a
+  Crucible preflight. In-program SBF faults surface as tx-errors (not host
+  panics), so the crash-first lane reads them correctly; Anchor brownfield now
+  reads IDL accounts (falls back to a committed `idl.json`).
+- **#137** — a brownfield demo fixture that models a real PDA-vault drain.
+
+### 4. Supply-chain
+
+- `anyhow 1.0.102 → 1.0.103` (Cargo.lock only; **RUSTSEC-2026-0190**,
+  `Error::downcast_mut()` unsoundness). Fixed by version bump, not an ignore
+  entry — `deny.toml` / CI `--ignore` lists are unchanged.
+
+## Compatibility notes
+
+- No CLI change, no `.qedspec` DSL change, no change to generated code / proofs
+  beyond the `qedgen-macros` version-tag re-stamp (`v2.37.0 → v2.38.0`) across the
+  6 codegen snapshots + 8 bundled-example `Cargo.toml` pins.
+- The Leanstral default moves to a Labs model that must be enabled for the
+  caller's Mistral org (same as before); `MISTRAL_API_KEY` unchanged.
+
+## Gates (RELEASING.md)
+
+- Version bumped in `Cargo.toml` + `package.json`; `check-version-consistency.sh` clean (2.38.0).
+- Version-pinned artifacts re-stamped (`UPDATE_SNAPSHOTS codegen_snapshot` + `qedgen check --regen-drift --write`); diff is **tag-line/version-line only** across the 6 snapshots + 8 example `Cargo.toml`.
+- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` ✅ (17 suites green).
+- `check-readme-drift.sh` ✅ (21 commands) · `qedgen check --regen-drift` clean (8 examples) · `qedgen check --frozen` clean (no stale locks; nonzero exits are pre-existing P2/P3 lint, not lock drift).
+- Zero unintended `sorry` in generated example proofs (only matches are codegen-helper DSL / docstrings in the vendored support lib — identical to v2.37.0).
+- Supply-chain: `cargo audit --deny warnings` (CI `--ignore` set) and `cargo deny check` both exit 0 after the anyhow bump.
+- Example `lake build` (`check-lake-build.sh`) unchanged — no `.lean` / `lean_solana` / qedsvm-pin change in this release; CI gate re-runs on the release PR.

--- a/examples/rust/cross-program-vault/programs/Cargo.toml
+++ b/examples/rust/cross-program-vault/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/examples/rust/lending/Cargo.toml
+++ b/examples/rust/lending/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/examples/rust/multisig/Cargo.toml
+++ b/examples/rust/multisig/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.37.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
 
 [workspace]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "Agent skill for spec-driven verification and audit of Solana programs \u2014 .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -16,9 +16,11 @@ The auditor's §3c trust-surface walk and authority-side intent-drift
 sweep require sustained multi-step reasoning across the program's
 dependency graph and documented invariants. Use one of:
 
-- **Claude Opus 4.8 with extended thinking** (Claude Code — this
-  skill auto-injects `ultrathink` via a UserPromptSubmit hook
-  installed alongside the skill; see `hooks/README.md`).
+- **Claude Fable 5** (Claude Code — preferred; the newest flagship).
+  Falls back to **Claude Opus 4.8 with extended thinking** when Fable 5
+  isn't available. Either way this skill auto-injects `ultrathink` via a
+  UserPromptSubmit hook installed alongside the skill; see
+  `hooks/README.md`.
 - **GPT-5.5 in high-reasoning mode** (Codex / Cursor / other
   agent-skills harnesses — set the harness's reasoning budget
   manually; no auto-injection on those harnesses).

--- a/skills/qedgen-auditor/hooks/README.md
+++ b/skills/qedgen-auditor/hooks/README.md
@@ -1,8 +1,8 @@
 # qedgen-auditor — thinking-budget hook
 
 A Claude Code `UserPromptSubmit` hook that detects audit-trigger phrases and
-appends `ultrathink` to the prompt so Opus 4.6 / 4.7 sessions allocate maximum
-thinking budget.
+appends `ultrathink` to the prompt so Fable 5 / Opus 4.8 sessions allocate
+maximum thinking budget.
 
 ## Why
 
@@ -21,7 +21,7 @@ harness-level hook fired on user prompt submission.
 
 When the submitted prompt matches one of the trigger phrases below
 (case-insensitive), the hook appends `\n\nultrathink` to the prompt before it
-reaches the model. On Opus 4.6 / 4.7 this allocates the maximum thinking
+reaches the model. On Fable 5 / Opus 4.8 this allocates the maximum thinking
 budget; on Sonnet / Haiku the word is a no-op or a partial lift (no harm).
 
 Trigger phrases:


### PR DESCRIPTION
Small config/maintenance release. Points the two external-model seams at their current-generation defaults and bundles the brownfield crucible fixes already on `main` since v2.37.0. No CLI surface change; no generated-output change beyond the version-tag re-stamp.

## What's in

- **Leanstral default → `labs-leanstral-1-5` (v1.5)** for `fill-sorry` / `generate` — single const in `crates/qedgen/src/dispatch/api.rs`.
- **Auditor recommended models** → **Fable 5** preferred / **Opus 4.8** fallback on Claude Code, **GPT-5.5** on Codex (`skills/qedgen-auditor/SKILL.md` + `hooks/README.md`; supersedes Opus 4.7 xhigh).
- Bundles **#136** (brownfield Anchor crucible fires end-to-end + auditor preflight) and **#137** (PDA-vault drain demo fixture).
- Supply-chain: **anyhow 1.0.102 → 1.0.103** (RUSTSEC-2026-0190, `Error::downcast_mut()` unsoundness) — fixed by bump, not ignore.
- Version bump re-stamps the `qedgen-macros` tag across 6 codegen snapshots + 8 example `Cargo.toml` pins.

Full notes: `docs/prds/RELEASE-v2.38.0.md`.

## Gates (RELEASING.md)

- `check-version-consistency.sh` clean (2.38.0).
- Re-stamped artifacts: diff is **tag/version-line only** across 6 snapshots + 8 example `Cargo.toml`.
- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` ✅ (17 suites).
- `check-readme-drift.sh` ✅ (21 commands) · `qedgen check --regen-drift` clean · `qedgen check --frozen` clean.
- Zero unintended `sorry` (vendored helper DSL only, unchanged from v2.37.0).
- `cargo audit` (CI `--ignore` set) + `cargo deny check` both exit 0 after the anyhow bump.
- `lake build` unchanged — no `.lean` / `lean_solana` / qedsvm-pin change; CI re-runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)