### PR TITLE
chore(release): v2.39.0 — effect RHS rendered per-backend from the typed AST (#143–#146)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.38.0"
+version = "2.39.0"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.38.0"
+version = "2.39.0"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/src/check/lints/structural.rs
+++ b/crates/qedgen/src/check/lints/structural.rs
@@ -315,6 +315,105 @@ pub(super) fn check_vacuous_property_lowering(spec: &ParsedSpec) -> Vec<Complete
     warnings
 }
 
+/// `unknown_guard_identifier` (issue #139 follow-up): a `requires` clause
+/// references a name that resolves to nothing — not a state field (those
+/// were canonicalized to `state.`-rooted paths at adapt time), not a param,
+/// account, const, `let` binding, abstract binder, CPI result binding, or
+/// auth actor. The string projections carry the name verbatim, so every
+/// generated backend (Lean transition, Kani harness, proptest model) fails
+/// to compile while `check` used to stay green. Also catches `state.<typo>`
+/// where the field segment isn't declared.
+///
+/// sBPF specs are exempt: their handler requires speak a runtime-input
+/// vocabulary (`instruction_data_len`, `pda_derivation_succeeds`,
+/// `derived_pda`, account attrs) that resolves against the input layout,
+/// not the state model.
+pub(super) fn check_unknown_guard_identifier(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
+    use crate::chumsky_adapter::GuardPathRef;
+
+    let mut warnings = Vec::new();
+    if spec.is_assembly_target() {
+        return warnings;
+    }
+
+    // Every declared state-field name, across representations: flat view,
+    // per-account-type fields + ADT variant fields, and ghosts (rendered as
+    // state fields).
+    let mut state_fields: std::collections::BTreeSet<&str> =
+        spec.state_fields.iter().map(|(n, _)| n.as_str()).collect();
+    for at in &spec.account_types {
+        state_fields.extend(at.fields.iter().map(|(n, _)| n.as_str()));
+        for v in &at.variants {
+            state_fields.extend(v.fields.iter().map(|(n, _)| n.as_str()));
+        }
+    }
+    if let Some(r) = spec.records.iter().find(|r| r.name == "State") {
+        state_fields.extend(r.fields.iter().map(|(n, _)| n.as_str()));
+    }
+    state_fields.extend(spec.ghosts.iter().map(|g| g.name.as_str()));
+
+    let consts: std::collections::BTreeSet<&str> =
+        spec.constants.iter().map(|(n, _)| n.as_str()).collect();
+
+    for h in &spec.handlers {
+        let mut known: std::collections::BTreeSet<&str> = consts.clone();
+        known.extend(h.takes_params.iter().map(|(n, _)| n.as_str()));
+        known.extend(h.accounts.iter().map(|a| a.name.as_str()));
+        known.extend(h.let_bindings.iter().map(|(n, _, _)| n.as_str()));
+        known.extend(h.abstract_binders.iter().map(|(n, _)| n.as_str()));
+        known.extend(h.calls.iter().filter_map(|c| c.result_binding.as_deref()));
+        if let Some(who) = &h.who {
+            known.insert(who.as_str());
+        }
+
+        // Dedup per handler: one finding per unresolved name.
+        let mut reported: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for req in &h.requires {
+            let Some(ast) = &req.ast_body else { continue };
+            for r in crate::chumsky_adapter::collect_guard_path_refs(ast) {
+                let (name, is_state_ref) = match r {
+                    GuardPathRef::Bare(n) => (n, false),
+                    GuardPathRef::StateField(f) => (f, true),
+                };
+                let resolves = if is_state_ref {
+                    state_fields.contains(name.as_str())
+                } else {
+                    known.contains(name.as_str()) || state_fields.contains(name.as_str())
+                };
+                if resolves || !reported.insert(name.clone()) {
+                    continue;
+                }
+                let display = if is_state_ref {
+                    format!("state.{name}")
+                } else {
+                    name.clone()
+                };
+                warnings.push(CompletenessWarning {
+                    rule: "unknown_guard_identifier".to_string(),
+                    severity: Severity::Error,
+                    priority: 0,
+                    message: format!(
+                        "handler '{}' references `{}` in a `requires` clause, but it \
+                         resolves to nothing — not a state field, parameter, account, \
+                         const, or binding. Generated code carries the name verbatim \
+                         and won't compile in any backend.",
+                        h.name, display
+                    ),
+                    subject: Some(h.name.clone()),
+                    fix: format!(
+                        "Declare `{name}` (state field, param, or const) or fix the \
+                         reference to an existing name."
+                    ),
+                    example: None,
+                    counterexample: None,
+                    fix_options: vec![],
+                });
+            }
+        }
+    }
+    warnings
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -755,103 +854,4 @@ handler initialize : State.Uninitialized -> State.Active {
             "sBPF requires vocabulary resolves against the input layout, not state"
         );
     }
