### PR TITLE
fix(spec): resolve bare state-field refs in guards across all backends (#139)

### DIFF
--- a/crates/qedgen/src/check/lints/mod.rs
+++ b/crates/qedgen/src/check/lints/mod.rs
@@ -1599,6 +1599,10 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
     // error variants, silently breaking every `error_codes` consumer. P0.
     warnings.extend(check_error_declared_as_record(spec));
 
+    // A `requires` name that resolves to nothing renders verbatim into
+    // every backend and fails to compile there — fail at check instead. P0.
+    warnings.extend(check_unknown_guard_identifier(spec));
+
     // `modifies [X]` with no effect write and no `ensures` reference: the
     // field is completely unconstrained — Lean frame proofs allow any
     // post-value, the impl-fill site has nothing to verify against. P0.

--- a/crates/qedgen/src/check/lints/structural.rs
+++ b/crates/qedgen/src/check/lints/structural.rs
@@ -684,4 +684,172 @@ mod tests {
                 .collect::<Vec<_>>(),
         );
     }
+
+    #[test]
+    fn unknown_guard_identifier_fires_on_typos_only() {
+        let src = r#"spec TypoVault
+program_id "11111111111111111111111111111111"
+
+const LIMIT = 100
+
+type State = {
+  active : U8,
+  fee : U64,
+}
+
+type Error | Unauthorized
+
+handler execute (amount : U64) : State -> State {
+  permissionless
+  requires actve == 0 else Unauthorized
+  requires state.fe > 0 else Unauthorized
+  requires active == 0 else Unauthorized
+  requires amount > 0 else Unauthorized
+  requires state.fee < LIMIT else Unauthorized
+  effect { fee := amount }
+}
+"#;
+        let spec = crate::chumsky_adapter::parse_str(src).expect("spec parses");
+        let warnings = check_unknown_guard_identifier(&spec);
+        let subjects: Vec<&str> = warnings
+            .iter()
+            .filter(|w| w.rule == "unknown_guard_identifier")
+            .map(|w| w.message.as_str())
+            .collect();
+        assert_eq!(
+            subjects.len(),
+            2,
+            "exactly the two typos fire — resolvable refs (state field, \
+             param, const) stay silent; got: {subjects:?}"
+        );
+        assert!(subjects.iter().any(|m| m.contains("`actve`")));
+        assert!(subjects.iter().any(|m| m.contains("`state.fe`")));
+        assert!(warnings
+            .iter()
+            .all(|w| w.severity == Severity::Error && w.priority == 0));
+    }
+
+    #[test]
+    fn unknown_guard_identifier_skips_sbpf_specs() {
+        let src = r#"spec SbpfCounter
+program_id "11111111111111111111111111111111"
+
+pragma sbpf {}
+
+type State
+  | Uninitialized
+  | Active
+
+type Error | BadPda
+
+handler initialize : State.Uninitialized -> State.Active {
+  permissionless
+  requires pda_derivation_succeeds else BadPda
+}
+"#;
+        let spec = crate::chumsky_adapter::parse_str(src).expect("spec parses");
+        assert!(
+            check_unknown_guard_identifier(&spec).is_empty(),
+            "sBPF requires vocabulary resolves against the input layout, not state"
+        );
+    }
+}
+
+/// `unknown_guard_identifier` (issue #139 follow-up): a `requires` clause
+/// references a name that resolves to nothing — not a state field (those
+/// were canonicalized to `state.`-rooted paths at adapt time), not a param,
+/// account, const, `let` binding, abstract binder, CPI result binding, or
+/// auth actor. The string projections carry the name verbatim, so every
+/// generated backend (Lean transition, Kani harness, proptest model) fails
+/// to compile while `check` used to stay green. Also catches `state.<typo>`
+/// where the field segment isn't declared.
+///
+/// sBPF specs are exempt: their handler requires speak a runtime-input
+/// vocabulary (`instruction_data_len`, `pda_derivation_succeeds`,
+/// `derived_pda`, account attrs) that resolves against the input layout,
+/// not the state model.
+pub(super) fn check_unknown_guard_identifier(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
+    use crate::chumsky_adapter::GuardPathRef;
+
+    let mut warnings = Vec::new();
+    if spec.is_assembly_target() {
+        return warnings;
+    }
+
+    // Every declared state-field name, across representations: flat view,
+    // per-account-type fields + ADT variant fields, and ghosts (rendered as
+    // state fields).
+    let mut state_fields: std::collections::BTreeSet<&str> =
+        spec.state_fields.iter().map(|(n, _)| n.as_str()).collect();
+    for at in &spec.account_types {
+        state_fields.extend(at.fields.iter().map(|(n, _)| n.as_str()));
+        for v in &at.variants {
+            state_fields.extend(v.fields.iter().map(|(n, _)| n.as_str()));
+        }
+    }
+    if let Some(r) = spec.records.iter().find(|r| r.name == "State") {
+        state_fields.extend(r.fields.iter().map(|(n, _)| n.as_str()));
+    }
+    state_fields.extend(spec.ghosts.iter().map(|g| g.name.as_str()));
+
+    let consts: std::collections::BTreeSet<&str> =
+        spec.constants.iter().map(|(n, _)| n.as_str()).collect();
+
+    for h in &spec.handlers {
+        let mut known: std::collections::BTreeSet<&str> = consts.clone();
+        known.extend(h.takes_params.iter().map(|(n, _)| n.as_str()));
+        known.extend(h.accounts.iter().map(|a| a.name.as_str()));
+        known.extend(h.let_bindings.iter().map(|(n, _, _)| n.as_str()));
+        known.extend(h.abstract_binders.iter().map(|(n, _)| n.as_str()));
+        known.extend(h.calls.iter().filter_map(|c| c.result_binding.as_deref()));
+        if let Some(who) = &h.who {
+            known.insert(who.as_str());
+        }
+
+        // Dedup per handler: one finding per unresolved name.
+        let mut reported: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for req in &h.requires {
+            let Some(ast) = &req.ast_body else { continue };
+            for r in crate::chumsky_adapter::collect_guard_path_refs(ast) {
+                let (name, is_state_ref) = match r {
+                    GuardPathRef::Bare(n) => (n, false),
+                    GuardPathRef::StateField(f) => (f, true),
+                };
+                let resolves = if is_state_ref {
+                    state_fields.contains(name.as_str())
+                } else {
+                    known.contains(name.as_str()) || state_fields.contains(name.as_str())
+                };
+                if resolves || !reported.insert(name.clone()) {
+                    continue;
+                }
+                let display = if is_state_ref {
+                    format!("state.{name}")
+                } else {
+                    name.clone()
+                };
+                warnings.push(CompletenessWarning {
+                    rule: "unknown_guard_identifier".to_string(),
+                    severity: Severity::Error,
+                    priority: 0,
+                    message: format!(
+                        "handler '{}' references `{}` in a `requires` clause, but it \
+                         resolves to nothing — not a state field, parameter, account, \
+                         const, or binding. Generated code carries the name verbatim \
+                         and won't compile in any backend.",
+                        h.name, display
+                    ),
+                    subject: Some(h.name.clone()),
+                    fix: format!(
+                        "Declare `{name}` (state field, param, or const) or fix the \
+                         reference to an existing name."
+                    ),
+                    example: None,
+                    counterexample: None,
+                    fix_options: vec![],
+                });
+            }
+        }
+    }
+    warnings
 }

