### PR TITLE
feat(codegen): make generate_guards MIR-direct for its handler-structure surface

### DIFF
--- a/crates/qedgen/src/codegen/codegen_mir.rs
+++ b/crates/qedgen/src/codegen/codegen_mir.rs
@@ -59,10 +59,18 @@ trait FrameworkCodegen {
     }
 
     fn emit_guards(&self, ctx: &CodegenCtx<'_>) -> Result<()> {
-        // Guards stay ParsedSpec-based: they render account-constraint
-        // surface (signer/writable flags, pda_seeds, variant-payload fields),
-        // not effect-body `Stmt` IR (see `codegen_shared`).
-        crate::codegen_shared::generate_guards(ctx.parsed, ctx.fp, ctx.output_dir, self.target())
+        // Guards render the account-constraint surface (signer/writable flags,
+        // pda_seeds, variant-payload fields) + per-handler requires/aborts. The
+        // emitter is being migrated to read these off `&Mir` (matching the other
+        // MIR-direct emitters); `ctx.parsed` stays threaded for the not-yet-
+        // lifted reads (helpers, let-bindings) until those land.
+        crate::codegen_shared::generate_guards(
+            ctx.mir,
+            ctx.parsed,
+            ctx.fp,
+            ctx.output_dir,
+            self.target(),
+        )
     }
 
     fn emit_math(&self, ctx: &CodegenCtx<'_>) -> Result<()> {

--- a/crates/qedgen/src/codegen/codegen_shared/guards.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/guards.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::mir::Mir;
 
 /// True if any rendered Rust expression in the spec references one of the
 /// fixed-point helpers in `src/math.rs`. Used to gate the `use crate::math::*;`
@@ -40,6 +41,7 @@ pub(crate) fn guards_use_math_helpers(spec: &ParsedSpec) -> bool {
 /// spec-declared guard checks. This file is always regenerated; any edit
 /// is clobbered on the next `qedgen codegen` (by design).
 pub(crate) fn generate_guards(
+    mir: &Mir,
     spec: &ParsedSpec,
     fp: &SpecFingerprint,
     output_dir: &Path,
@@ -97,14 +99,18 @@ pub(crate) fn generate_guards(
     // `instructions/<name>.rs` and re-exports via `instructions::*`.
     out.push_str(surface.guard_accounts_import());
 
-    for handler in &spec.handlers {
+    // Walk MIR handlers in lockstep with their ParsedSpec source (1:1, same
+    // order — `mir.handlers = parsed.handlers.map(lower_handler)`). `hm` is the
+    // migration target; reads move from `handler`/`spec` to `hm`/`mir` slice by
+    // slice, gated byte-identical by `codegen_snapshot`.
+    for (hm, handler) in mir.handlers.iter().zip(&spec.handlers) {
         let pascal = to_pascal_case(&handler.name);
-        let any_mut = handler.accounts.iter().any(|a| a.is_writable);
+        let any_mut = hm.accounts.iter().any(|a| a.writable);
         let self_ref = if any_mut { "&mut " } else { "&" };
         // v2.29 — match the handler-scaffold + Accounts-struct
         // lifetime decision so the guard fn's ctx ref doesn't
         // reference an unused `<'info>` on a unit Accounts struct.
-        let handler_needs_lifetime = !handler.accounts.is_empty() || handler.who.is_some();
+        let handler_needs_lifetime = !hm.accounts.is_empty() || hm.auth.is_some();
         let lp: &str = if handler_needs_lifetime {
             &lifetime_params
         } else {
@@ -569,7 +575,7 @@ pub(crate) fn generate_guards(
         // reference an abstract binder can't run in the guard fn (the
         // binder is computed AFTER the guard fires in the handler
         // scaffold). Defer to the handler body and document the skip.
-        let abstract_binder_names: Vec<&str> = handler
+        let abstract_binder_names: Vec<&str> = hm
             .abstract_binders
             .iter()
             .map(|(n, _)| n.as_str())


### PR DESCRIPTION
Seam checkpoint toward Phase 6 (full codegen→MIR migration / ParsedSpec deletion from codegen).

`generate_guards` was the lone `codegen_mir` emitter still taking only `ctx.parsed`; every other emitter (events / errors / instructions / ref_impls / imported_mirror) already takes `&Mir`. This threads `&Mir` in and migrates the handler-structure reads MIR canonically owns:

- `any_mut` — from `AccountBindingShape.writable`
- the lifetime decision (accounts/auth)
- abstract-binder names

walked via `mir.handlers` in lockstep with `spec.handlers` (1:1, same order, by construction of `lower_handler`).

`ctx.parsed` stays threaded for reads not yet liftable — per-clause requires (MIR drops the in-order + error pairing), raw PDA seed tokens, let-bindings, and the shared helpers used across the whole codegen. Those move in the broader Phase 6 pass, which needs 3 MIR extensions and stays queued.

## Validation

- Byte-identical output: `codegen_snapshot` green (the byte-equivalence gate for this refactor).
- Rebased onto main past #140 (the canon.rs seam); full `cargo test` 17/17 suites green post-rebase; fmt + clippy clean.
