### PR TITLE
ci(kani): standing pin for the qedgen-kani-prelude soundness proofs (#188)

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,0 +1,58 @@
+# Standing pin for the qedgen-kani-prelude soundness proofs (#188).
+#
+# Every generated Kani harness leans on this crate's abstractions via
+# `#[kani::stub]`; their soundness argument is machine-checked here
+# (`kani_prelude/`, dependency-free — see its README). Path-filtered: the
+# proofs can only change when the crate (or this workflow) changes, because
+# the delivered copy is `include_str!`-embedded from these exact files.
+name: Kani
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'kani_prelude/**'
+      - '.github/workflows/kani.yml'
+  pull_request:
+    paths:
+      - 'kani_prelude/**'
+      - '.github/workflows/kani.yml'
+  workflow_dispatch:
+
+env:
+  # Keep in lock step with the version the prelude was developed against
+  # (kani_prelude/README.md). Bump deliberately, with a green local run.
+  KANI_VERSION: 0.67.0
+
+jobs:
+  prelude-soundness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # ~/.kani holds the toolchain + solver bundle `cargo kani setup`
+      # downloads (~200MB); the two binaries come from `cargo install`.
+      # Keyed on the pinned version only — the prelude is dependency-free,
+      # so nothing else affects the install.
+      - name: Cache Kani install
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/kani
+            ~/.cargo/bin/cargo-kani
+            ~/.kani
+          key: ${{ runner.os }}-kani-${{ env.KANI_VERSION }}
+
+      - name: Install Kani (pinned)
+        run: |
+          if ! command -v cargo-kani >/dev/null 2>&1; then
+            cargo install --locked kani-verifier --version "$KANI_VERSION"
+          fi
+          cargo kani setup
+
+      - name: Prelude soundness proofs
+        working-directory: kani_prelude
+        run: cargo kani


### PR DESCRIPTION
## What

Adds `.github/workflows/kani.yml`: a standing CI pin for the `kani_prelude/` soundness proofs — the machine-checked argument every generated Kani harness now leans on via `#[kani::stub]`. Until now the proofs were runnable in-repo but gated nowhere; a prelude edit could silently break them.

## Design

- **Pinned install**: `kani-verifier 0.67.0` (the version the prelude was developed against, per its README) via `cargo install --locked` + `cargo kani setup`, cached on the version key (`~/.kani` + the two binaries) so warm runs skip the ~200MB setup.
- **Path-filtered** to `kani_prelude/**` + the workflow itself: the delivered copy is `include_str!`-embedded from these exact files, so nothing else can change the proofs. Keeps the job off every unrelated PR.
- Separate workflow from `ci.yml` — the main `test` job's runtime is untouched.

## Acceptance

- Local: `cd kani_prelude && cargo kani` → 3/3 green.
- Mutation: flipping `wide_eq_32`'s `&&` to `||` fails exactly its equivalence harness (`VERIFICATION:- FAILED`, non-zero exit → red CI); revert restores 3/3 green.
- This PR touches the workflow, so the path filter fires and the job runs live below.

Closes #188.