### PR TITLE
fix(examples): migrate sbpf proofs to qedsvm v0.9.0 semantics (#154)

### DIFF
--- a/examples/sbpf/slippage/formal_verification/Spec.lean
+++ b/examples/sbpf/slippage/formal_verification/Spec.lean
@@ -22,7 +22,14 @@ private theorem ea_tok (b : Nat) : effectiveAddr b TOKEN_ACCOUNT_BALANCE = b + 1
 /-! ## Property P1: slippage rejection
 
 SPEC.md §3.1 P1: When minimum_balance >= token_account_balance,
-the program MUST exit with code 1. -/
+the program MUST exit with code 1.
+
+The reject path logs "Slippage exceeded" before exiting. qedsvm ≥ v0.9.0
+models `sol_log_` faithfully (guarded 17-byte read at r1, log push) instead
+of a no-op, so the proof needs the message region readable. `h_rt_log` is
+stated at address 0 because asm2lean resolves the `.rodata` symbol `e` to 0
+(the lift does not lay out rodata); the hypothesis tracks the lifted
+program, not the deployed VA. -/
 
 set_option maxHeartbeats 800000 in
 theorem rejects_insufficient_balance
@@ -30,6 +37,7 @@ theorem rejects_insufficient_balance
     (minBal tokenBal : Nat)
     (h_rt_min : rt.containsRange (inputAddr + 10520) 8 = true)
     (h_rt_tok : rt.containsRange (inputAddr + 160) 8 = true)
+    (h_rt_log : rt.containsRange 0 17 = true)
     (h_min : readU64 mem (inputAddr + 10520) = minBal)
     (h_tok : readU64 mem (inputAddr + 160) = tokenBal)
     (h_slip : minBal ≥ tokenBal) :

--- a/examples/sbpf/transfer/formal_verification/Spec.lean
+++ b/examples/sbpf/transfer/formal_verification/Spec.lean
@@ -76,10 +76,19 @@ theorem rejects_insufficient_lamports
     (executeFn progAt (initState inputAddr mem rt) 20).exitCode = some E_INSUFFICIENT_LAMPORTS := by
   wp_exec [progAt] [ea_0, ea_88, ea_10344, ea_10424, ea_20680, ea_31032, ea_31040, ea_80]
 
-/-! ## P3: happy path → exit 0
+/-! ## P3: happy path → reaches the CPI boundary
 
-   All checks pass, balance sufficient → normal exit.
-   The program invokes sol_invoke_signed (CPI) then exits with r0 = 0. -/
+   All checks pass, balance sufficient → after the 15-instruction
+   validation prefix, control sits AT the `sol_invoke_signed` call
+   (pc 15) with no error, r2 = sender balance, r4 = transfer amount.
+
+   qedsvm ≥ v0.9.0 models the proof-facing CPI fail-closed (`Cpi.exec`
+   aborts rather than fabricate a successful no-effect invoke — audit
+   C4/C5), so the pre-v0.9 "exit 0 through the CPI" statement is no
+   longer provable, and was never sound. The boundary statement is the
+   honest claim this file's scope (the validation prefix) supports;
+   what the invoke is HANDED can be pinned with `SVM.Solana.cpiEnvelope`
+   once the CPI construction is lifted (the .s elides it). -/
 
 set_option maxHeartbeats 16000000 in
 theorem accepts_valid_transfer
@@ -102,8 +111,12 @@ theorem accepts_valid_transfer
     (h_amt   : readU64 mem (inputAddr + 31040) = amount)
     (h_bal   : readU64 mem (inputAddr + 80) = senderLamports)
     (h_suf   : senderLamports ≥ amount) :
-    (executeFn progAt (initState inputAddr mem rt) 20).exitCode = some 0 := by
+    (executeFn progAt (initState inputAddr mem rt) 15).pc = 15 ∧
+    (executeFn progAt (initState inputAddr mem rt) 15).exitCode = none ∧
+    (executeFn progAt (initState inputAddr mem rt) 15).regs.r2 = senderLamports ∧
+    (executeFn progAt (initState inputAddr mem rt) 15).regs.r4 = amount := by
   have h_not_lt : ¬(senderLamports < amount) := by omega
-  wp_exec [progAt] [ea_0, ea_88, ea_10344, ea_10424, ea_20680, ea_31032, ea_31040, ea_80]
+  refine ⟨?_, ?_, ?_, ?_⟩ <;>
+    wp_exec [progAt] [ea_0, ea_88, ea_10344, ea_10424, ea_20680, ea_31032, ea_31040, ea_80]
 
 end TransferProofs

--- a/examples/sbpf/tree/formal_verification/Spec.lean
+++ b/examples/sbpf/tree/formal_verification/Spec.lean
@@ -20,7 +20,10 @@ set_option maxRecDepth 4096
 /-! ## Initial state
 
    The tree program reads both r1 (input accounts buffer) and r2 (instruction
-   data pointer). Standard initState only sets r1. -/
+   data pointer). Standard initState only sets r1. (qedsvm ≥ v0.9.0 ships
+   `initState2` for this shape; kept local for the wp_exec bracket.)
+   `cuBudget` must be nonzero: runs are budget-metered (H5) and the field
+   defaults to 0, which halts after one step. 200000 = the tx default. -/
 
 @[simp] def treeInit (accts insn : Nat) (mem : Mem) (rt : RegionTable) : State where
   regs := { r1 := accts, r2 := insn, r10 := STACK_START + 0x1000 }
@@ -28,6 +31,7 @@ set_option maxRecDepth 4096
   regions := rt
   pc := 0
   exitCode := none
+  cuBudget := 200000
 
 /-! ## effectiveAddr helper for negative offset -/
 


### PR DESCRIPTION
Migrates the three sBPF example proof bodies that lagged the qedsvm v0.8.0 → v0.9.0 pin bump (v2.40.0 shipped with this debt documented; tracker #154, now closed). All three root causes were v0.9.0 semantic deltas — no asm2lean regen and no full re-proof needed:

## transfer — CPI is fail-closed now
`accepts_valid_transfer` claimed *exit 0 through the CPI*, which only ever held because the pre-v0.9 `Cpi.exec` stub fabricated a successful no-effect invoke — the exact unsoundness v0.9.0 closed (audit C4/C5). Restated as the boundary claim the file's validation-prefix scope supports:

> all 7 checks + balance check pass → after 15 steps control sits AT `sol_invoke_signed` (pc 15), `exitCode = none`, r2 = sender balance, r4 = transfer amount.

Conjunction goal via `refine ⟨?_, ?_, ?_, ?_⟩ <;> wp_exec […]`. Pinning what the invoke is *handed* can later use `SVM.Solana.cpiEnvelope`; the `.s` elides the CPI construction, so there is nothing more to lift today.

## slippage — `sol_log_` is modeled faithfully now
The reject path logs "Slippage exceeded" (17 bytes); v0.9.0's `Logging.execLog` does a guarded read at r1 + log push instead of a no-op. Added `h_rt_log : rt.containsRange 0 17` — stated at address 0 because asm2lean resolves the `.rodata` symbol to 0 (lift artifact, documented in-proof; root-cause fix filed as #157).

## tree — `State.cuBudget` defaults to 0 now
The `⊢ False` residual was not proof rot: v0.9.0 added budget metering (H5) and the hand-rolled `treeInit` left `cuBudget` at its 0 default, halting every run after one step. One line: `cuBudget := 200000` (the tx default, matching upstream `initState2`).

## Verification
Full `lake build` green on all three projects (warm caches: 26s / 9s / 11s Spec targets). Lake gate back to **10/10** across the bundled examples.

Closes #154.