--- a/crates/qedgen/src/codegen/kani_mir/tests.rs
+++ b/crates/qedgen/src/codegen/kani_mir/tests.rs
@@ -421,3 +421,26 @@ fn render_emits_mod_wrapping_for_multi_account() {
         "expected `}} // mod loan` close"
     );
 }
+
+/// Issue #139: bare state-field names in `requires` must reach the Kani
+/// transition fn and guard-rejection assumes with the `s.` receiver —
+/// bare `active` is a compile error inside `fn execute(s: &mut State, …)`.
+#[test]
+fn bare_state_field_requires_reach_harness_with_receiver() {
+    let (mir, parsed) = lower_fixture(
+        "crates/qedgen/tests/fixtures/regressions/issue-139-bare-state-refs/generic_vault.qedspec",
+    );
+    let out = render(&mir, &parsed);
+    assert!(
+        out.contains("if !((s.active == 0) && (amount > 0))"),
+        "transition guard must read state through `s`:\n{out}"
+    );
+    assert!(
+        out.contains("kani::assume(!((s.active == 0) && (amount > 0)));"),
+        "guard-rejection assume must read state through `s`:\n{out}"
+    );
+    assert!(
+        !out.contains("(active == 0)"),
+        "bare state-field guard leaked into the harness:\n{out}"
+    );
+}

--- a/crates/qedgen/src/codegen/lean_gen_mir/tests.rs
+++ b/crates/qedgen/src/codegen/lean_gen_mir/tests.rs
@@ -644,3 +644,22 @@ fn render_pilot_fixtures_no_panic() {
         assert!(out.contains("end "), "{}", fixture);
     }
 }
