### PR TITLE
feat(idl): mine Codama program.pdas[] seeds into real PDA declarations (#200)

### DIFF
--- a/crates/qedgen/src/spec/idl.rs
+++ b/crates/qedgen/src/spec/idl.rs
@@ -223,6 +223,54 @@ fn codama_type_label(node: &serde_json::Value) -> serde_json::Value {
     }
 }
 
+/// Lower a Codama `pdaNode`'s `seeds[]` to the Anchor-shaped seed array
+/// `IdlPda` deserializes (#200):
+/// - `constantPdaSeedNode` with a `stringValueNode` → `{"kind":"const",
+///   "value":[<utf8 bytes>]}` (what `render_pda_seeds` decodes back to a
+///   string literal); other constant value kinds keep an empty value →
+///   the `"const"` placeholder.
+/// - `variablePdaSeedNode { name }` → `{"kind":"variable","path":<snake>}`
+///   (an account/arg reference).
+fn codama_pda_seeds(pda_node: &serde_json::Value) -> serde_json::Value {
+    use serde_json::json;
+    let seeds: Vec<serde_json::Value> = pda_node
+        .get("seeds")
+        .and_then(|s| s.as_array())
+        .map(|seeds| {
+            seeds
+                .iter()
+                .filter_map(|seed| {
+                    let kind = seed.get("kind").and_then(|k| k.as_str())?;
+                    match kind {
+                        "constantPdaSeedNode" => {
+                            let bytes: Vec<serde_json::Value> = seed
+                                .get("value")
+                                .filter(|v| {
+                                    v.get("kind").and_then(|k| k.as_str())
+                                        == Some("stringValueNode")
+                                })
+                                .and_then(|v| v.get("string"))
+                                .and_then(|s| s.as_str())
+                                .map(|s| s.bytes().map(|b| json!(b)).collect())
+                                .unwrap_or_default();
+                            Some(json!({ "kind": "const", "value": bytes }))
+                        }
+                        "variablePdaSeedNode" => {
+                            let name = seed.get("name").and_then(|n| n.as_str())?;
+                            Some(json!({
+                                "kind": "variable",
+                                "path": camel_to_snake(name),
+                            }))
+                        }
+                        _ => None,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    json!(seeds)
+}
+
 /// Codama struct fields (`structTypeNode.fields[]` of
 /// `structFieldTypeNode { name, type }`) → Anchor-shaped field list.
 fn codama_struct_fields(struct_node: &serde_json::Value) -> Vec<serde_json::Value> {
@@ -252,8 +300,10 @@ fn codama_struct_fields(struct_node: &serde_json::Value) -> Vec<serde_json::Valu
 ///   `defaultValueStrategy: "omitted"` args — a single-byte
 ///   `numberValueNode` default among them becomes the `discriminator`);
 ///   account `isSigner`/`isWritable` → `signer`/`writable`; a `pda` object
-///   or `pdaValueNode` default marks the account PDA. Codama has no
-///   `has_one`, so `relations` stays empty.
+///   or `pdaValueNode` default marks the account PDA, and a `pdaLinkNode`
+///   under it resolves through `program.pdas[]` to real seeds (#200) —
+///   only a link with no matching definition degrades to the seedless
+///   TODO marker. Codama has no `has_one`, so `relations` stays empty.
 /// - `definedTypes[]` AND `accounts[]` (account-state structs live under
 ///   `accountNode.data` in Codama) → `types[]`, so state-layout inference
 ///   sees them exactly like Anchor `types`.
@@ -268,6 +318,21 @@ fn codama_to_idl(root: &serde_json::Value) -> Result<Idl> {
         .and_then(|n| n.as_str())
         .unwrap_or("program");
     let address = program.get("publicKey").and_then(|k| k.as_str());
+
+    // `program.pdas[]` seed definitions, keyed by pdaNode name — resolved
+    // when an instruction account's `pdaValueNode` links to one (#200).
+    let pda_defs: std::collections::HashMap<String, serde_json::Value> = program
+        .get("pdas")
+        .and_then(|v| v.as_array())
+        .map(|pdas| {
+            pdas.iter()
+                .filter_map(|p| {
+                    let pname = p.get("name").and_then(|n| n.as_str())?;
+                    Some((pname.to_string(), codama_pda_seeds(p)))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
 
     let instructions: Vec<serde_json::Value> = program
         .get("instructions")
@@ -332,18 +397,36 @@ fn codama_to_idl(root: &serde_json::Value) -> Result<Idl> {
                                         .or_else(|| a.get("writable"))
                                         .and_then(|b| b.as_bool())
                                         .unwrap_or(false);
-                                    let is_pda = a.get("pda").is_some()
-                                        || a.get("defaultValue")
-                                            .and_then(|d| d.get("kind"))
-                                            .and_then(|k| k.as_str())
-                                            == Some("pdaValueNode");
+                                    let default = a.get("defaultValue");
+                                    let is_pda_value = default
+                                        .and_then(|d| d.get("kind"))
+                                        .and_then(|k| k.as_str())
+                                        == Some("pdaValueNode");
                                     let mut acct = json!({
                                         "name": camel_to_snake(acct_name),
                                         "signer": signer,
                                         "writable": writable,
                                     });
-                                    if is_pda {
-                                        acct["pda"] = json!({ "seeds": [] });
+                                    if a.get("pda").is_some() || is_pda_value {
+                                        // Resolve the pdaLinkNode through
+                                        // `program.pdas[]` (#200); an inline
+                                        // pdaNode carries its own seeds; a
+                                        // dangling link keeps the seedless
+                                        // marker (→ scaffold TODO).
+                                        let seeds = default
+                                            .and_then(|d| d.get("pda"))
+                                            .and_then(|link| {
+                                                match link.get("kind").and_then(|k| k.as_str()) {
+                                                    Some("pdaNode") => Some(codama_pda_seeds(link)),
+                                                    _ => link
+                                                        .get("name")
+                                                        .and_then(|n| n.as_str())
+                                                        .and_then(|n| pda_defs.get(n))
+                                                        .cloned(),
+                                                }
+                                            })
+                                            .unwrap_or_else(|| json!([]));
+                                        acct["pda"] = json!({ "seeds": seeds });
                                     }
                                     Some(acct)
                                 })

--- a/crates/qedgen/src/spec/idl2spec.rs
+++ b/crates/qedgen/src/spec/idl2spec.rs
@@ -762,7 +762,7 @@ mod tests {
                 "name": "settings",
                 "isWritable": true,
                 "isSigner": false,
-                "defaultValue": { "kind": "pdaValueNode" }
+                "defaultValue": { "kind": "pdaValueNode", "pda": { "kind": "pdaLinkNode", "name": "settings" } }
               },
               { "kind": "instructionAccountNode", "name": "admin", "isSigner": true, "isWritable": false }
             ]
@@ -785,7 +785,24 @@ mod tests {
         "errors": [
           { "kind": "errorNode", "name": "notActive", "code": 6000, "message": "settings not active" }
         ],
-        "pdas": []
+        "pdas": [
+          {
+            "kind": "pdaNode",
+            "name": "settings",
+            "seeds": [
+              {
+                "kind": "constantPdaSeedNode",
+                "type": { "kind": "stringTypeNode", "encoding": "utf8" },
+                "value": { "kind": "stringValueNode", "string": "settings" }
+              },
+              {
+                "kind": "variablePdaSeedNode",
+                "name": "admin",
+                "type": { "kind": "publicKeyTypeNode" }
+              }
+            ]
+          }
+        ]
       }
     }"#;
 
@@ -816,7 +833,16 @@ mod tests {
         assert_eq!(ix.args[0].name, "new_threshold");
         assert_eq!(ix.args[0].ty, serde_json::json!("u64"));
         let settings = &ix.accounts[0];
-        assert!(settings.writable && !settings.signer && settings.pda.is_some());
+        assert!(settings.writable && !settings.signer);
+        // #200: the pdaLinkNode resolved through program.pdas[] to real seeds.
+        let pda = settings.pda.as_ref().unwrap();
+        assert_eq!(pda.seeds.len(), 2);
+        assert_eq!(
+            pda.seeds[0].value,
+            Some(serde_json::json!([115, 101, 116, 116, 105, 110, 103, 115])),
+            "const string seed lowered to utf8 bytes"
+        );
+        assert_eq!(pda.seeds[1].path.as_deref(), Some("admin"));
         let admin = &ix.accounts[1];
         assert!(admin.signer && !admin.writable);
         // accountNode data struct exposed as a state-layout candidate.
@@ -844,5 +870,36 @@ mod tests {
             "Codama program.publicKey becomes the program_id:\n{spec}"
         );
         assert!(spec.contains("NotActive"), "error surfaced:\n{spec}");
+        // #200: seeds mined from program.pdas[] — a real declaration, no TODO.
+        assert!(
+            spec.contains("pda settings [\"settings\", admin]"),
+            "resolved PDA declaration:\n{spec}"
+        );
+        assert!(
+            !spec.contains("IDL carries no seeds"),
+            "no seedless TODO when seeds resolve:\n{spec}"
+        );
+    }
+
+    /// #200 negative: a `pdaValueNode` whose link has no matching
+    /// `program.pdas[]` definition keeps the seedless marker → the
+    /// scaffold degrades to the TODO comment (never unparseable `pda x []`).
+    #[test]
+    fn codama_dangling_pda_link_degrades_to_todo() {
+        let dangling = CODAMA_IDL.replace(
+            r#""pda": { "kind": "pdaLinkNode", "name": "settings" }"#,
+            r#""pda": { "kind": "pdaLinkNode", "name": "missing" }"#,
+        );
+        let tmp = std::env::temp_dir().join(format!("codama_d_{}.json", std::process::id()));
+        std::fs::write(&tmp, dangling).unwrap();
+        let (idl, analyses) = idl::parse_idl(&tmp).unwrap();
+        let _ = std::fs::remove_file(&tmp);
+        let spec = render(&idl, &analyses);
+        assert!(
+            // Line-anchored: the TODO's own example text mentions
+            // `pda settings [`, but only inside a `//` comment.
+            spec.contains("IDL carries no seeds") && !spec.contains("\npda settings ["),
+            "dangling link degrades to the TODO comment:\n{spec}"
+        );
     }
 }

--- a/crates/qedgen/src/spec/idl2spec.rs
+++ b/crates/qedgen/src/spec/idl2spec.rs
@@ -48,7 +48,26 @@ fn map_type(value: &serde_json::Value) -> String {
                     return name.to_string();
                 }
             }
-            // Complex types (option, vec, array, etc.) — fallback
+            // Container types → the DSL's `Option T` / `Vec T` field forms
+            // (G9/G10). Anchor IDLs use `{"option"|"vec": <inner>}` and
+            // `{"array": [<inner>, N]}`; the Codama normalizer emits the same
+            // shapes. Recurse into the element so `Option<Pubkey>` renders
+            // `Option Pubkey` (not the old lossy `U64` — which silently
+            // mistyped e.g. a mint's `Option<Pubkey>` authority field).
+            if let Some(inner) = obj.get("option") {
+                return format!("Option {}", map_type(inner));
+            }
+            if let Some(inner) = obj.get("vec") {
+                return format!("Vec {}", map_type(inner));
+            }
+            if let Some(serde_json::Value::Array(parts)) = obj.get("array") {
+                // Fixed-length arrays have no DSL type; degrade to `Vec T`
+                // (element type preserved, length dropped — better than U64).
+                if let Some(inner) = parts.first() {
+                    return format!("Vec {}", map_type(inner));
+                }
+            }
+            // Genuinely unknown object shape — last-resort scalar.
             "U64".into()
         }
         _ => "U64".into(),
@@ -638,8 +657,24 @@ mod tests {
     }
 
     #[test]
-    fn map_type_complex_fallback() {
-        assert_eq!(map_type(&serde_json::json!({"vec": "u8"})), "U64");
+    fn map_type_container_types() {
+        // Container shapes recurse into the element (#197 real-world fidelity
+        // from p-token: an `Option<Pubkey>` authority field was mistyped U64).
+        assert_eq!(map_type(&serde_json::json!({"vec": "u8"})), "Vec U8");
+        assert_eq!(
+            map_type(&serde_json::json!({"option": "publicKey"})),
+            "Option Pubkey"
+        );
+        assert_eq!(
+            map_type(&serde_json::json!({"array": ["u8", 32]})),
+            "Vec U8"
+        );
+        assert_eq!(
+            map_type(&serde_json::json!({"option": {"defined": "Hook"}})),
+            "Option Hook"
+        );
+        // A genuinely unknown object shape still degrades to a scalar.
+        assert_eq!(map_type(&serde_json::json!({"mystery": 1})), "U64");
     }
 
     #[test]


### PR DESCRIPTION
Follow-on to #197. A Codama account's `pdaValueNode` default links via `pdaLinkNode` to a `program.pdas[]` definition; the normalizer now resolves it and lowers `pdaNode.seeds[]` into `IdlPda` seeds (`constantPdaSeedNode` + `stringValueNode` → utf8 byte value → string literal; `variablePdaSeedNode` → account/arg path). The scaffold emits a real `pda <name> ["seed", account]` declaration instead of the seedless TODO.

A dangling link (no matching `program.pdas[]` entry) keeps the seedless marker, so it still degrades to the TODO comment rather than an unparseable `pda x []` — covered by `codama_dangling_pda_link_degrades_to_todo`.

Verified end-to-end: the Codama fixture (now carrying a real `pdas[]` def) flows through `qedgen spec --idl` to `pda settings ["settings", admin]`, and the spec passes `check`. Full suite 20/20 green; clippy clean.

Closes #200.