-}
-
-/// `unknown_guard_identifier` (issue #139 follow-up): a `requires` clause
-/// references a name that resolves to nothing — not a state field (those
-/// were canonicalized to `state.`-rooted paths at adapt time), not a param,
-/// account, const, `let` binding, abstract binder, CPI result binding, or
-/// auth actor. The string projections carry the name verbatim, so every
-/// generated backend (Lean transition, Kani harness, proptest model) fails
-/// to compile while `check` used to stay green. Also catches `state.<typo>`
-/// where the field segment isn't declared.
-///
-/// sBPF specs are exempt: their handler requires speak a runtime-input
-/// vocabulary (`instruction_data_len`, `pda_derivation_succeeds`,
-/// `derived_pda`, account attrs) that resolves against the input layout,
-/// not the state model.
-pub(super) fn check_unknown_guard_identifier(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
-    use crate::chumsky_adapter::GuardPathRef;
-
-    let mut warnings = Vec::new();
-    if spec.is_assembly_target() {
-        return warnings;
-    }
-
-    // Every declared state-field name, across representations: flat view,
-    // per-account-type fields + ADT variant fields, and ghosts (rendered as
-    // state fields).
-    let mut state_fields: std::collections::BTreeSet<&str> =
-        spec.state_fields.iter().map(|(n, _)| n.as_str()).collect();
-    for at in &spec.account_types {
-        state_fields.extend(at.fields.iter().map(|(n, _)| n.as_str()));
-        for v in &at.variants {
-            state_fields.extend(v.fields.iter().map(|(n, _)| n.as_str()));
-        }
-    }
-    if let Some(r) = spec.records.iter().find(|r| r.name == "State") {
-        state_fields.extend(r.fields.iter().map(|(n, _)| n.as_str()));
-    }
-    state_fields.extend(spec.ghosts.iter().map(|g| g.name.as_str()));
-
-    let consts: std::collections::BTreeSet<&str> =
-        spec.constants.iter().map(|(n, _)| n.as_str()).collect();
-
-    for h in &spec.handlers {
-        let mut known: std::collections::BTreeSet<&str> = consts.clone();
-        known.extend(h.takes_params.iter().map(|(n, _)| n.as_str()));
-        known.extend(h.accounts.iter().map(|a| a.name.as_str()));
-        known.extend(h.let_bindings.iter().map(|(n, _, _)| n.as_str()));
-        known.extend(h.abstract_binders.iter().map(|(n, _)| n.as_str()));
-        known.extend(h.calls.iter().filter_map(|c| c.result_binding.as_deref()));
-        if let Some(who) = &h.who {
-            known.insert(who.as_str());
-        }
-
-        // Dedup per handler: one finding per unresolved name.
-        let mut reported: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-        for req in &h.requires {
-            let Some(ast) = &req.ast_body else { continue };
-            for r in crate::chumsky_adapter::collect_guard_path_refs(ast) {
-                let (name, is_state_ref) = match r {
-                    GuardPathRef::Bare(n) => (n, false),
-                    GuardPathRef::StateField(f) => (f, true),
-                };
-                let resolves = if is_state_ref {
-                    state_fields.contains(name.as_str())
-                } else {
-                    known.contains(name.as_str()) || state_fields.contains(name.as_str())
-                };
-                if resolves || !reported.insert(name.clone()) {
-                    continue;
-                }
-                let display = if is_state_ref {
-                    format!("state.{name}")
-                } else {
-                    name.clone()
-                };
-                warnings.push(CompletenessWarning {
-                    rule: "unknown_guard_identifier".to_string(),
-                    severity: Severity::Error,
-                    priority: 0,
-                    message: format!(
-                        "handler '{}' references `{}` in a `requires` clause, but it \
-                         resolves to nothing — not a state field, parameter, account, \
-                         const, or binding. Generated code carries the name verbatim \
-                         and won't compile in any backend.",
-                        h.name, display
-                    ),
-                    subject: Some(h.name.clone()),
-                    fix: format!(
-                        "Declare `{name}` (state field, param, or const) or fix the \
-                         reference to an existing name."
-                    ),
-                    example: None,
-                    counterexample: None,
-                    fix_options: vec![],
-                });
-            }
-        }
-    }
-    warnings
 }

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/lending.codegen.txt
+++ b/crates/qedgen/tests/snapshots/lending.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 anchor-lang = "0.32.1"
 

