### PR TITLE
refactor(auditor): mark qedgen-codegen categories brownfield-skip (concern #3)

### DIFF
--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -1762,6 +1762,18 @@ codegen-target dep referenced by `qedgen init --target ...`),
 the program is split into codegen-owned and user-owned files.
 This changes how the catalog applies:
 
+> **Brownfield / third-party audits skip this whole section.** The four
+> categories filed here — `spec_impl_drift_user_owned`, `generated_guard_bypass`,
+> `stored_field_never_written`, `qed_hash_drift_or_forgery` — fire ONLY on
+> qedgen-*generated* code; they are structurally impossible on a hand-written
+> program (there is no codegen boundary, generated guard, or content-pin to
+> drift). The bench confirms it: **zero fires across the entire audit corpus**
+> (non-DeFi + DeFi lending/vault), because every audit target is brownfield. So
+> unless the runtime is qedgen-codegen, do NOT spend the per-category walk on
+> them — they live down here, out of the always-scanned Category catalog, for
+> exactly that reason. (Fire-rate analysis: they were the *only* categories that
+> never fired once a domain-diverse corpus exercised the rest.)
+
 - **Codegen-owned** (`Cargo.toml`, `state.rs`, `errors.rs`,
   `events.rs`, `instructions/<h>/guards.rs`, the `lib.rs` Anchor
   wrapping, `formal_verification/Spec.lean`,


### PR DESCRIPTION
Closes concern #3 (the fire-rate / catalog-pruning question).

The fire-rate tally (`~/.qedgen-bench/results/category-fire-rate.md`) ran across a domain-diverse corpus — the original non-DeFi programs plus a DeFi vault (kvault) and lending protocol (klend). Result: the DeFi long-tail (oracle/twap/liquidation/rounding/frontrun/flash-loan) is all alive; the ONLY categories that never fire are the four `qedgen-codegen` ones, because they can only apply to qedgen-*generated* code (a codegen boundary, a generated guard, a content-pin) — structurally impossible on a hand-written brownfield audit target.

Change: an explicit callout at the top of the `## qedgen-codegen runtime` section that a brownfield / third-party audit **skips** these four categories. They already lived in that section (not the always-scanned Category catalog); this makes the skip explicit and evidence-backed, so the auditor stops spending per-category effort on categories that cannot fire. Zero recall loss.

This is the data-grounded prune the fire-rate work unblocked — the pruning decision was previously confounded (27 "zero-fire" categories) until a DeFi corpus proved the rest alive and isolated these four as the genuine never-fire set.