### PR TITLE
refactor(auditor): cross-link passes to their catalog categories (concern #2)

### DIFF
--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -764,6 +764,30 @@ Each category has a **spec-aware predicate** (CLI-emitted via
 cover **Anchor and native Rust only** — sBPF/assembly is out of scope
 (see the "NOT supported" note above).
 
+### Passes are primary; these categories are their evidence
+
+Some categories below are the per-shape *predicate* for a cross-cutting pass
+(§3a–§3h): the **pass is the read-driven primary surface**, the catalog entry
+is where its exact recognition signals and corpus line live. Run the pass;
+open the category entry for detail. Do NOT treat a pass and its category as two
+separate checklists — that double-counts effort and is how the two lists drift.
+One home per class:
+
+| Pass | Primary for these categories |
+|---|---|
+| §3b per-role identity-anchoring | `token_account_role_anchoring`, `field_chain_missing_root_anchor`, `init_config_field_unanchored` |
+| §3f dead-guard / unwired-error-variant | `generated_guard_bypass`, `stored_field_never_written` |
+| §3g lifecycle-transition soundness | `permissionless_create_account_dos`, `lifecycle_one_shot_violation`, `init_without_is_initialized`, `missing_rent_exemption_check_on_init`, `pda_lifecycle_reuse_after_close` |
+| §3h zero / sentinel asymmetry | `sentinel_null_key_array_short_circuit` |
+
+Every other category stands alone as its own primary lens (`missing_signer`,
+`arbitrary_cpi`, the DeFi-specific set, …). **§3a** (coverage-of-safe-utility)
+and **§3c** (trust-surface dep walk) are meta-passes with no single owned
+category. **§3d** (comparison-direction) and **§3e** (store-without-validate)
+have *no* category twin on purpose — they cover classes the catalog never had,
+which is why they were added; there is nothing to cross-link, only net-new
+coverage.
+
 ### `missing_signer` — CRITICAL
 Spec-aware: handler has no `auth X` clause and is not marked
 `permissionless` (the CLI surfaces this directly).


### PR DESCRIPTION
Review concern #2 (pass ↔ catalog drift). The eight cross-cutting passes and the 43-category catalog were becoming two parallel checklists — several categories are really the per-shape predicate for a pass (`permissionless_create_account_dos` is §3g's bricked-creation shape; `token_account_role_anchoring` is §3b; etc.).

## Change

One cross-reference table at the top of the Category catalog, stating the principle — **the pass is the read-driven primary surface, the category entry is its evidence/predicate** — and mapping the genuine ownerships:

| Pass | Primary for |
|---|---|
| §3b | `token_account_role_anchoring`, `field_chain_missing_root_anchor`, `init_config_field_unanchored` |
| §3f | `generated_guard_bypass`, `stored_field_never_written` |
| §3g | `permissionless_create_account_dos`, `lifecycle_one_shot_violation`, `init_without_is_initialized`, `missing_rent_exemption_check_on_init`, `pda_lifecycle_reuse_after_close` |
| §3h | `sentinel_null_key_array_short_circuit` |

Only strong mappings are listed — forcing weak ones would mislead. It notes explicitly that **§3d/§3e have no category twin** (net-new coverage, which is why they were added) and §3a/§3c are meta-passes.

One table (+24 lines) instead of annotating 43 entries — kills the drift without a large error-prone diff.

## Note on concern #3

The fire-rate tally (local) showed long-tail pruning is **blocked on corpus breadth, not tooling**: all 3 corpus programs are non-DeFi, so the 27 zero-fire categories are confounded with "not exercised." The `Surfaced by:` provenance tag (merged in #211) makes the fire rate a standing signal; #3 waits on a domain-diverse corpus.