### PR TITLE
feat(asm2lean): lay out .rodata symbols instead of resolving them to 0 (#157)

### DIFF
--- a/crates/qedgen/src/codegen/asm2lean.rs
+++ b/crates/qedgen/src/codegen/asm2lean.rs
@@ -36,13 +36,189 @@ struct AsmInsn {
     line_no: usize,
 }
 
+/// A `.rodata` symbol: label name, byte offset within the rodata blob, and
+/// its content bytes (accumulated across directives until the next label).
+#[derive(Debug, Clone)]
+struct RodataSymbol {
+    name: String,
+    offset: usize,
+    bytes: Vec<u8>,
+}
+
 struct ParsedProgram {
     equates: Vec<(String, i64)>,     // insertion-order
     equates_hex: HashSet<String>,    // names originally written in hex
     offset_symbols: HashSet<String>, // symbols used as memory offsets → typed Int
     instructions: Vec<AsmInsn>,
     labels: HashMap<String, usize>, // label → instruction index
+    rodata: Vec<RodataSymbol>,      // insertion-order (= layout order)
     warnings: Vec<String>,
+}
+
+/// Lean constant name for a `.rodata` symbol (`e` → `RODATA_e`).
+fn rodata_lean_name(sym: &str) -> String {
+    let sanitized: String = sym
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    format!("RODATA_{}", sanitized)
+}
+
+/// Parse a string literal starting at the first `"` in `s`. Returns the
+/// decoded bytes. Supports the common GAS escapes.
+fn parse_string_literal(s: &str, line_no: usize) -> Result<Vec<u8>> {
+    let start = s
+        .find('"')
+        .with_context(|| format!("line {}: expected string literal", line_no))?;
+    let mut bytes = Vec::new();
+    let mut chars = s[start + 1..].chars();
+    loop {
+        let c = chars
+            .next()
+            .with_context(|| format!("line {}: unterminated string literal", line_no))?;
+        match c {
+            '"' => return Ok(bytes),
+            '\\' => {
+                let esc = chars
+                    .next()
+                    .with_context(|| format!("line {}: dangling escape", line_no))?;
+                match esc {
+                    'n' => bytes.push(b'\n'),
+                    't' => bytes.push(b'\t'),
+                    'r' => bytes.push(b'\r'),
+                    '0' => bytes.push(0),
+                    '\\' => bytes.push(b'\\'),
+                    '"' => bytes.push(b'"'),
+                    'x' => {
+                        let h1 = chars.next().and_then(|c| c.to_digit(16));
+                        let h2 = chars.next().and_then(|c| c.to_digit(16));
+                        match (h1, h2) {
+                            (Some(a), Some(b)) => bytes.push((a * 16 + b) as u8),
+                            _ => bail!("line {}: bad \\x escape", line_no),
+                        }
+                    }
+                    other => bail!("line {}: unsupported escape '\\{}'", line_no, other),
+                }
+            }
+            other => {
+                let mut buf = [0u8; 4];
+                bytes.extend_from_slice(other.encode_utf8(&mut buf).as_bytes());
+            }
+        }
+    }
+}
+
+/// Parse one numeric argument (decimal or 0x hex, optionally negative).
+fn parse_rodata_num(s: &str, line_no: usize) -> Result<i64> {
+    let s = s.trim();
+    let (neg, body) = match s.strip_prefix('-') {
+        Some(rest) => (true, rest.trim()),
+        None => (false, s),
+    };
+    let v = if let Some(hex) = body.strip_prefix("0x").or_else(|| body.strip_prefix("0X")) {
+        i64::from_str_radix(hex, 16)
+    } else {
+        body.parse::<i64>()
+    }
+    .with_context(|| format!("line {}: bad numeric literal '{}'", line_no, s))?;
+    Ok(if neg { -v } else { v })
+}
+
+/// Decode one `.rodata` data directive into bytes (little-endian for the
+/// multi-byte widths). Returns `None` (with a warning) for directives we
+/// don't lay out — the caller must then treat subsequent offsets as unknown.
+fn parse_rodata_directive(
+    line: &str,
+    line_no: usize,
+    warnings: &mut Vec<String>,
+) -> Result<Option<Vec<u8>>> {
+    let (dir, args) = match line.find(|c: char| c.is_whitespace()) {
+        Some(pos) => (&line[..pos], line[pos..].trim()),
+        None => (line, ""),
+    };
+    let width: usize = match dir {
+        ".ascii" => return parse_string_literal(args, line_no).map(Some),
+        ".asciz" | ".string" => {
+            let mut b = parse_string_literal(args, line_no)?;
+            b.push(0);
+            return Ok(Some(b));
+        }
+        ".byte" => 1,
+        ".short" | ".2byte" | ".half" => 2,
+        ".word" | ".long" | ".4byte" => 4,
+        ".quad" | ".8byte" | ".dword" => 8,
+        other => {
+            warnings.push(format!(
+                "line {}: unsupported .rodata directive '{}' — subsequent rodata offsets are unknown",
+                line_no, other
+            ));
+            return Ok(None);
+        }
+    };
+    let mut bytes = Vec::new();
+    for arg in args.split(',') {
+        let v = parse_rodata_num(arg, line_no)? as u64;
+        bytes.extend_from_slice(&v.to_le_bytes()[..width]);
+    }
+    Ok(Some(bytes))
+}
+
+/// State threaded through `.rodata` line parsing.
+#[derive(Default)]
+struct RodataState {
+    symbols: Vec<RodataSymbol>,
+    offset: usize,
+    /// A directive we can't lay out poisons every later offset.
+    layout_broken: bool,
+}
+
+fn parse_rodata_line(
+    line: &str,
+    line_no: usize,
+    st: &mut RodataState,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let mut rest = line;
+    if let Some(colon) = rest.find(':') {
+        let before = rest[..colon].trim();
+        if !before.is_empty()
+            && !before.contains(' ')
+            && !before.contains('"')
+            && !before.starts_with('.')
+        {
+            if st.layout_broken {
+                warnings.push(format!(
+                    "line {}: rodata symbol '{}' follows an un-layoutable directive — resolving to 0",
+                    line_no, before
+                ));
+            } else {
+                st.symbols.push(RodataSymbol {
+                    name: before.to_string(),
+                    offset: st.offset,
+                    bytes: Vec::new(),
+                });
+            }
+            rest = rest[colon + 1..].trim();
+        }
+    }
+    if rest.is_empty() {
+        return Ok(());
+    }
+    match parse_rodata_directive(rest, line_no, warnings)? {
+        Some(bytes) => {
+            st.offset += bytes.len();
+            if let Some(last) = st.symbols.last_mut() {
+                last.bytes.extend(bytes);
+            } else {
+                warnings.push(format!(
+                    "line {}: .rodata bytes before any label — laid out but unnameable",
+                    line_no
+                ));
+            }
+        }
+        None => st.layout_broken = true,
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -50,18 +226,37 @@ struct ParsedProgram {
 // ---------------------------------------------------------------------------
 
 fn strip_comment(line: &str) -> &str {
-    // Strip `//` comments, and `#` comments outside brackets.
-    let mut result = line;
-    if let Some(pos) = result.find("//") {
-        result = &result[..pos];
-    }
-    if let Some(pos) = result.find('#') {
-        let before = &result[..pos];
-        if before.matches('[').count() <= before.matches(']').count() {
-            result = &result[..pos];
+    // Strip `//` comments, and `#` comments outside brackets. Both markers
+    // are ignored inside string literals (`.ascii "a # b"` keeps its hash).
+    let bytes = line.as_bytes();
+    let mut in_str = false;
+    let mut escaped = false;
+    let mut bracket = 0i32;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_str = false;
+            }
+            i += 1;
+            continue;
         }
+        match c {
+            b'"' => in_str = true,
+            b'[' => bracket += 1,
+            b']' => bracket -= 1,
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => return line[..i].trim(),
+            b'#' if bracket <= 0 => return line[..i].trim(),
+            _ => {}
+        }
+        i += 1;
     }
-    result.trim()
+    line.trim()
 }
 
 fn parse_value(s: &str, _equates: &HashMap<String, i64>) -> Value {
@@ -194,8 +389,9 @@ fn parse(source: &str) -> Result<ParsedProgram> {
 
     // Intermediate: raw instruction lines (mnemonic, operand_text, line_no)
     let mut raw_insns: Vec<(String, String, usize)> = Vec::new();
+    let mut rodata_state = RodataState::default();
 
-    // ── Pass 1: collect .equ, labels, and raw instruction lines ──
+    // ── Pass 1: collect .equ, labels, .rodata, and raw instruction lines ──
     {
         let mut in_rodata = false;
         let mut pending_label: Option<String> = None;
@@ -206,11 +402,18 @@ fn parse(source: &str) -> Result<ParsedProgram> {
             if line.is_empty() {
                 continue;
             }
-            if line.starts_with(".rodata") {
+            if line.starts_with(".rodata")
+                || (line.starts_with(".section") && line.contains(".rodata"))
+            {
                 in_rodata = true;
                 continue;
             }
+            if line == ".text" || (line.starts_with(".section") && line.contains(".text")) {
+                in_rodata = false;
+                continue;
+            }
             if in_rodata {
+                parse_rodata_line(line, line_no + 1, &mut rodata_state, &mut warnings)?;
                 continue;
             }
 
@@ -326,6 +529,11 @@ fn parse(source: &str) -> Result<ParsedProgram> {
     }
 
     // Check for undefined symbols used in instructions (skip syscall names in `call`)
+    let rodata_names: HashSet<&str> = rodata_state
+        .symbols
+        .iter()
+        .map(|s| s.name.as_str())
+        .collect();
     for insn in &instructions {
         if insn.mnemonic == "call" {
             continue; // operand is a syscall name, not a symbol
@@ -336,7 +544,10 @@ fn parse(source: &str) -> Result<ParsedProgram> {
             | Operand::Imm(Value::NegSym(s))
             | Operand::Mem(_, Value::NegSym(s)) = op
             {
-                if !equates_map.contains_key(s) && !labels.contains_key(s) {
+                if !equates_map.contains_key(s)
+                    && !labels.contains_key(s)
+                    && !rodata_names.contains(s.as_str())
+                {
                     warnings.push(format!(
                         "line {}: undefined symbol '{}', using 0",
                         insn.line_no, s
@@ -352,6 +563,7 @@ fn parse(source: &str) -> Result<ParsedProgram> {
         offset_symbols,
         instructions,
         labels,
+        rodata: rodata_state.symbols,
         warnings,
     })
 }
@@ -380,12 +592,18 @@ fn lean_width(mnemonic: &str) -> &'static str {
 
 /// Format a value for use in the prog array — use named constants when available
 /// so that `simp` can match hypothesis terms syntactically (avoids abbrev unfolding).
-fn lean_value(v: &Value, equates: &HashMap<String, i64>) -> String {
+fn lean_value(
+    v: &Value,
+    equates: &HashMap<String, i64>,
+    rodata: &HashMap<String, String>,
+) -> String {
     match v {
         Value::Num(n) => format_num(*n),
         Value::Sym(s) => {
             if equates.contains_key(s) {
                 s.clone()
+            } else if let Some(name) = rodata.get(s) {
+                name.clone()
             } else {
                 format!("0 /- undefined: {} -/", s)
             }
@@ -415,6 +633,7 @@ fn format_num(n: i64) -> String {
 fn lean_imm_value(
     v: &Value,
     equates: &HashMap<String, i64>,
+    rodata: &HashMap<String, String>,
     _offset_symbols: &HashSet<String>,
 ) -> String {
     match v {
@@ -422,6 +641,8 @@ fn lean_imm_value(
         Value::Sym(s) => {
             if equates.contains_key(s) {
                 s.clone()
+            } else if let Some(name) = rodata.get(s) {
+                name.clone()
             } else {
                 format!("0 /- undefined: {} -/", s)
             }
@@ -440,6 +661,7 @@ fn lean_src(
     op: &Operand,
     equates: &HashMap<String, i64>,
     labels: &HashMap<String, usize>,
+    rodata: &HashMap<String, String>,
     offset_symbols: &HashSet<String>,
 ) -> String {
     match op {
@@ -451,7 +673,10 @@ fn lean_src(
                     return format!("{}", idx);
                 }
             }
-            format!("(.imm {})", lean_imm_value(v, equates, offset_symbols))
+            format!(
+                "(.imm {})",
+                lean_imm_value(v, equates, rodata, offset_symbols)
+            )
         }
         _ => "(.imm 0)".to_string(),
     }
@@ -481,6 +706,7 @@ fn emit_insn(
     insn: &AsmInsn,
     equates: &HashMap<String, i64>,
     labels: &HashMap<String, usize>,
+    rodata: &HashMap<String, String>,
     offset_symbols: &HashSet<String>,
 ) -> Result<String> {
     let mn = insn.mnemonic.as_str();
@@ -495,7 +721,7 @@ fn emit_insn(
             _ => bail!("line {}: ldx dst must be register", insn.line_no),
         };
         let (src, off) = match &ops[1] {
-            Operand::Mem(base, offset) => (lean_reg(base), lean_value(offset, equates)),
+            Operand::Mem(base, offset) => (lean_reg(base), lean_value(offset, equates, rodata)),
             _ => bail!("line {}: ldx src must be memory operand", insn.line_no),
         };
         return Ok(format!(".ldx {} {} {} {}", width, dst, src, off));
@@ -508,7 +734,7 @@ fn emit_insn(
         };
         let val = match &ops[1] {
             // lddw loads a Nat, so use imm_value for proper unsigned handling
-            Operand::Imm(v) => lean_imm_value(v, equates, offset_symbols),
+            Operand::Imm(v) => lean_imm_value(v, equates, rodata, offset_symbols),
             _ => bail!("line {}: lddw src must be immediate", insn.line_no),
         };
         return Ok(format!(".lddw {} {}", dst, val));
@@ -519,7 +745,7 @@ fn emit_insn(
         // stx{b,h,w,dw} [dst + off], src
         let width = lean_width(mn);
         let (dst, off) = match &ops[0] {
-            Operand::Mem(base, offset) => (lean_reg(base), lean_value(offset, equates)),
+            Operand::Mem(base, offset) => (lean_reg(base), lean_value(offset, equates, rodata)),
             _ => bail!("line {}: stx dst must be memory operand", insn.line_no),
         };
         let src = match &ops[1] {
@@ -534,12 +760,12 @@ fn emit_insn(
         let real_mn = if mn == "st" { "stdw" } else { mn };
         let width = lean_width(real_mn);
         let (dst, off) = match &ops[0] {
-            Operand::Mem(base, offset) => (lean_reg(base), lean_value(offset, equates)),
+            Operand::Mem(base, offset) => (lean_reg(base), lean_value(offset, equates, rodata)),
             _ => bail!("line {}: st dst must be memory operand", insn.line_no),
         };
         let imm = match &ops[1] {
             // st takes imm : Nat, so use imm_value for proper type handling
-            Operand::Imm(v) => lean_imm_value(v, equates, offset_symbols),
+            Operand::Imm(v) => lean_imm_value(v, equates, rodata, offset_symbols),
             _ => bail!("line {}: st src must be immediate", insn.line_no),
         };
         return Ok(format!(".st {} {} {} {}", width, dst, off, imm));
@@ -556,7 +782,7 @@ fn emit_insn(
             Operand::Reg(r) => lean_reg(r),
             _ => bail!("line {}: {} dst must be register", insn.line_no, mn),
         };
-        let src = lean_src(&ops[1], equates, labels, offset_symbols);
+        let src = lean_src(&ops[1], equates, labels, rodata, offset_symbols);
         return Ok(format!(".{} {} {}", mn, dst, src));
     }
 
@@ -578,7 +804,7 @@ fn emit_insn(
             Operand::Reg(r) => lean_reg(r),
             _ => bail!("line {}: {} dst must be register", insn.line_no, mn),
         };
-        let src = lean_src(&ops[1], equates, labels, offset_symbols);
+        let src = lean_src(&ops[1], equates, labels, rodata, offset_symbols);
         let target = lean_jump_target(&ops[2], equates, labels);
         return Ok(format!(".{} {} {} {}", mn, dst, src, target));
     }
@@ -628,6 +854,20 @@ pub fn extract_source_hash(lean_content: &str) -> Option<String> {
 pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<String> {
     let prog = parse(source)?;
     let equates_map: HashMap<String, i64> = prog.equates.iter().cloned().collect();
+    // .rodata layout: the program region base (BYTECODE_START = 0x100000000,
+    // where the loader's R_BPF_64_Relative patching lands sub-region
+    // addresses) + the .text size in binary slots (lddw occupies 2).
+    let text_slots: usize = prog
+        .instructions
+        .iter()
+        .map(|i| if i.mnemonic == "lddw" { 2 } else { 1 })
+        .sum();
+    let rodata_base: u64 = 0x1_0000_0000u64 + (text_slots as u64) * 8;
+    let rodata_names: HashMap<String, String> = prog
+        .rodata
+        .iter()
+        .map(|s| (s.name.clone(), rodata_lean_name(&s.name)))
+        .collect();
 
     for w in &prog.warnings {
         eprintln!("warning: {}", w);
@@ -667,6 +907,61 @@ pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<S
             } else {
                 writeln!(out, "abbrev {} : {} := {}", name, ty, val)?;
             }
+        }
+        writeln!(out)?;
+    }
+
+    if !prog.rodata.is_empty() {
+        writeln!(out, "/-! ## .rodata symbols\n")?;
+        writeln!(
+            out,
+            "Laid out in the program region: `BYTECODE_START` (0x100000000) + .text size"
+        )?;
+        writeln!(
+            out,
+            "({} binary slots × 8 bytes; `lddw` occupies 2 slots). Deployed VAs additionally",
+            text_slots
+        )?;
+        writeln!(
+            out,
+            "include ELF header/section offsets a source-level lift cannot see, so proofs"
+        )?;
+        writeln!(
+            out,
+            "MUST reference these symbols by name — a corrected base only shifts the"
+        )?;
+        writeln!(
+            out,
+            "numerals. Fidelity to the deployed binary is the binary lane's job (qedlift). -/\n"
+        )?;
+        for sym in &prog.rodata {
+            let name = &rodata_names[&sym.name];
+            let printable =
+                sym.bytes.iter().all(|&b| (0x20..0x7f).contains(&b)) && !sym.bytes.is_empty();
+            let preview = if printable {
+                format!("\"{}\"", String::from_utf8_lossy(&sym.bytes))
+            } else {
+                format!("{} raw bytes", sym.bytes.len())
+            };
+            writeln!(
+                out,
+                "/-- `{}` at rodata offset 0x{:x}: {} -/",
+                sym.name, sym.offset, preview
+            )?;
+            writeln!(
+                out,
+                "abbrev {} : Nat := 0x{:x}",
+                name,
+                rodata_base + sym.offset as u64
+            )?;
+            writeln!(out, "abbrev {}_LEN : Nat := {}", name, sym.bytes.len())?;
+            let byte_list = sym
+                .bytes
+                .iter()
+                .map(|b| format!("0x{:02x}", b))
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(out, "def {}_BYTES : ByteArray := ⟨#[{}]⟩", name, byte_list)?;
         }
         writeln!(out)?;
     }
@@ -713,6 +1008,11 @@ pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<S
                             if val >= 0 && !lddw_nat_syms.contains(s) {
                                 lddw_nat_syms.push(s.clone());
                             }
+                        } else if let Some(name) = rodata_names.get(s.as_str()) {
+                            // rodata addresses are Nat abbrevs loaded via lddw
+                            if !lddw_nat_syms.contains(name) {
+                                lddw_nat_syms.push(name.clone());
+                            }
                         }
                     }
                 }
@@ -753,7 +1053,13 @@ pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<S
 
             for idx in start..end {
                 let insn = &prog.instructions[idx];
-                let lean = emit_insn(insn, &equates_map, &prog.labels, &prog.offset_symbols)?;
+                let lean = emit_insn(
+                    insn,
+                    &equates_map,
+                    &prog.labels,
+                    &rodata_names,
+                    &prog.offset_symbols,
+                )?;
                 let comment = if let Some(ref lbl) = insn.label {
                     format!("-- {}: {}", idx, lbl)
                 } else {
@@ -778,7 +1084,13 @@ pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<S
 
         writeln!(out, "def prog : Program := #[")?;
         for (idx, insn) in prog.instructions.iter().enumerate() {
-            let lean = emit_insn(insn, &equates_map, &prog.labels, &prog.offset_symbols)?;
+            let lean = emit_insn(
+                insn,
+                &equates_map,
+                &prog.labels,
+                &rodata_names,
+                &prog.offset_symbols,
+            )?;
             let comma = if idx + 1 < n_insns { "," } else { "" };
             writeln!(out, "  {}{}", lean, comma)?;
         }
@@ -788,7 +1100,13 @@ pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<S
         writeln!(out, "@[simp] def prog : Program := #[")?;
 
         for (idx, insn) in prog.instructions.iter().enumerate() {
-            let lean = emit_insn(insn, &equates_map, &prog.labels, &prog.offset_symbols)?;
+            let lean = emit_insn(
+                insn,
+                &equates_map,
+                &prog.labels,
+                &rodata_names,
+                &prog.offset_symbols,
+            )?;
             let comma = if idx + 1 < prog.instructions.len() {
                 ","
             } else {
@@ -815,7 +1133,13 @@ pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<S
         // wp_exec dsimp lists in proof files both reference `progAt`.
         writeln!(out, "@[simp] def progAt : Nat → Option SVM.SBPF.Insn")?;
         for (idx, insn) in prog.instructions.iter().enumerate() {
-            let lean = emit_insn(insn, &equates_map, &prog.labels, &prog.offset_symbols)?;
+            let lean = emit_insn(
+                insn,
+                &equates_map,
+                &prog.labels,
+                &rodata_names,
+                &prog.offset_symbols,
+            )?;
             writeln!(out, "  | {} => some ({})", idx, lean)?;
         }
         writeln!(out, "  | _ => none\n")?;
@@ -829,7 +1153,13 @@ pub fn generate(source: &str, namespace: &str, input_filename: &str) -> Result<S
         writeln!(out, "/-! ## Instruction fetch cache -/\n")?;
         for idx in 0..n_insns {
             let insn = &prog.instructions[idx];
-            let lean = emit_insn(insn, &equates_map, &prog.labels, &prog.offset_symbols)?;
+            let lean = emit_insn(
+                insn,
+                &equates_map,
+                &prog.labels,
+                &rodata_names,
+                &prog.offset_symbols,
+            )?;
             writeln!(
                 out,
                 "@[simp] theorem insn_{} : progAt {} = some ({}) := by native_decide",
@@ -866,12 +1196,147 @@ pub fn asm2lean(input: &Path, output: &Path, namespace: Option<&str>) -> Result<
 
     crate::codegen_shared::write_generated_file(output, &lean_code)?;
 
+    let rodata_note = if prog.rodata.is_empty() {
+        String::new()
+    } else {
+        format!(", {} rodata symbols", prog.rodata.len())
+    };
     eprintln!(
-        "✓ Generated {} ({} instructions, {} constants)",
+        "✓ Generated {} ({} instructions, {} constants{})",
         output.display(),
         prog.instructions.len(),
         prog.equates.len(),
+        rodata_note,
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RODATA_SRC: &str = r#"
+.globl entrypoint
+entrypoint:
+    lddw r1, e
+    lddw r2, 17
+    call sol_log_
+    exit
+.rodata
+    e: .ascii "Slippage exceeded"
+"#;
+
+    #[test]
+    fn rodata_symbol_parsed_with_content() {
+        let prog = parse(RODATA_SRC).unwrap();
+        assert_eq!(prog.rodata.len(), 1);
+        assert_eq!(prog.rodata[0].name, "e");
+        assert_eq!(prog.rodata[0].offset, 0);
+        assert_eq!(prog.rodata[0].bytes, b"Slippage exceeded");
+        assert!(prog.warnings.is_empty(), "{:?}", prog.warnings);
+    }
+
+    #[test]
+    fn rodata_address_is_program_region_after_text() {
+        // 2 lddw (2 slots each) + call + exit = 6 slots × 8 = 0x30
+        let lean = generate(RODATA_SRC, "T", "t.s").unwrap();
+        assert!(
+            lean.contains("abbrev RODATA_e : Nat := 0x100000030"),
+            "{}",
+            lean
+        );
+        assert!(lean.contains("abbrev RODATA_e_LEN : Nat := 17"));
+        assert!(lean.contains(
+            "def RODATA_e_BYTES : ByteArray := ⟨#[0x53, 0x6c, 0x69, 0x70, 0x70, 0x61, 0x67, \
+             0x65, 0x20, 0x65, 0x78, 0x63, 0x65, 0x65, 0x64, 0x65, 0x64]⟩"
+        ));
+    }
+
+    #[test]
+    fn rodata_symbol_resolves_in_lddw_with_bridge() {
+        let lean = generate(RODATA_SRC, "T", "t.s").unwrap();
+        assert!(lean.contains(".lddw .r1 RODATA_e"), "{}", lean);
+        assert!(!lean.contains("undefined: e"), "{}", lean);
+        assert!(lean.contains("theorem bridge_RODATA_e : toU64 (↑RODATA_e : Int) = RODATA_e"));
+    }
+
+    #[test]
+    fn rodata_multi_symbol_offsets_and_widths() {
+        let src = r#"
+entrypoint:
+    exit
+.rodata
+    msg: .asciz "hi"
+    tbl: .byte 1, 2
+         .quad 0x0102
+    w:   .word 7
+"#;
+        let prog = parse(src).unwrap();
+        let syms: Vec<(&str, usize, usize)> = prog
+            .rodata
+            .iter()
+            .map(|s| (s.name.as_str(), s.offset, s.bytes.len()))
+            .collect();
+        // "hi\0" = 3 bytes; tbl = 2 + 8; w at 3 + 10
+        assert_eq!(syms, vec![("msg", 0, 3), ("tbl", 3, 10), ("w", 13, 4)]);
+        assert_eq!(
+            prog.rodata[1].bytes,
+            vec![1, 2, 0x02, 0x01, 0, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(prog.rodata[2].bytes, vec![7, 0, 0, 0]);
+    }
+
+    #[test]
+    fn rodata_string_escapes_and_comment_markers() {
+        let src = "entrypoint:\n    exit\n.rodata\n    m: .ascii \"a\\n# b // c\\\"\\x41\"\n";
+        let prog = parse(src).unwrap();
+        assert_eq!(prog.rodata[0].bytes, b"a\n# b // c\"A");
+    }
+
+    #[test]
+    fn rodata_section_directive_and_text_toggle() {
+        let src = "
+.section .rodata
+    m: .ascii \"x\"
+.section .text
+entrypoint:
+    lddw r1, m
+    exit
+";
+        let prog = parse(src).unwrap();
+        assert_eq!(prog.rodata.len(), 1);
+        assert_eq!(prog.instructions.len(), 2);
+        assert!(prog.warnings.is_empty(), "{:?}", prog.warnings);
+    }
+
+    #[test]
+    fn unsupported_rodata_directive_poisons_later_symbols() {
+        let src = "
+entrypoint:
+    lddw r1, b
+    exit
+.rodata
+    a: .ascii \"ok\"
+    .align 8
+    b: .byte 1
+";
+        let prog = parse(src).unwrap();
+        // `a` survives; `b` is dropped from layout and the lddw warns.
+        assert_eq!(prog.rodata.len(), 1);
+        assert_eq!(prog.rodata[0].name, "a");
+        assert!(prog.warnings.iter().any(|w| w.contains(".align")));
+        assert!(prog
+            .warnings
+            .iter()
+            .any(|w| w.contains("undefined symbol 'b'")));
+    }
+
+    #[test]
+    fn no_rodata_emits_no_section() {
+        let src = "entrypoint:\n    exit\n";
+        let lean = generate(src, "T", "t.s").unwrap();
+        assert!(!lean.contains(".rodata symbols"));
+        assert!(!lean.contains("RODATA_"));
+    }
 }

--- a/examples/sbpf/slippage/formal_verification/Program.lean
+++ b/examples/sbpf/slippage/formal_verification/Program.lean
@@ -13,6 +13,19 @@ open SVM.SBPF
 abbrev TOKEN_ACCOUNT_BALANCE : Int := 0xa0
 abbrev MINIMUM_BALANCE : Int := 0x2918
 
+/-! ## .rodata symbols
+
+Laid out in the program region: `BYTECODE_START` (0x100000000) + .text size
+(12 binary slots × 8 bytes; `lddw` occupies 2 slots). Deployed VAs additionally
+include ELF header/section offsets a source-level lift cannot see, so proofs
+MUST reference these symbols by name — a corrected base only shifts the
+numerals. Fidelity to the deployed binary is the binary lane's job (qedlift). -/
+
+/-- `e` at rodata offset 0x0: "Slippage exceeded" -/
+abbrev RODATA_e : Nat := 0x100000060
+abbrev RODATA_e_LEN : Nat := 17
+def RODATA_e_BYTES : ByteArray := ⟨#[0x53, 0x6c, 0x69, 0x70, 0x70, 0x61, 0x67, 0x65, 0x20, 0x65, 0x78, 0x63, 0x65, 0x65, 0x64, 0x65, 0x64]⟩
+
 /-! ## effectiveAddr lemmas -/
 
 section EffectiveAddr
@@ -27,6 +40,10 @@ open SVM.SBPF.Memory
 
 end EffectiveAddr
 
+/-! ## toU64 bridge lemmas (lddw constants) -/
+
+@[simp] theorem bridge_RODATA_e : toU64 (↑RODATA_e : Int) = RODATA_e := by native_decide
+
 /-! ## Program -/
 
 @[simp] def prog : Program := #[
@@ -34,7 +51,7 @@ end EffectiveAddr
   .ldx .dword .r4 .r1 TOKEN_ACCOUNT_BALANCE,       -- 1
   .jge .r3 (.reg .r4) 4,                           -- 2
   .exit,                                           -- 3
-  .lddw .r1 0 /- undefined: e -/,                  -- 4: end
+  .lddw .r1 RODATA_e,                              -- 4: end
   .lddw .r2 17,                                    -- 5
   .call .sol_log_,                                 -- 6
   .lddw .r0 1,                                     -- 7
@@ -46,7 +63,7 @@ end EffectiveAddr
   | 1 => some (.ldx .dword .r4 .r1 TOKEN_ACCOUNT_BALANCE)
   | 2 => some (.jge .r3 (.reg .r4) 4)
   | 3 => some (.exit)
-  | 4 => some (.lddw .r1 0 /- undefined: e -/)
+  | 4 => some (.lddw .r1 RODATA_e)
   | 5 => some (.lddw .r2 17)
   | 6 => some (.call .sol_log_)
   | 7 => some (.lddw .r0 1)
@@ -59,7 +76,7 @@ end EffectiveAddr
 @[simp] theorem insn_1 : progAt 1 = some (.ldx .dword .r4 .r1 TOKEN_ACCOUNT_BALANCE) := by native_decide
 @[simp] theorem insn_2 : progAt 2 = some (.jge .r3 (.reg .r4) 4) := by native_decide
 @[simp] theorem insn_3 : progAt 3 = some (.exit) := by native_decide
-@[simp] theorem insn_4 : progAt 4 = some (.lddw .r1 0 /- undefined: e -/) := by native_decide
+@[simp] theorem insn_4 : progAt 4 = some (.lddw .r1 RODATA_e) := by native_decide
 @[simp] theorem insn_5 : progAt 5 = some (.lddw .r2 17) := by native_decide
 @[simp] theorem insn_6 : progAt 6 = some (.call .sol_log_) := by native_decide
 @[simp] theorem insn_7 : progAt 7 = some (.lddw .r0 1) := by native_decide

--- a/examples/sbpf/slippage/formal_verification/Spec.lean
+++ b/examples/sbpf/slippage/formal_verification/Spec.lean
@@ -26,10 +26,9 @@ the program MUST exit with code 1.
 
 The reject path logs "Slippage exceeded" before exiting. qedsvm ≥ v0.9.0
 models `sol_log_` faithfully (guarded 17-byte read at r1, log push) instead
-of a no-op, so the proof needs the message region readable. `h_rt_log` is
-stated at address 0 because asm2lean resolves the `.rodata` symbol `e` to 0
-(the lift does not lay out rodata); the hypothesis tracks the lifted
-program, not the deployed VA. -/
+of a no-op, so the proof needs the message region readable: `h_rt_log`
+covers `RODATA_e` (the asm2lean-laid-out address of the `.rodata` string
+in the program region — see the layout note in Program.lean). -/
 
 set_option maxHeartbeats 800000 in
 theorem rejects_insufficient_balance
@@ -37,7 +36,7 @@ theorem rejects_insufficient_balance
     (minBal tokenBal : Nat)
     (h_rt_min : rt.containsRange (inputAddr + 10520) 8 = true)
     (h_rt_tok : rt.containsRange (inputAddr + 160) 8 = true)
-    (h_rt_log : rt.containsRange 0 17 = true)
+    (h_rt_log : rt.containsRange RODATA_e RODATA_e_LEN = true)
     (h_min : readU64 mem (inputAddr + 10520) = minBal)
     (h_tok : readU64 mem (inputAddr + 160) = tokenBal)
     (h_slip : minBal ≥ tokenBal) :

--- a/references/sbpf.md
+++ b/references/sbpf.md
@@ -31,11 +31,14 @@ $QEDGEN asm2lean --input src/program.s --output formal_verification/ProgramProg.
 
 This generates:
 - `abbrev` definitions for all `.equ` constants (offsets as `Int`, values as `Nat`)
+- `RODATA_<sym>` / `RODATA_<sym>_LEN` / `RODATA_<sym>_BYTES` for each `.rodata` symbol (`.ascii`/`.asciz`/`.byte`/`.short`/`.word`/`.quad`), laid out at `BYTECODE_START` + .text size (lddw = 2 slots). Reference these by NAME in proofs — the numeral approximates the deployed VA (ELF header/section offsets are invisible to a source lift); exact fidelity is the binary lane's job
 - `@[simp] def prog : Program` with named constants and index comments
 - For large programs (>64 instructions): `def progAt : Nat -> Option Insn` — chunked function-based lookup for O(1) simp performance
 - `@[simp] theorem ea_NAME` — effectiveAddr lemmas for each offset symbol
-- `@[simp] theorem bridge_NAME` — toU64 bridge lemmas for Nat lddw constants
+- `@[simp] theorem bridge_NAME` — toU64 bridge lemmas for Nat lddw constants (including rodata addresses)
 - `@[simp] theorem insn_N` — instruction fetch cache via `native_decide`
+
+Programs that `call sol_log_` on a rodata string need `rt.containsRange RODATA_<sym> RODATA_<sym>_LEN = true` as a hypothesis (qedsvm ≥ v0.9.0 models the guarded read); pin the logged bytes with `readBytes mem RODATA_<sym> RODATA_<sym>_LEN = RODATA_<sym>_BYTES` when the property needs message content.
 
 ### Assembly syntax reference
 


### PR DESCRIPTION
Closes #157 (filed during the #154 v0.9.0 proof migration).

## Problem
asm2lean skipped `.rodata` sections and lifted rodata symbols as `0 /- undefined: <sym> -/`. That was invisible while qedsvm modeled `sol_log_` as a no-op — but v0.9.0 models the guarded read, so a lifted program that logs a rodata string executes a 17-byte read at **address 0**, and proofs had to hypothesize a region at an address that exists in neither the model's memory map (M3: nothing is mapped at 0) nor any deployed binary.

## What this does
- **Parses `.rodata`**: labels + `.ascii`/`.asciz`/`.string`/`.byte`/`.short`/`.word`/`.quad` (little-endian widths, GAS string escapes), `.section` toggling back to `.text`, and a quote-aware comment stripper so `#`/`//` inside string literals survive.
- **Lays symbols out in the program region**: `BYTECODE_START` (0x100000000, where the loader's `R_BPF_64_Relative` patching lands sub-region addresses per qedsvm's Memory.lean) + .text size in binary slots × 8 (`lddw` = 2 slots).
- **Emits per symbol**: `abbrev RODATA_<sym>` (address, referenced by name in instructions), `abbrev RODATA_<sym>_LEN`, `def RODATA_<sym>_BYTES : ByteArray` (for pinning logged bytes), and a `toU64` bridge lemma when lddw-loaded — plus a generated layout note directing proofs to reference symbols **by name**, since the numeral approximates the deployed VA (ELF header/section offsets are invisible to a source-level lift; binary fidelity stays the binary lane's job).
- **Fails closed**: unsupported rodata directives (`.align` …) warn and poison later offsets back to the undefined-symbol path rather than emit wrong addresses.

## Example impact
- **slippage** regenerated: `lddw r1, e` → `.lddw .r1 RODATA_e` (0x100000060); `Spec.lean`'s `h_rt_log` now covers `RODATA_e RODATA_e_LEN` instead of address 0. `lake build` green.
- **transfer / counter / tree** regen **byte-identical** (no rodata) — the comment-stripper rewrite causes no churn.

## Verification
- 8 new unit tests in `asm2lean.rs` (parsing, offsets/widths, escapes, address math, bridge lemma, section toggling, fail-closed poisoning, no-rodata no-op)
- Full `cargo test` green (1082 unit + suites), `clippy -D warnings` clean, `fmt --check` clean
- `references/sbpf.md` updated (asm2lean output list + log-proof hypothesis guidance)