--- a/crates/qedgen/tests/snapshots/percolator.codegen.txt
+++ b/crates/qedgen/tests/snapshots/percolator.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 anchor-lang = "0.32.1"
 

--- a/docs/prds/RELEASE-v2.39.0.md
+++ b/docs/prds/RELEASE-v2.39.0.md
@@ -1,0 +1,99 @@
+# QEDGen v2.39.0 — effect RHS rendered per-backend from the typed AST (#143–#146)
+
+**Status:** release-prep (on `chore/release-v2.39.0`). **Theme:** xeroc's
+v2.38.0 Kani-codegen quartet (#143 #144 #145 #146), fixed at one root cause
+in PR #147, plus the crucible wallet-lamport guard broadening merged to
+`main` since v2.38.0.
+
+## What shipped
+
+### 1. Effect RHS renders per-backend from the canonicalized typed AST (#143, #144)
+
+The adapter's `render_effect` used to lower compound effect RHS **once, in
+Lean form, with an empty type env and no canonicalization**; that single
+string flowed verbatim into MIR `Expr.rust` (`Expr::from_raw`) and out
+through every backend. Consequences: ref_impl calls emitted ML application
+syntax (`(bps_mul (amount) (rate))`), `if … then … else` passed through
+unlowered, state fields lost their receiver — and the **Lean backend was
+broken by the same string** (`residual := fee - cut` rendered `s.fee - cut`
+with `cut` unbound; the downstream heuristic only prefixes the front of
+the string).
+
+Now `render_effect_rhs_forms` canonicalizes the RHS AST (the #139
+`canon.rs` seam) and renders both forms — Lean via `expr_to_lean` with the
+real env, Rust via `expr_to_rust` — threading the Rust form through
+`ParsedHandler::effects_rust` / `ParsedEffectArm::effects_rust` →
+`lower_effects` → MIR `Expr.rust`. Simple RHS shapes (params, literals,
+bare fields) keep the legacy single-form string, so binder-specific
+resolution downstream (`resolve_value`, Anchor `mechanize_effect`) is
+byte-identical — the Anchor/Quasar scaffold outputs did not change.
+
+### 2. `mul_div_floor` in ref_impl bodies (#145)
+
+Two bugs: `guards_use_math_helpers` only probed requires/aborts/ensures/
+lets — a `mul_div_floor` used *only* inside a `ref_impl` body never
+triggered the inline `mul_div_floor_u128` helper emission — and even with
+the helper present, the generated fn had a u128-typed body against its
+declared-width signature. The gate now probes ref_impl bodies + effect
+RHS, and the ref_impl body narrows back to the declared return width
+(`(…) as u64`), the same precedent as `let X = mul_div_floor(…)`.
+
+### 3. Checked / math-exact arithmetic in the harness lane (#146)
+
+- **Predicates** (requires / properties / ensures): new math-exact render
+  (`RustOpts::widen_arith`), stored in parallel `rust_expr_math` /
+  `rust_expression_math` / `rust_expr_binary_math` fields (MIR
+  `Expr::rust_math` / `rust_binary_math`) and preferred by the
+  Kani/proptest emitters. Arithmetic inside comparisons evaluates in
+  u128/i128 — `-` on unsigned kinds saturates (Nat monus), `/`·`%` follow
+  Lean's total-function convention — so the predicate computes exactly
+  what the Lean `Nat` model computes and can never overflow-panic on
+  unconstrained symbolic state. The `(a * b) / 10000` shape is exempt so
+  the solver-tuned `mul_bps_floor_u128` rewrite keeps firing.
+- **Effect RHS**: bare `+`/`-`/`*`/`/`/`%` in `:=` bodies lowers checked
+  (`RustOpts::checked_arith` → `(a).checked_sub(b)?` inside an
+  `(|| Some(…))()` closure; `None` → transition returns `false`),
+  extending the v2.7 checked `+=`/`-=` doctrine.
+- **Documented divergence** (`references/qedspec-dsl.md` § Bare arithmetic
+  in `:=` RHS and predicates): Lean `Nat` subtraction in a `:=` RHS is
+  monus while the harness rejects on underflow; auto bound-guards on the
+  Lean transition are follow-up (#148). Workaround: write the guard
+  explicitly (`requires fee >= cut`) — both models then agree.
+
+### 4. Crucible wallet-lamport guard (merged to `main` since v2.38.0)
+
+The brownfield lamport-inflation guard's tracked set broadened from signer
+keypairs to **every fuzzer-controlled fixture keypair** (signers AND
+non-signer writables, PDA vault excluded) — a drain crediting a plain
+writable `recipient` (the textbook missing-authority withdraw, where no
+signer gains) now fires `assert_no_wallet_inflation`.
+
+## Compatibility notes
+
+- No CLI change. No `.qedspec` DSL syntax change — the DSL reference gains
+  the bare-arithmetic semantics section.
+- Generated **Anchor/Quasar scaffold** output: unchanged beyond the
+  version-tag re-stamp.
+- Generated **Kani/proptest harnesses** change where specs use compound
+  effect RHS or arithmetic inside predicates: previously-broken shapes now
+  compile; arithmetic predicates render widened. Bundled multisig /
+  percolator harnesses + the 5 affected snapshots regenerated.
+- Generated **Lean** changes only for compound effect RHS (previously
+  emitted unbound bare fields — did not elaborate).
+- Regression fixture: `crates/qedgen/tests/fixtures/regressions/issues-143-146-kani-arith/`
+  with a `syn::parse_file` gate over the whole emitted harness.
+
+## Gates (RELEASING.md)
+
+`fmt` · `clippy -D warnings` (incl. moving `check_unknown_guard_identifier`
+above the test module for clippy 1.94's `items_after_test_module`) ·
+`cargo test` (17 suites) · `check-readme-drift` (21 cmds) · `regen-drift`
+(8/8 clean) · `frozen` (8/8) · zero unintended `sorry` · `cargo audit` +
+`cargo deny` — all green locally + CI on PR #147.
+
+`check-lake-build.sh --strict`: 9/10 examples report *cold-checkout*
+(`.lake/` caches cleaned locally for disk pressure — the v2.34 lesson);
+`escrow` rebuilt green end-to-end (incl. the qedsvm bridge), and
+`regen-drift` proves every committed `Spec.lean` is byte-identical to
+v2.38.0, which shipped with the gate green. No Lean-facing output changed
+for any bundled example in this release.

--- a/examples/rust/cross-program-vault/programs/Cargo.toml
+++ b/examples/rust/cross-program-vault/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/examples/rust/lending/Cargo.toml
+++ b/examples/rust/lending/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/examples/rust/multisig/Cargo.toml
+++ b/examples/rust/multisig/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/examples/rust/percolator/programs/Cargo.toml
+++ b/examples/rust/percolator/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.38.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.39.0" }
 
 [workspace]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "Agent skill for spec-driven verification and audit of Solana programs \u2014 .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
Release cut for **v2.39.0**. Bundles PR #147 (xeroc's Kani-codegen quartet #143–#146, fixed at one root cause) and the crucible wallet-lamport guard broadening (a15c0d3) merged to `main` since v2.38.0.

Full notes: [`docs/prds/RELEASE-v2.39.0.md`](https://github.com/QEDGen/solana-skills/blob/chore/release-v2.39.0/docs/prds/RELEASE-v2.39.0.md).

## In this PR

- Version bump `2.38.0 → 2.39.0` (Cargo.toml + package.json, `check-version-consistency` clean)
- `qedgen-macros` tag re-stamp across 6 codegen snapshots + 8 bundled-example `Cargo.toml`s — verified tag-line-only diffs; `regen-drift` clean (8/8)
- `check_unknown_guard_identifier` moved above the test module (clippy 1.94 `items_after_test_module`, pre-existing from #140)
- Release notes doc

## Gate status (RELEASING.md)

`fmt` · `clippy -D warnings` · `cargo test` · `check-readme-drift` (21 cmds) · `regen-drift` · `frozen` (8/8) · zero unintended `sorry` · `cargo audit` + `cargo deny` — all green locally; CI green on #147.

`check-lake-build.sh --strict`: 9/10 examples report **cold checkout** (local `.lake` caches were cleaned for disk pressure — the v2.34 lesson), not build failures. `escrow` rebuilt green end-to-end (incl. the qedsvm rust bridge), and `regen-drift` proves every committed `Spec.lean` is byte-identical to v2.38.0, which shipped with this gate green — no Lean-facing output changed for any bundled example in this release.

Tag `v2.39.0` after merge.