+
+/// Issue #139: a `requires` written with bare state-field names must render
+/// the transition guard through the `s` receiver — `if s.active = 0`, not
+/// the non-elaborating `if active = 0`. Params stay bare.
+#[test]
+fn bare_state_field_requires_render_with_receiver() {
+    let mir = lower_fixture(
+        "crates/qedgen/tests/fixtures/regressions/issue-139-bare-state-refs/generic_vault.qedspec",
+    );
+    let out = render(&mir);
+    assert!(
+        out.contains("if s.active = 0 ∧ amount > 0 then"),
+        "transition guard must read state through `s`:\n{out}"
+    );
+    assert!(
+        !out.contains("if active = 0"),
+        "bare state-field guard leaked into the transition:\n{out}"
+    );
+}

--- a/crates/qedgen/src/spec/chumsky_adapter/adapt.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/adapt.rs
@@ -999,6 +999,7 @@ fn expand_handler(
 
     // Build a shared base handler (parent without the branch clause).
     let base = adapt_handler(h, consts, env);
+    let canon = canon_scope_for_handler(h, consts, env);
 
     // Accumulate negated guards so that earlier arms' failure implies
     // later arms' precondition (first-match semantics). Triple is
@@ -1026,6 +1027,7 @@ fn expand_handler(
         // Current arm's guard (if any) becomes a requires; negation is
         // recorded for subsequent arms.
         if let Some(guard) = &arm.guard {
+            let guard = canonicalize_state_refs(guard, &canon);
             let lean = expr_to_lean(&guard.node, Ctx::Guard, consts, env);
             let rust = expr_to_rust(&guard.node, Ctx::Guard, consts, opts_native(env));
             let rust_pod = expr_to_rust(&guard.node, Ctx::Guard, consts, opts_pod(env));
@@ -1034,7 +1036,7 @@ fn expand_handler(
                 rust_expr: rust.clone(),
                 rust_expr_pod: rust_pod.clone(),
                 error_name: None,
-                ast_body: Some(guard.clone()),
+                ast_body: Some(guard),
             });
             prior_conds.push((
                 format!("\u{00AC}({})", lean),
@@ -1185,6 +1187,7 @@ fn adapt_handler(h: &a::HandlerDecl, consts: ConstTable, env: &TypeEnv) -> Parse
         .iter()
         .map(|p| (p.name.clone(), type_ref_to_string(&p.ty)))
         .collect();
+    let canon = canon_scope_for_handler(h, consts, env);
 
     // `on_account` is the type prefix of the pre-state ref, if qualified.
     //   `Loan.Active` → on_account = Some("Loan"), pre_status = Some("Active")
@@ -1275,15 +1278,17 @@ fn adapt_handler(h: &a::HandlerDecl, consts: ConstTable, env: &TypeEnv) -> Parse
                 }
             }
             a::HandlerClause::Requires { guard, on_fail } => {
+                let guard = canonicalize_state_refs(guard, &canon);
                 handler.requires.push(ParsedRequires {
                     lean_expr: expr_to_lean(&guard.node, Ctx::Guard, consts, env),
                     rust_expr: expr_to_rust(&guard.node, Ctx::Guard, consts, opts_native(env)),
                     rust_expr_pod: expr_to_rust(&guard.node, Ctx::Guard, consts, opts_pod(env)),
                     error_name: on_fail.clone(),
-                    ast_body: Some(guard.clone()),
+                    ast_body: Some(guard),
                 });
             }
             a::HandlerClause::Ensures(e) => {
+                let e = canonicalize_state_refs(e, &canon);
                 handler.ensures.push(ParsedEnsures {
                     lean_expr: expr_to_lean(&e.node, Ctx::Ensures, consts, env),
                     rust_expr: expr_to_rust(&e.node, Ctx::Ensures, consts, opts_native(env)),
@@ -1302,6 +1307,7 @@ fn adapt_handler(h: &a::HandlerDecl, consts: ConstTable, env: &TypeEnv) -> Parse
                 handler.modifies = Some(fs.clone());
             }
             a::HandlerClause::Let { name, value } => {
+                let value = canonicalize_state_refs(value, &canon);
                 let rust = expr_to_rust(&value.node, Ctx::Guard, consts, opts_native(env));
                 // Narrow `let X = mul_div_*(...)` to U64 at the binding
                 // site — the spec-level operation is U64 → U64 but the

--- a/crates/qedgen/src/spec/chumsky_adapter/canon.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/canon.rs
@@ -1,0 +1,324 @@
+//! Bare state-field canonicalization: `requires active == 0` must read the
+//! same state slot as `requires state.active == 0`. The parser accepts the
+//! bare form, but only `state.`-rooted paths pick up the state receiver at
+//! render time — bare roots fell through verbatim into every backend (Lean
+//! `if active = 0`, Kani/proptest `if !((active == 0))`), none of which
+//! compile (issue #139). Rewriting the typed AST here, before the Lean/Rust
+//! string projections and before `ast_body` is stored, fixes all consumers
+//! at one seam.
+
+use super::*;
+
+/// Handler-scoped name sets deciding whether a bare path root is a state
+/// field read. `skip` holds every name bound by something other than state:
+/// params, consts, handler accounts, handler-level `let`s, abstract binders,
+/// and the `auth` actor. Expression-level binders (quantifiers, `sum`, `let
+/// … in`, match-arm payloads) shadow lexically during the walk instead.
+pub(super) struct CanonScope {
+    state_fields: std::collections::BTreeSet<String>,
+    skip: std::collections::BTreeSet<String>,
+}
+
+/// Build the scope for one handler. Clauses may appear in any order, so
+/// accounts / lets / abstract binders are collected up front rather than as
+/// the clause loop reaches them.
+pub(super) fn canon_scope_for_handler(
+    h: &a::HandlerDecl,
+    consts: ConstTable,
+    env: &TypeEnv,
+) -> CanonScope {
+    let mut skip: std::collections::BTreeSet<String> = consts.keys().cloned().collect();
+    skip.extend(h.params.iter().map(|p| p.name.clone()));
+    for Node { node: clause, .. } in &h.clauses {
+        match clause {
+            a::HandlerClause::Accounts(descs) => {
+                skip.extend(descs.iter().map(|d| d.name.clone()));
+            }
+            a::HandlerClause::Let { name, .. } => {
+                skip.insert(name.clone());
+            }
+            a::HandlerClause::Abstract { name, .. } => {
+                skip.insert(name.clone());
+            }
+            a::HandlerClause::Auth(actor) => {
+                skip.insert(actor.clone());
+            }
+            _ => {}
+        }
+    }
+    // `env.state_fields` carries ADT variant fields + ghosts; the record
+    // form (`type State = { … }` / `state { … }` sugar) keeps its fields in
+    // `records["State"]` instead (see `TypeEnv::from_spec`), so union both.
+    let mut state_fields: std::collections::BTreeSet<String> =
+        env.state_fields.keys().cloned().collect();
+    if let Some(state_record) = env.records.get("State") {
+        state_fields.extend(state_record.keys().cloned());
+    }
+    CanonScope { state_fields, skip }
+}
+
+/// Rewrite bare state-field reads (`active`) into `state.`-rooted paths
+/// (`state.active`) throughout `n`. Returns an owned copy; the input AST is
+/// shared with other clause consumers and stays untouched.
+pub(super) fn canonicalize_state_refs(n: &Node<Expr>, scope: &CanonScope) -> Node<Expr> {
+    let mut shadow: Vec<String> = Vec::new();
+    walk(n, scope, &mut shadow)
+}
+
+fn walk(n: &Node<Expr>, scope: &CanonScope, shadow: &mut Vec<String>) -> Node<Expr> {
+    Node::new(walk_expr(&n.node, scope, shadow), n.span.clone())
+}
+
+fn boxed(n: &Node<Expr>, scope: &CanonScope, shadow: &mut Vec<String>) -> Box<Node<Expr>> {
+    Box::new(walk(n, scope, shadow))
+}
+
+/// Walk under a binder: `name` shadows any same-named state field within
+/// `body` only.
+fn walk_under(
+    name: &str,
+    body: &Node<Expr>,
+    scope: &CanonScope,
+    shadow: &mut Vec<String>,
+) -> Box<Node<Expr>> {
+    shadow.push(name.to_string());
+    let out = boxed(body, scope, shadow);
+    shadow.pop();
+    out
+}
+
+fn walk_expr(e: &Expr, scope: &CanonScope, shadow: &mut Vec<String>) -> Expr {
+    match e {
+        Expr::Int(_) | Expr::Bool(_) => e.clone(),
+        Expr::Path(p) => {
+            if p.root != "state"
+                && scope.state_fields.contains(&p.root)
+                && !scope.skip.contains(&p.root)
+                && !shadow.iter().any(|s| s == &p.root)
+            {
+                let mut segments = Vec::with_capacity(p.segments.len() + 1);
+                segments.push(a::PathSeg::Field(p.root.clone()));
+                segments.extend(p.segments.iter().cloned());
+                Expr::Path(a::Path {
+                    root: "state".to_string(),
+                    segments,
+                })
+            } else {
+                e.clone()
+            }
+        }
+        Expr::Old(inner) => Expr::Old(boxed(inner, scope, shadow)),
+        Expr::Sum {
+            binder,
+            binder_ty,
+            body,
+        } => Expr::Sum {
+            binder: binder.clone(),
+            binder_ty: binder_ty.clone(),
+            body: walk_under(binder, body, scope, shadow),
+        },
+        Expr::Quant {
+            kind,
+            binder,
+            binder_ty,
+            body,
+        } => Expr::Quant {
+            kind: *kind,
+            binder: binder.clone(),
+            binder_ty: binder_ty.clone(),
+            body: walk_under(binder, body, scope, shadow),
+        },
+        Expr::BoolOp { op, lhs, rhs } => Expr::BoolOp {
+            op: *op,
+            lhs: boxed(lhs, scope, shadow),
+            rhs: boxed(rhs, scope, shadow),
+        },
+        Expr::Not(inner) => Expr::Not(boxed(inner, scope, shadow)),
+        Expr::Cmp { op, lhs, rhs } => Expr::Cmp {
+            op: *op,
+            lhs: boxed(lhs, scope, shadow),
+            rhs: boxed(rhs, scope, shadow),
+        },
+        Expr::Arith { op, lhs, rhs } => Expr::Arith {
+            op: *op,
+            lhs: boxed(lhs, scope, shadow),
+            rhs: boxed(rhs, scope, shadow),
+        },
+        Expr::Paren(inner) => Expr::Paren(boxed(inner, scope, shadow)),
+        Expr::MulDivFloor { a, b, d } => Expr::MulDivFloor {
+            a: boxed(a, scope, shadow),
+            b: boxed(b, scope, shadow),
+            d: boxed(d, scope, shadow),
+        },
+        Expr::MulDivCeil { a, b, d } => Expr::MulDivCeil {
+            a: boxed(a, scope, shadow),
+            b: boxed(b, scope, shadow),
+            d: boxed(d, scope, shadow),
+        },
+        Expr::Match { scrutinee, arms } => Expr::Match {
+            scrutinee: boxed(scrutinee, scope, shadow),
+            arms: arms
+                .iter()
+                .map(|arm| a::MatchExprArm {
+                    variant: arm.variant.clone(),
+                    binder: arm.binder.clone(),
+                    body: match &arm.binder {
+                        Some(b) => walk_under(b, &arm.body, scope, shadow),
+                        None => boxed(&arm.body, scope, shadow),
+                    },
+                })
+                .collect(),
+        },
+        Expr::Ctor { variant, payload } => Expr::Ctor {
+            variant: variant.clone(),
+            payload: payload.as_ref().map(|p| boxed(p, scope, shadow)),
+        },
+        Expr::RecordLit(fields) => Expr::RecordLit(
+            fields
+                .iter()
+                .map(|(n, v)| (n.clone(), walk(v, scope, shadow)))
+                .collect(),
+        ),
+        Expr::RecordUpdate { base, updates } => Expr::RecordUpdate {
+            base: boxed(base, scope, shadow),
+            updates: updates
+                .iter()
+                .map(|(n, v)| (n.clone(), walk(v, scope, shadow)))
+                .collect(),
+        },
+        Expr::IsVariant { scrutinee, variant } => Expr::IsVariant {
+            scrutinee: boxed(scrutinee, scope, shadow),
+            variant: variant.clone(),
+        },
+        Expr::App { func, args } => Expr::App {
+            func: func.clone(),
+            args: args.iter().map(|n| walk(n, scope, shadow)).collect(),
+        },
+        Expr::Field { base, field } => Expr::Field {
+            base: boxed(base, scope, shadow),
+            field: field.clone(),
+        },
+        Expr::Let { name, value, body } => Expr::Let {
+            name: name.clone(),
+            value: boxed(value, scope, shadow),
+            body: walk_under(name, body, scope, shadow),
+        },
+        Expr::IfThenElse {
+            cond,
+            then_branch,
+            else_branch,
+        } => Expr::IfThenElse {
+            cond: boxed(cond, scope, shadow),
+            then_branch: boxed(then_branch, scope, shadow),
+            else_branch: boxed(else_branch, scope, shadow),
+        },
+    }
+}
+
+// ============================================================================
+// Shadow-aware path-reference collection (backs `unknown_guard_identifier`)
+// ============================================================================
+
+/// A path reference surfaced from a guard-position expression, with
+/// expression-level binders (quantifiers, `sum`, `let … in`, match-arm
+/// payloads) already discharged — shadowed roots never surface.
+pub(crate) enum GuardPathRef {
+    /// Segment-less bare root: `active`, `amount`. Roots with segments
+    /// (`vault.owner`, `Active.total`) are account / variant / namespace
+    /// references with too many legitimate shapes to classify here.
+    Bare(String),
+    /// First field segment of a `state.`-rooted path: `state.active` →
+    /// `active`. A name absent from the declared state fields renders
+    /// verbatim (`s.actve`) and won't compile.
+    StateField(String),
+}
+
+pub(crate) fn collect_guard_path_refs(node: &Node<Expr>) -> Vec<GuardPathRef> {
+    let mut out = Vec::new();
+    let mut shadow: Vec<String> = Vec::new();
+    collect_refs(node, &mut shadow, &mut out);
+    out
+}
+
+fn collect_refs(n: &Node<Expr>, shadow: &mut Vec<String>, out: &mut Vec<GuardPathRef>) {
+    let under =
+        |name: &str, body: &Node<Expr>, shadow: &mut Vec<String>, out: &mut Vec<GuardPathRef>| {
+            shadow.push(name.to_string());
+            collect_refs(body, shadow, out);
+            shadow.pop();
+        };
+    match &n.node {
+        Expr::Int(_) | Expr::Bool(_) => {}
+        Expr::Path(p) => {
+            if p.root == "state" {
+                if let Some(a::PathSeg::Field(f)) = p.segments.first() {
+                    out.push(GuardPathRef::StateField(f.clone()));
+                }
+            } else if p.segments.is_empty() && !shadow.iter().any(|s| s == &p.root) {
+                out.push(GuardPathRef::Bare(p.root.clone()));
+            }
+        }
+        Expr::Old(inner) | Expr::Not(inner) | Expr::Paren(inner) => {
+            collect_refs(inner, shadow, out)
+        }
+        Expr::Sum { binder, body, .. } | Expr::Quant { binder, body, .. } => {
+            under(binder, body, shadow, out)
+        }
+        Expr::BoolOp { lhs, rhs, .. }
+        | Expr::Cmp { lhs, rhs, .. }
+        | Expr::Arith { lhs, rhs, .. } => {
+            collect_refs(lhs, shadow, out);
+            collect_refs(rhs, shadow, out);
+        }
+        Expr::MulDivFloor { a, b, d } | Expr::MulDivCeil { a, b, d } => {
+            collect_refs(a, shadow, out);
+            collect_refs(b, shadow, out);
+            collect_refs(d, shadow, out);
+        }
+        Expr::Match { scrutinee, arms } => {
+            collect_refs(scrutinee, shadow, out);
+            for arm in arms {
+                match &arm.binder {
+                    Some(b) => under(b, &arm.body, shadow, out),
+                    None => collect_refs(&arm.body, shadow, out),
+                }
+            }
+        }
+        Expr::Ctor { payload, .. } => {
+            if let Some(p) = payload {
+                collect_refs(p, shadow, out);
+            }
+        }
+        Expr::RecordLit(fields) => {
+            for (_, v) in fields {
+                collect_refs(v, shadow, out);
+            }
+        }
+        Expr::RecordUpdate { base, updates } => {
+            collect_refs(base, shadow, out);
+            for (_, v) in updates {
+                collect_refs(v, shadow, out);
+            }
+        }
+        Expr::IsVariant { scrutinee, .. } => collect_refs(scrutinee, shadow, out),
+        Expr::App { args, .. } => {
+            for arg in args {
+                collect_refs(arg, shadow, out);
+            }
+        }
+        Expr::Field { base, .. } => collect_refs(base, shadow, out),
+        Expr::Let { name, value, body } => {
+            collect_refs(value, shadow, out);
+            under(name, body, shadow, out);
+        }
+        Expr::IfThenElse {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            collect_refs(cond, shadow, out);
+            collect_refs(then_branch, shadow, out);
+            collect_refs(else_branch, shadow, out);
+        }
+    }
+}

--- a/crates/qedgen/src/spec/chumsky_adapter/mod.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/mod.rs
@@ -21,6 +21,7 @@ use crate::check::{
 // items so the existing `crate::chumsky_adapter::<name>` call sites — and the
 // cross-submodule references — continue to resolve unchanged.
 mod adapt;
+mod canon;
 mod effects;
 mod lean;
 mod rust;
@@ -29,6 +30,8 @@ mod typecheck;
 pub use adapt::{adapt, parse_str};
 pub use typecheck::typecheck_spec;
 
+pub(in crate::spec::chumsky_adapter) use canon::*;
+pub(crate) use canon::{collect_guard_path_refs, GuardPathRef};
 pub(in crate::spec::chumsky_adapter) use effects::*;
 pub(in crate::spec::chumsky_adapter) use lean::*;
 pub(in crate::spec::chumsky_adapter) use rust::*;

--- a/crates/qedgen/src/spec/chumsky_adapter/tests.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/tests.rs
@@ -1579,3 +1579,79 @@ handler accept (total : U64) (fee_bps : U64) : State.Active -> State.Active {
         "parenthesised mul_div RHS must still narrow; got: {fee_rhs}"
     );
 }
+
+/// Issue #139: bare state-field reads in `requires` must pick up the state
+/// receiver in both string projections (Kani/proptest read `rust_expr`, the
+/// Lean transition reads `lean_expr`). Handler params stay bare.
+#[test]
+fn bare_state_field_refs_in_requires_get_state_receiver() {
+    let src = r#"spec GenericVault
+program_id "11111111111111111111111111111111"
+
+type State = {
+  active : U8,
+  fee : U64,
+}
+
+type Error | Unauthorized
+
+handler execute (amount : U64) : State -> State {
+  permissionless
+  requires active == 0 else Unauthorized
+  requires amount > 0 else Unauthorized
+  ensures fee == amount
+  effect { fee := amount }
+}
+"#;
+    let spec = parse_str(src).expect("parse");
+    let h = &spec.handlers[0];
+    assert_eq!(h.requires[0].rust_expr, "s.active == 0");
+    assert_eq!(h.requires[0].lean_expr, "s.active = 0");
+    // Param ref stays bare.
+    assert_eq!(h.requires[1].rust_expr, "amount > 0");
+    // Ensures: bare state field reads post-state.
+    assert!(
+        h.ensures[0].lean_expr.contains("s'.fee"),
+        "ensures must canonicalize bare state refs; got: {}",
+        h.ensures[0].lean_expr
+    );
+}
+
+/// Names bound closer than state win: handler params, quantifier binders,
+/// `let … in` binders, declared consts, and handler accounts all suppress
+/// the `state.` rewrite even when they collide with a state field name.
+#[test]
+fn bound_names_shadow_state_fields_in_requires() {
+    let src = r#"spec ShadowVault
+program_id "11111111111111111111111111111111"
+
+const LIMIT = 100
+
+type State = {
+  fee : U64,
+  slots : U64,
+}
+
+type Error | Bad
+
+handler pay (fee : U64) : State -> State {
+  permissionless
+  requires fee > 0 else Bad
+  requires slots < LIMIT else Bad
+  requires forall slots : U8, slots >= 0
+  effect { fee := fee }
+}
+"#;
+    let spec = parse_str(src).expect("parse");
+    let h = &spec.handlers[0];
+    // `fee` is a param — stays bare despite the state field of the same name.
+    assert_eq!(h.requires[0].rust_expr, "fee > 0");
+    // `slots` is only a state field — canonicalized; `LIMIT` substitutes.
+    assert_eq!(h.requires[1].rust_expr, "s.slots < 100");
+    // Quantifier binder shadows the state field inside its body.
+    assert!(
+        h.requires[2].rust_expr.contains("|slots| slots >= 0"),
+        "binder must shadow state field; got: {}",
+        h.requires[2].rust_expr
+    );
+}

--- a/crates/qedgen/tests/fixtures/regressions/issue-139-bare-state-refs/generic_vault.qedspec
+++ b/crates/qedgen/tests/fixtures/regressions/issue-139-bare-state-refs/generic_vault.qedspec
@@ -1,0 +1,31 @@
+// Issue #139: bare state-field reads in `requires` guards lost the state
+// receiver in every backend (Kani/proptest `if !((active == 0))`, Lean
+// `if active = 0`) — none of which compile. Handler params (`amount`) must
+// stay bare. Filed against v2.38.0; spec shape is the reporter's repro:
+// record-form state (`type State = { … }`), no accounts block.
+
+spec GenericVault
+program_id "11111111111111111111111111111111"
+
+type State = {
+  active : U8,
+  rate   : U16,
+  fee    : U64,
+  cut    : U64,
+}
+
+type Error | Unauthorized
+
+handler execute (amount : U64) : State -> State {
+  permissionless
+  requires active == 0 else Unauthorized
+  requires amount > 0 else Unauthorized
+  effect {
+    fee := amount
+    cut := fee
+  }
+}
+
+property conservation :
+  (state.cut + state.fee) == state.fee
+  preserved_by all

--- a/references/qedspec-dsl.md
+++ b/references/qedspec-dsl.md
@@ -606,6 +606,16 @@ handler transfer_sol { ... }
 | `takes { ... }` | Parameters (sugar, prefer signature) | `takes amount : U64` |
 | `abstract` (v2.29) | Existentially-quantified value the handler refers to in `requires` / `effect` / `ensures` without expressing how it was computed. | `abstract d : U64` |
 
+**Name resolution in `requires` / `ensures` / `let`:** a bare identifier
+resolves innermost-binding-first — expression binders (`forall` / `exists` /
+`sum` / `let … in` / match-arm payloads), then handler params, `let`
+bindings, `abstract` binders, account names, and consts — and finally falls
+back to the state fields, where `active` reads the same slot as
+`state.active` (both render through the state receiver: `s.active` in
+Rust-side harnesses, `s.active` in the Lean transition). A name that
+resolves to nothing is a check error (`unknown_guard_identifier`) rather
+than non-compiling generated code.
+
 #### `abstract <name> : <Type>` (v2.29)
 
 When a handler's spec depends on a value that comes from a library call or


### PR DESCRIPTION
Fixes #139.

## Problem

`requires active == 0` (bare state-field name) parsed cleanly, but nothing resolved the bare identifier against the state fields — only `state.`-rooted paths picked up the state receiver at render time. The name reached **every backend** verbatim, not just Kani as filed:

- Kani / proptest: `if !((active == 0) && (amount > 0))` — `cannot find value 'active'`
- Lean: `if active = 0 ∧ amount > 0` — doesn't elaborate
- only effect-RHS resolution handled bare fields (which is why `s.cut = s.fee` came out right in the reporter's dump)

Worse, `qedgen check` passed such specs with warnings only — lint never resolved guard identifiers, so a spec whose codegen compiles nowhere sailed through green.

The trigger is record-form state (`type State = { … }`) with no accounts block: `TypeEnv.state_fields` only carried ADT-variant fields + ghosts, while record-form fields live in `records["State"]` — every bundled fixture happened to use `state.`-prefixed refs or ADT/account shapes, so nothing ever caught it.

## Fix

**One seam, all consumers.** New `spec/chumsky_adapter/canon.rs`: shadow-aware canonicalization on the typed AST, before the Lean/Rust string projections and before `ast_body` is stored. A bare path root that matches a state field — and is not shadowed by a param, const, account, handler `let`, `abstract` binder, the `auth` actor, or an expression-level binder (`forall`/`exists`/`sum`/`let … in`/match-arm payloads) — rewrites to a `state.`-rooted path. Applied to `requires`, `ensures`, handler `let`s, and match-arm guards. Lean, Kani, proptest, and the MIR all inherit; no per-backend string patching.

**Check gap closed.** New `unknown_guard_identifier` lint (Error, P0): post-canonicalization, a `requires` name that resolves to nothing fires at check time instead of producing non-compiling codegen — including `state.<typo>` on undeclared fields. sBPF specs are exempt (their requires vocabulary — `pda_derivation_succeeds`, `instruction_data_len`, account attrs — resolves against the input layout, not the state model).

## Validation

- Reporter's repro now emits `if !((s.active == 0) && (amount > 0))` (Kani/proptest) and `if s.active = 0 ∧ amount > 0` (Lean); params stay bare.
- Regression fixture at `crates/qedgen/tests/fixtures/regressions/issue-139-bare-state-refs/` + tests in the adapter (canonicalization + shadowing precedence), `kani_mir`, `lean_gen_mir`, and the lint module.
- Generated proptest harness for the fixture compiles in a scratch cargo project.
- Lint false-positive sweep over every bundled example + fixture spec: zero hits.
- `check --regen-drift` over all 8 committed examples: clean (no committed codegen output changes).
- Full `cargo test`: 17/17 suites green, including all four snapshot suites.
- DSL name-resolution rule documented in `references/qedspec-dsl.md`.

## Known follow-ups (out of scope)

Schema `requires` (adapted outside handler scope), ghost-update RHS, and CPI call args still miss canonicalization — same fix shape if they bite. `ensures` isn't linted (`ParsedEnsures` carries no `ast_body`).
