### PR TITLE
fix framework-support gaps: agnostic probes everywhere (#196), Codama IDL ingestion (#197), doc drift (#198) + capability matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ See `examples/rust/escrow/formal_verification/VERIFICATION_SCOPE.md`.
 - [`references/sbpf.md`](references/sbpf.md) — sBPF workflow, `wp_exec`/`wp_step`, memory disjointness, simp-performance rules
 - [`references/support-library.md`](references/support-library.md) — `QEDGen.Solana` API
 - [`docs/design/`](docs/design/) — codegen / MIR architecture
+- [`docs/framework-support.md`](docs/framework-support.md) — per-framework capability matrix (Anchor / Quasar / Pinocchio / native / sBPF), gate-verified
 - [`docs/RELEASING.md`](docs/RELEASING.md) — **pre-release checklist (run before any tag)**
 - `SKILL.md` — the user-facing proof/verification workflow
 - `.claude/rules/lean-proofs.md` — Lean gotchas, auto-loaded when editing `.lean` files

--- a/crates/qedgen/src/cli.rs
+++ b/crates/qedgen/src/cli.rs
@@ -16,9 +16,9 @@ pub(crate) struct Cli {
 }
 
 /// Solana program framework target for greenfield codegen
-/// (`qedgen init --target ...`). `anchor` and `quasar` are wired
-/// end-to-end; `pinocchio` reserves the CLI surface but is not yet
-/// implemented — selecting it errors at the init dispatcher.
+/// (`qedgen init --target ...`). All three targets are wired
+/// end-to-end (`codegen_mir` dispatch): full scaffold + spec-model
+/// Kani/proptest + per-target impl-Kani shape.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub(crate) enum Target {
     /// Anchor-compatible Rust program. `use anchor_lang::prelude::*`,
@@ -487,10 +487,9 @@ pub(crate) enum Commands {
         mathlib: bool,
 
         /// Also generate the program crate + Kani harnesses for the
-        /// named framework target. `anchor` and `quasar` are fully
-        /// implemented; `pinocchio` reserves the CLI surface but its
-        /// codegen branch is not yet implemented and errors cleanly
-        /// when selected. Omit to skip program scaffolding entirely.
+        /// named framework target (`anchor`, `quasar`, or `pinocchio` —
+        /// all fully implemented). Omit to skip program scaffolding
+        /// entirely.
         #[arg(long, value_enum)]
         target: Option<Target>,
 
@@ -852,10 +851,12 @@ pub(crate) enum Commands {
         #[arg(long)]
         spec: Option<PathBuf>,
 
-        /// Framework target for the Rust program crate. `anchor` is
-        /// fully implemented (default); `quasar` is fully implemented
-        /// (Blueshift's `quasar_lang`); `pinocchio` reserves the CLI
-        /// surface but its codegen branch is not yet implemented.
+        /// Framework target for the Rust program crate: `anchor`
+        /// (default), `quasar` (Blueshift's `quasar_lang`), or
+        /// `pinocchio` — all fully implemented. Known per-target gaps
+        /// (generic CPI on Quasar/Pinocchio, imported account mirrors
+        /// on Pinocchio) surface as `todo!()` breadcrumbs or a clean
+        /// error, never silent wrong output.
         #[arg(long, value_enum, default_value_t = Target::Anchor)]
         target: Target,
 
@@ -882,7 +883,9 @@ pub(crate) enum Commands {
         /// emission is auto-triggered when any handler has `modifies`
         /// listing fields absent from its `effect` block (the v2.25 LP-
         /// shape signal indicating the impl is expected to fill those
-        /// fields). Anchor target only in v2.26.
+        /// fields). Per-target shapes: Anchor/Quasar drive the accounts
+        /// struct; Pinocchio uses its `#[repr(C)]` stack-`AccountInfo`
+        /// shape. The brownfield/context modes below are Anchor-only.
         #[arg(long)]
         kani_impl: bool,
 

--- a/crates/qedgen/src/codegen/kani_impl/mod.rs
+++ b/crates/qedgen/src/codegen/kani_impl/mod.rs
@@ -96,11 +96,12 @@ fn auto_triggered_handlers(spec: &ParsedSpec) -> Vec<&str> {
         .collect()
 }
 
-/// Emit `programs/tests/kani_impl.rs` against the user's real Anchor
-/// handlers. `explicit_flag` is true when `--kani-impl` was passed; auto-
-/// triggered emission stamps a header comment naming the triggering
-/// handlers. Non-Anchor targets (Quasar, Pinocchio) are a clean no-op
-/// (no file written) — see the target gate in `generate_from_spec`.
+/// Emit `programs/tests/kani_impl.rs` against the user's real handlers.
+/// `explicit_flag` is true when `--kani-impl` was passed; auto-triggered
+/// emission stamps a header comment naming the triggering handlers.
+/// Every target emits — Anchor/Quasar the struct-framework shape,
+/// Pinocchio its `#[repr(C)]` stack-`AccountInfo` shape — only the
+/// harness body differs (see the `match target` dispatch below).
 ///
 /// Per-handler emission is gated on the handler having at least one
 /// `ensures` clause — without ensures there's nothing to assert.

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -276,14 +276,10 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 }
                 let catalogue = pinocchio_probe::scan_program(prog_root)?;
                 let mut findings = pinocchio_probe::findings_from_catalogue(&catalogue);
-                // Arithmetic-symbol catalog: runtime-agnostic source-scan
-                // findings merge into the same envelope.
-                findings.extend(arithmetic_symbol_probe::scan_program(prog_root)?);
-                // Paired-validator asymmetry across files.
-                findings.extend(paired_validator_probe::scan_program(prog_root)?);
-                // Lifecycle catalog: pairs authority-conferring CPI grants
-                // with close handlers that don't tear them down.
-                findings.extend(lifecycle_probe::scan_program(prog_root)?);
+                // Runtime-agnostic source scanners (arithmetic-symbol,
+                // paired-validator, lifecycle) — same set every runtime
+                // branch merges (#196).
+                findings.extend(run_helpers::runtime_agnostic_findings(prog_root)?);
                 // --emit-spec-candidates: lift findings into proto-clauses,
                 // then cluster.
                 let clusters = if emit_spec_candidates {

--- a/crates/qedgen/src/run_helpers.rs
+++ b/crates/qedgen/src/run_helpers.rs
@@ -400,13 +400,27 @@ pub(crate) fn format_lint_warning(warning: &check::CompletenessWarning) -> Strin
     out
 }
 
+/// The runtime-agnostic source scanners — arithmetic-symbol, lifecycle,
+/// paired-validator — merged into EVERY `--program` probe envelope. They
+/// are framework-neutral by construction (regex over `*.rs`), but until
+/// #196 they were wired only into the Pinocchio branch, so Anchor/Native
+/// runs returned zero per-site findings from scanners that would have
+/// fired on them verbatim.
+pub(crate) fn runtime_agnostic_findings(prog_root: &Path) -> Result<Vec<probe::Finding>> {
+    let mut findings = arithmetic_symbol_probe::scan_program(prog_root)?;
+    findings.extend(paired_validator_probe::scan_program(prog_root)?);
+    findings.extend(lifecycle_probe::scan_program(prog_root)?);
+    Ok(findings)
+}
+
 /// Anchor (and Quasar) probe path used by `qedgen probe --program <root>`.
 /// Mirrors the Pinocchio branch's shape: runs the runtime-specific
 /// extractor, clusters proto-clauses, optionally materializes the audit
-/// working set, and prints the schema-v3 envelope. Anchor doesn't emit
-/// per-site findings yet — the auditor SKILL.md handles them at the
-/// agent layer via Read+Grep, while the scaffold-to-spec interview
-/// works off the extractor's clusters directly.
+/// working set, and prints the schema-v3 envelope. Per-site findings come
+/// from the runtime-agnostic scanners (#196); Anchor-specific site
+/// discovery stays at the agent layer (auditor SKILL.md via Read+Grep),
+/// while the scaffold-to-spec interview works off the extractor's
+/// clusters directly.
 pub(crate) fn run_anchor_probe(
     prog_root: &Path,
     runtime_final: probe::Runtime,
@@ -448,7 +462,7 @@ pub(crate) fn run_anchor_probe(
         runtime: Some(runtime_final),
         handlers: handlers_opt,
         applicable_categories: Some(applicable),
-        findings: Vec::new(),
+        findings: runtime_agnostic_findings(prog_root)?,
         clusters,
         dispatcher_kind: None,
     };
@@ -523,7 +537,7 @@ pub(crate) fn run_native_probe(
         runtime: Some(runtime_final),
         handlers,
         applicable_categories: Some(applicable),
-        findings: Vec::new(),
+        findings: runtime_agnostic_findings(prog_root)?,
         clusters,
         dispatcher_kind,
     };
@@ -557,9 +571,45 @@ pub(crate) fn narrow_shank_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::{expand_ci_template, format_lint_warning, redirect_kani_impl_to_src};
+    use super::{
+        expand_ci_template, format_lint_warning, redirect_kani_impl_to_src,
+        runtime_agnostic_findings,
+    };
     use crate::check::{CompletenessWarning, Severity};
     use std::path::PathBuf;
+
+    /// #196: the runtime-agnostic scanners fire on an ANCHOR-shaped crate —
+    /// they used to be wired only into the Pinocchio probe branch, leaving
+    /// Anchor/Native `--program` runs with zero per-site findings.
+    #[test]
+    fn agnostic_findings_fire_on_anchor_shaped_source() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        // The canonical silent_success_arithmetic shape (timestamp-shaped
+        // saturating_sub + downstream gating comparison) inside an
+        // Anchor-flavored handler.
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            r#"
+use anchor_lang::prelude::*;
+pub fn process_transfer(ctx: Context<T>, current_ts: i64) -> Result<()> {
+    let elapsed = current_ts.saturating_sub(*period_start_ts);
+    if elapsed >= period_length {
+        advance_period(ctx)?;
+    }
+    Ok(())
+}
+"#,
+        )
+        .unwrap();
+        let findings = runtime_agnostic_findings(dir.path()).unwrap();
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.category_tag == "silent_success_arithmetic"),
+            "agnostic scanner must fire on Anchor-shaped source; got {findings:#?}"
+        );
+    }
 
     #[test]
     fn kani_impl_path_redirects_tests_to_src_for_pinocchio() {

--- a/crates/qedgen/src/spec/idl.rs
+++ b/crates/qedgen/src/spec/idl.rs
@@ -1,9 +1,19 @@
-//! Anchor IDL parsing and pattern inference.
+//! IDL parsing and pattern inference.
 //!
-//! Decodes Anchor IDL JSON to typed structs and infers patterns (signers,
+//! Decodes IDL JSON to typed structs and infers patterns (signers,
 //! writable accounts, PDAs, has_one relations, token-program presence, close
 //! semantics, numeric args). Consumed by `idl2spec` (IDL → `.qedspec`
 //! scaffolder) and `interface_gen` (IDL → spec interface block).
+//!
+//! Two wire formats are accepted (#197):
+//! - **Anchor** (pre-0.30 and 0.30+) — parsed directly into [`Idl`].
+//! - **Codama IR** (`{"kind":"rootNode","program":{...}}`, the IDL format
+//!   Pinocchio programs ship) — normalized into the same Anchor-shaped
+//!   [`Idl`] by [`codama_to_idl`], so `qedgen spec --idl` and
+//!   `qedgen interface --idl` work identically for both. Names are
+//!   snake_cased (Codama uses camelCase), type nodes are lowered to the
+//!   Anchor labels `idl2spec::map_type` understands, and `omitted`
+//!   discriminator arguments become the instruction `discriminator`.
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -136,10 +146,281 @@ pub(crate) struct InstructionAnalysis {
 
 pub(crate) fn parse_idl(idl_path: &Path) -> Result<(Idl, Vec<InstructionAnalysis>)> {
     let idl_source = std::fs::read_to_string(idl_path)?;
-    let idl: Idl = serde_json::from_str(&idl_source)?;
+    let raw: serde_json::Value = serde_json::from_str(&idl_source)?;
+    // Codama IR carries the program under a `program` envelope; an Anchor
+    // IDL never has one. Normalize Codama into the Anchor-shaped `Idl`.
+    let idl: Idl = if raw
+        .get("program")
+        .is_some_and(|p| p.get("instructions").is_some())
+    {
+        codama_to_idl(&raw)?
+    } else {
+        serde_json::from_str(&idl_source)?
+    };
     let analyses: Vec<InstructionAnalysis> =
         idl.instructions.iter().map(analyze_instruction).collect();
     Ok((idl, analyses))
+}
+
+/// camelCase → snake_case (Codama names instructions/accounts/args in
+/// camelCase; qedspec conventions and Anchor 0.30 IDLs are snake_case).
+fn camel_to_snake(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Lower a Codama type node to the Anchor-style label `idl2spec::map_type`
+/// and `interface_gen` understand. Recognized nodes map precisely; anything
+/// else falls back to the node's `kind` string — the same
+/// fail-visible-not-silent behavior unknown Anchor types get.
+fn codama_type_label(node: &serde_json::Value) -> serde_json::Value {
+    use serde_json::json;
+    // Anchor string shorthand may appear nested inside Codama trees.
+    if node.is_string() {
+        return node.clone();
+    }
+    let kind = node.get("kind").and_then(|k| k.as_str()).unwrap_or("");
+    match kind {
+        "numberTypeNode" => node.get("format").cloned().unwrap_or_else(|| json!("u64")),
+        "publicKeyTypeNode" => json!("pubkey"),
+        "booleanTypeNode" => json!("bool"),
+        "stringTypeNode" => json!("string"),
+        "bytesTypeNode" => json!("bytes"),
+        "optionTypeNode" | "zeroableOptionTypeNode" => {
+            let inner = node
+                .get("item")
+                .map(codama_type_label)
+                .unwrap_or_else(|| json!("u64"));
+            json!({ "option": inner })
+        }
+        "definedTypeLinkNode" => {
+            let name = node.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            json!({ "defined": name })
+        }
+        "arrayTypeNode" => {
+            let inner = node
+                .get("item")
+                .map(codama_type_label)
+                .unwrap_or_else(|| json!("u8"));
+            let count = node
+                .get("count")
+                .and_then(|c| c.get("value"))
+                .cloned()
+                .unwrap_or_else(|| json!(0));
+            json!({ "array": [inner, count] })
+        }
+        other => json!(other),
+    }
+}
+
+/// Codama struct fields (`structTypeNode.fields[]` of
+/// `structFieldTypeNode { name, type }`) → Anchor-shaped field list.
+fn codama_struct_fields(struct_node: &serde_json::Value) -> Vec<serde_json::Value> {
+    struct_node
+        .get("fields")
+        .and_then(|f| f.as_array())
+        .map(|fields| {
+            fields
+                .iter()
+                .filter_map(|f| {
+                    let name = f.get("name").and_then(|n| n.as_str())?;
+                    let ty = f.get("type").map(codama_type_label)?;
+                    Some(serde_json::json!({ "name": camel_to_snake(name), "type": ty }))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Normalize a Codama IR root into the Anchor-shaped [`Idl`] (#197). Builds
+/// an Anchor-form JSON value and reuses the existing serde derives, so the
+/// two formats can never drift in what downstream consumers see.
+///
+/// Mapping:
+/// - `program.name` → `metadata.name`; `program.publicKey` → `address`.
+/// - `instructions[]`: `arguments[]` → `args[]` (dropping
+///   `defaultValueStrategy: "omitted"` args — a single-byte
+///   `numberValueNode` default among them becomes the `discriminator`);
+///   account `isSigner`/`isWritable` → `signer`/`writable`; a `pda` object
+///   or `pdaValueNode` default marks the account PDA. Codama has no
+///   `has_one`, so `relations` stays empty.
+/// - `definedTypes[]` AND `accounts[]` (account-state structs live under
+///   `accountNode.data` in Codama) → `types[]`, so state-layout inference
+///   sees them exactly like Anchor `types`.
+/// - `errors[]` (`message`) → `errors[]` (`msg`).
+fn codama_to_idl(root: &serde_json::Value) -> Result<Idl> {
+    use serde_json::json;
+    let program = root
+        .get("program")
+        .expect("caller checked program presence");
+    let name = program
+        .get("name")
+        .and_then(|n| n.as_str())
+        .unwrap_or("program");
+    let address = program.get("publicKey").and_then(|k| k.as_str());
+
+    let instructions: Vec<serde_json::Value> = program
+        .get("instructions")
+        .and_then(|v| v.as_array())
+        .map(|ixs| {
+            ixs.iter()
+                .filter_map(|ix| {
+                    let ix_name = ix.get("name").and_then(|n| n.as_str())?;
+                    let mut discriminator: Vec<u8> = Vec::new();
+                    let args: Vec<serde_json::Value> = ix
+                        .get("arguments")
+                        .and_then(|a| a.as_array())
+                        .map(|args| {
+                            args.iter()
+                                .filter_map(|a| {
+                                    let omitted =
+                                        a.get("defaultValueStrategy").and_then(|s| s.as_str())
+                                            == Some("omitted");
+                                    if omitted {
+                                        // A fixed single-byte default among the
+                                        // omitted args IS the discriminator.
+                                        if let Some(n) = a
+                                            .get("defaultValue")
+                                            .filter(|d| {
+                                                d.get("kind").and_then(|k| k.as_str())
+                                                    == Some("numberValueNode")
+                                            })
+                                            .and_then(|d| d.get("number"))
+                                            .and_then(|n| n.as_u64())
+                                        {
+                                            if discriminator.is_empty() && n <= u8::MAX as u64 {
+                                                discriminator.push(n as u8);
+                                            }
+                                        }
+                                        return None;
+                                    }
+                                    let arg_name = a.get("name").and_then(|n| n.as_str())?;
+                                    let ty = a.get("type").map(codama_type_label)?;
+                                    Some(json!({
+                                        "name": camel_to_snake(arg_name),
+                                        "type": ty,
+                                    }))
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let accounts: Vec<serde_json::Value> = ix
+                        .get("accounts")
+                        .and_then(|a| a.as_array())
+                        .map(|accts| {
+                            accts
+                                .iter()
+                                .filter_map(|a| {
+                                    let acct_name = a.get("name").and_then(|n| n.as_str())?;
+                                    let signer = a
+                                        .get("isSigner")
+                                        .or_else(|| a.get("signer"))
+                                        .and_then(|b| b.as_bool())
+                                        .unwrap_or(false);
+                                    let writable = a
+                                        .get("isWritable")
+                                        .or_else(|| a.get("writable"))
+                                        .and_then(|b| b.as_bool())
+                                        .unwrap_or(false);
+                                    let is_pda = a.get("pda").is_some()
+                                        || a.get("defaultValue")
+                                            .and_then(|d| d.get("kind"))
+                                            .and_then(|k| k.as_str())
+                                            == Some("pdaValueNode");
+                                    let mut acct = json!({
+                                        "name": camel_to_snake(acct_name),
+                                        "signer": signer,
+                                        "writable": writable,
+                                    });
+                                    if is_pda {
+                                        acct["pda"] = json!({ "seeds": [] });
+                                    }
+                                    Some(acct)
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    Some(json!({
+                        "name": camel_to_snake(ix_name),
+                        "docs": ix.get("docs").cloned().unwrap_or_else(|| json!([])),
+                        "accounts": accounts,
+                        "args": args,
+                        "discriminator": discriminator,
+                    }))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // State-layout candidates: Codama's `definedTypes[]` plus the struct
+    // under each `accountNode.data` — both become Anchor-shaped `types[]`.
+    let mut types: Vec<serde_json::Value> = Vec::new();
+    if let Some(dts) = program.get("definedTypes").and_then(|v| v.as_array()) {
+        for dt in dts {
+            let Some(tname) = dt.get("name").and_then(|n| n.as_str()) else {
+                continue;
+            };
+            let Some(ty) = dt.get("type") else { continue };
+            types.push(json!({
+                "name": snake_to_title(&camel_to_snake(tname)).replace(' ', ""),
+                "type": { "kind": "struct", "fields": codama_struct_fields(ty) },
+            }));
+        }
+    }
+    if let Some(accts) = program.get("accounts").and_then(|v| v.as_array()) {
+        for acct in accts {
+            let Some(aname) = acct.get("name").and_then(|n| n.as_str()) else {
+                continue;
+            };
+            let Some(data) = acct.get("data") else {
+                continue;
+            };
+            types.push(json!({
+                "name": snake_to_title(&camel_to_snake(aname)).replace(' ', ""),
+                "type": { "kind": "struct", "fields": codama_struct_fields(data) },
+            }));
+        }
+    }
+
+    let errors: Vec<serde_json::Value> = program
+        .get("errors")
+        .and_then(|v| v.as_array())
+        .map(|errs| {
+            errs.iter()
+                .filter_map(|e| {
+                    let ename = e.get("name").and_then(|n| n.as_str())?;
+                    let msg = e
+                        .get("message")
+                        .or_else(|| e.get("msg"))
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("");
+                    Some(json!({
+                        "name": snake_to_title(&camel_to_snake(ename)).replace(' ', ""),
+                        "msg": msg,
+                    }))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let anchor_shaped = json!({
+        "metadata": { "name": name },
+        "address": address,
+        "instructions": instructions,
+        "types": types,
+        "errors": errors,
+    });
+    Ok(serde_json::from_value(anchor_shaped)?)
 }
 
 pub(crate) fn analyze_instruction(ix: &IdlInstruction) -> InstructionAnalysis {

--- a/crates/qedgen/src/spec/idl2spec.rs
+++ b/crates/qedgen/src/spec/idl2spec.rs
@@ -200,12 +200,17 @@ pub(crate) fn render(idl: &Idl, analyses: &[InstructionAnalysis]) -> String {
         .map(|t| t.name.clone())
         .collect();
 
-    // Collect PDA info: account_name → pda_name
+    // Collect PDA info: account_name → pda_name. Seedless PDA markers
+    // (Codama `pdaValueNode` carries no seed data, #197) are excluded —
+    // an empty `pda <name> []` declaration doesn't parse, so those degrade
+    // to a TODO comment at the declaration site instead.
     let mut pda_names: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     let mut seen_pdas: HashSet<String> = HashSet::new();
     for ix in &idl.instructions {
         for acct in &ix.accounts {
-            if acct.pda.is_some() && seen_pdas.insert(acct.name.clone()) {
+            if acct.pda.as_ref().is_some_and(|p| !p.seeds.is_empty())
+                && seen_pdas.insert(acct.name.clone())
+            {
                 pda_names.insert(acct.name.clone(), acct.name.clone());
             }
         }
@@ -214,7 +219,7 @@ pub(crate) fn render(idl: &Idl, analyses: &[InstructionAnalysis]) -> String {
     // ── Header ───────────────────────────────────────────────────────────
     writeln!(
         s,
-        "// Generated from Anchor IDL — review and complete TODO items"
+        "// Generated from IDL (Anchor or Codama IR) — review and complete TODO items"
     )
     .unwrap();
     writeln!(s, "//").unwrap();
@@ -235,8 +240,16 @@ pub(crate) fn render(idl: &Idl, analyses: &[InstructionAnalysis]) -> String {
     // with `pragma sbpf { ... }`.
     writeln!(s, "spec {}", program_name).unwrap();
     writeln!(s).unwrap();
-    writeln!(s, "// TODO: Replace with deployed program ID").unwrap();
-    writeln!(s, "program_id \"11111111111111111111111111111111\"").unwrap();
+    // The IDL's own address is authoritative when present (Anchor 0.30+
+    // root `address`, Codama `program.publicKey`); only fall back to the
+    // TODO placeholder without one.
+    match idl.address.as_deref() {
+        Some(addr) => writeln!(s, "program_id \"{}\"", addr).unwrap(),
+        None => {
+            writeln!(s, "// TODO: Replace with deployed program ID").unwrap();
+            writeln!(s, "program_id \"11111111111111111111111111111111\"").unwrap();
+        }
+    }
     writeln!(s).unwrap();
 
     // ── State / Account blocks ───────────────────────────────────────────
@@ -307,7 +320,20 @@ pub(crate) fn render(idl: &Idl, analyses: &[InstructionAnalysis]) -> String {
             if let Some(pda) = &acct.pda {
                 if seen_pdas.insert(acct.name.clone()) {
                     let seeds = render_pda_seeds(pda);
-                    writeln!(s, "pda {} [{}]", acct.name, seeds.join(", ")).unwrap();
+                    if seeds.is_empty() {
+                        // Codama `pdaValueNode` marks the account PDA but
+                        // carries no seed data (#197) — an empty seed list
+                        // doesn't parse, so leave the derivation to the user.
+                        writeln!(
+                            s,
+                            "// TODO: `{}` is a PDA but the IDL carries no seeds — declare\n\
+                             // them: pda {} [\"<literal>\", <account_or_arg>, ...]",
+                            acct.name, acct.name
+                        )
+                        .unwrap();
+                    } else {
+                        writeln!(s, "pda {} [{}]", acct.name, seeds.join(", ")).unwrap();
+                    }
                 }
             }
         }
@@ -696,5 +722,127 @@ mod tests {
         assert!(content.contains("pda escrow"));
         assert!(content.contains("\"escrow\""));
         assert!(content.contains("initializer"));
+    }
+
+    /// #197: a Codama IR tree (the IDL format Pinocchio programs ship)
+    /// normalizes into the same Anchor-shaped `Idl` — camelCase names
+    /// snake_cased, type nodes lowered, omitted single-byte discriminator
+    /// lifted, accountNode data structs exposed as `types`.
+    const CODAMA_IDL: &str = r#"{
+      "kind": "rootNode",
+      "standard": "codama",
+      "version": "1.0.0",
+      "program": {
+        "kind": "programNode",
+        "name": "ctxGate",
+        "publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+        "version": "0.1.0",
+        "instructions": [
+          {
+            "kind": "instructionNode",
+            "name": "setThreshold",
+            "docs": ["Update the gate threshold"],
+            "arguments": [
+              {
+                "kind": "instructionArgumentNode",
+                "name": "discriminator",
+                "type": { "kind": "numberTypeNode", "format": "u8" },
+                "defaultValue": { "kind": "numberValueNode", "number": 1 },
+                "defaultValueStrategy": "omitted"
+              },
+              {
+                "kind": "instructionArgumentNode",
+                "name": "newThreshold",
+                "type": { "kind": "numberTypeNode", "format": "u64" }
+              }
+            ],
+            "accounts": [
+              {
+                "kind": "instructionAccountNode",
+                "name": "settings",
+                "isWritable": true,
+                "isSigner": false,
+                "defaultValue": { "kind": "pdaValueNode" }
+              },
+              { "kind": "instructionAccountNode", "name": "admin", "isSigner": true, "isWritable": false }
+            ]
+          }
+        ],
+        "accounts": [
+          {
+            "kind": "accountNode",
+            "name": "settings",
+            "data": {
+              "kind": "structTypeNode",
+              "fields": [
+                { "kind": "structFieldTypeNode", "name": "admin", "type": { "kind": "publicKeyTypeNode" } },
+                { "kind": "structFieldTypeNode", "name": "threshold", "type": { "kind": "numberTypeNode", "format": "u64" } }
+              ]
+            }
+          }
+        ],
+        "definedTypes": [],
+        "errors": [
+          { "kind": "errorNode", "name": "notActive", "code": 6000, "message": "settings not active" }
+        ],
+        "pdas": []
+      }
+    }"#;
+
+    #[test]
+    fn codama_ir_normalizes_to_anchor_shaped_idl() {
+        let tmp = std::env::temp_dir().join(format!("codama_{}.json", std::process::id()));
+        std::fs::write(&tmp, CODAMA_IDL).unwrap();
+        let (idl, analyses) = idl::parse_idl(&tmp).unwrap();
+        let _ = std::fs::remove_file(&tmp);
+
+        assert_eq!(idl.metadata.name, "ctxGate");
+        assert_eq!(
+            idl.address.as_deref(),
+            Some("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS")
+        );
+        let ix = &idl.instructions[0];
+        assert_eq!(ix.name, "set_threshold", "camelCase name snake_cased");
+        assert_eq!(
+            ix.discriminator,
+            vec![1],
+            "omitted numberValueNode arg lifted"
+        );
+        assert_eq!(
+            ix.args.len(),
+            1,
+            "omitted discriminator arg dropped from args"
+        );
+        assert_eq!(ix.args[0].name, "new_threshold");
+        assert_eq!(ix.args[0].ty, serde_json::json!("u64"));
+        let settings = &ix.accounts[0];
+        assert!(settings.writable && !settings.signer && settings.pda.is_some());
+        let admin = &ix.accounts[1];
+        assert!(admin.signer && !admin.writable);
+        // accountNode data struct exposed as a state-layout candidate.
+        let ty = idl.types.iter().find(|t| t.name == "Settings").unwrap();
+        assert_eq!(ty.ty.fields.len(), 2);
+        assert_eq!(idl.errors[0].name, "NotActive");
+        // Signer inference flows through the shared analysis.
+        assert_eq!(analyses[0].signers, vec!["admin".to_string()]);
+    }
+
+    #[test]
+    fn codama_ir_renders_qedspec_scaffold() {
+        let tmp = std::env::temp_dir().join(format!("codama_r_{}.json", std::process::id()));
+        std::fs::write(&tmp, CODAMA_IDL).unwrap();
+        let (idl, analyses) = idl::parse_idl(&tmp).unwrap();
+        let _ = std::fs::remove_file(&tmp);
+        let spec = render(&idl, &analyses);
+        assert!(spec.contains("set_threshold"), "handler present:\n{spec}");
+        assert!(
+            spec.contains("threshold : U64") && spec.contains(": Pubkey"),
+            "state fields lowered from the accountNode struct:\n{spec}"
+        );
+        assert!(
+            spec.contains("program_id \"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS\""),
+            "Codama program.publicKey becomes the program_id:\n{spec}"
+        );
+        assert!(spec.contains("NotActive"), "error surfaced:\n{spec}");
     }
 }

--- a/docs/framework-support.md
+++ b/docs/framework-support.md
@@ -1,0 +1,67 @@
+# Framework support matrix
+
+What each pipeline surface supports per framework/target, verified against the
+code gates (not aspirations). Update this table when a per-target gate changes;
+each row names the module that owns the gate so claims stay checkable.
+
+Five *distinct* framework notions exist — they are not one enum:
+
+| Notion | Where | Values |
+|---|---|---|
+| Greenfield `Target` | `cli.rs` | anchor, quasar, pinocchio |
+| Probe `--runtime` override | `cli.rs` (`RuntimeOverride`) | + native, sbpf |
+| Brownfield audit `Runtime` | `probe/mod.rs` | + qedgen-codegen, unknown |
+| Adapter `ProgramFramework` | `adapt/program_model.rs` | anchor, pinocchio, native |
+| Ratchet `Framework` | `verify/ratchet.rs` | anchor, quasar |
+
+sBPF assembly is selected by `pragma sbpf` in the spec, not by a `Target`.
+
+## The matrix
+
+✅ full · ⚠️ partial (noted) · ❌ none · n/a not meaningful
+
+| Surface (owning module) | Anchor | Quasar | Pinocchio | Native | sBPF asm |
+|---|---|---|---|---|---|
+| IDL → spec scaffold (`spec/idl.rs` + `idl2spec`) | ✅ pre-0.30 + 0.30 | ❌ | ✅ Codama IR (#197) | ❌ | ❌ |
+| IDL → Tier-0 interface (`interface_gen`) | ✅ | ❌ | ✅ Codama IR (#197) | ❌ | ❌ |
+| IDL → brownfield fuzz (`probe/crucible_brownfield`) | ✅ 0.30 | ✅ | ⚠️ needs on-disk Codama/0.30 IDL | ❌ deferred | ❌ parked |
+| Brownfield adapt → spec skeleton (`adapt/`) | ✅ args + accounts + errors | ❌ no adapter | ⚠️ handlers-only skeleton | ⚠️ loose (no conventions) | ❌ |
+| Greenfield Rust scaffold (`codegen_mir`) | ✅ | ⚠️ generic CPI → `todo!()` | ⚠️ generic CPI → `todo!()`; imported mirrors error | n/a | n/a |
+| Kani spec-model (`kani_mir`) | ✅ | ✅ | ✅ | n/a | skip by design |
+| impl-Kani (`kani_impl`) | ✅ greenfield + state-struct (#162) + Context (#169) | ⚠️ greenfield shape only | ⚠️ own `#[repr(C)]` shape; some ix-data field types TODO | ❌ | ❌ |
+| proptest (`proptest_gen_mir`) | ✅ | ✅ | ✅ | n/a | skip by design |
+| Lean (`lean_gen_mir`) | ✅ | ✅ | ✅ | n/a | ✅ dedicated sBPF path |
+| Probe: runtime-agnostic scanners (`run_helpers`) | ✅ (#196) | ✅ (#196) | ✅ | ✅ (#196) | ❌ bootstrap only |
+| Probe: runtime-specific findings (`probe/`) | ❌ agent-layer (SKILL.md) | ❌ agent-layer | ✅ richest (`pinocchio_probe`) | ⚠️ Shank dispatcher discovery only | ❌ |
+| Miri divergence repros (`verify/miri_verify`) | ❌ | ❌ | ✅ | ❌ | n/a |
+| Ratchet / readiness (`verify/ratchet`) | ✅ | ✅ | ❌ no ratchet crate | ❌ | ❌ |
+
+## Reading the Pinocchio column
+
+Pinocchio is a first-class *audit* target (richest probe path, Miri repros,
+Codama-gated fuzz) and a full *greenfield* target, and — since #197 — its
+Codama IDL enters the same front door as Anchor's (`qedgen spec --idl`,
+`qedgen interface --idl`). Remaining real gaps:
+
+- **Brownfield spec depth** — `pinocchio_to_spec` infers handlers only;
+  account lists / param types / error enums are agent-completed (the Codama
+  path is the richer alternative when an IDL exists).
+- **Generic CPI mechanization** in the greenfield scaffold (SPL/System are
+  mechanized; anything else is a `todo!()` breadcrumb).
+- **impl-Kani ix-data field types** — the `#[repr(C)]` profile covers the
+  common numeric shapes; exotic field types leave bytes symbolic with a TODO.
+- **No ratchet** — mainnet-readiness gating is Anchor/Quasar only.
+
+## Reading the Quasar column
+
+Quasar is greenfield + ratchet + fuzz. It has **no brownfield adapter** and
+only the greenfield impl-Kani shape — a pre-existing Quasar program can be
+audited (probe/agnostic scanners) but not spec-skeletoned or state-struct
+harnessed.
+
+## sBPF assembly
+
+Verified through the Lean path exclusively (`asm2lean`, `qedsvm`); every
+Rust-shaped artifact (Kani, proptest, Crucible, scaffold) is skipped by
+design — generated Rust harnesses are meaningless for assembly
+(`feedback_sbpf_no_kani_proptest`). Client-side tests own runtime checks.


### PR DESCRIPTION
## What

Fixes the three findings from the framework-support audit and commits the gate-verified capability matrix as `docs/framework-support.md` (linked from CLAUDE.md).

## #196 — runtime-agnostic scanners fire on every runtime

New `run_helpers::runtime_agnostic_findings()` merges the arithmetic-symbol / lifecycle / paired-validator scanners into **every** `--program` probe branch. Anchor/Quasar/Native previously returned `findings: []` from scanners that are framework-neutral by construction — likely a contributor to thin Anchor-side bench recall. Verified: an Anchor-shaped crate now returns `silent_success_arithmetic` where it returned zero.

## #197 — Codama IDL ingestion (Pinocchio parity at the main front door)

`spec/idl.rs` detects Codama IR (`{"kind":"rootNode","program":{…}}` — the IDL format Pinocchio programs ship) and normalizes it into the Anchor-shaped `Idl`, reusing the existing serde derives so the two formats can't drift downstream:

- camelCase names → snake_case; Codama type nodes → the Anchor labels `map_type` understands (number/publicKey/boolean/string/bytes/option/defined/array)
- `defaultValueStrategy: "omitted"` discriminator args dropped from params and lifted into the instruction `discriminator`
- `accountNode.data` structs exposed as `types[]` → state-layout inference sees them exactly like Anchor types
- `isSigner`/`isWritable`/`pdaValueNode` → signer/writable/pda flags

**End-to-end verified:** a Codama fixture flows through both `qedgen spec --idl` (parseable `.qedspec` scaffold with real `program_id`, state fields, handler + accounts, errors — passes `qedgen check`) and `qedgen interface --idl` (Tier-0 interface).

Adjacent scaffold fixes: seedless PDA markers degrade to a TODO comment instead of emitting unparseable `pda x []`; the IDL's own address becomes `program_id` instead of the `111…` placeholder.

## #198 — doc drift

Corrected the five stale claims (Pinocchio codegen "not yet implemented", impl-Kani "Anchor target only", kani_impl "non-Anchor no-op").

## docs/framework-support.md

The per-surface × per-framework matrix (Anchor / Quasar / Pinocchio / Native / sBPF), each row naming the module that owns the gate; includes the five-distinct-framework-enums map and per-column readings.

## Verification

3 new/updated regression tests (`agnostic_findings_fire_on_anchor_shaped_source`, `codama_ir_normalizes_to_anchor_shaped_idl`, `codama_ir_renders_qedspec_scaffold`); full suite 20/20 suites green; clippy `-D warnings` clean; `bin/qedgen` refreshed.

Closes #196. Closes #197. Closes #198.