### PR TITLE
release: v2.42.0 — Kani abstraction library, nested-predicate DSL, eight-pass auditor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "qedgen-solana-skills"
-version = "2.41.0"
+version = "2.42.0"
 dependencies = [
  "anyhow",
  "chumsky",

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qedgen-solana-skills"
-version = "2.41.0"
+version = "2.42.0"
 edition = "2021"
 authors = ["abishekk92"]
 description = "Spec-driven formal verification for Solana programs: .qedspec → Lean 4 proofs, Kani harnesses, coverage matrix, and Anchor-compatible Rust codegen"

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -16,7 +16,7 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]
 

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/lending.codegen.txt
+++ b/crates/qedgen/tests/snapshots/lending.codegen.txt
@@ -582,7 +582,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -571,7 +571,7 @@ debug = []
 
 
 [dependencies]
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 anchor-lang = "0.32.1"
 

--- a/docs/prds/RELEASE-v2.42.0.md
+++ b/docs/prds/RELEASE-v2.42.0.md
@@ -1,96 +1,112 @@
-# QEDGen v2.42.0 — the eight-pass auditor
+# QEDGen v2.42.0 — Kani abstraction library, nested-predicate DSL, and the eight-pass auditor
 
-**Status:** shipped (PRs #207, #209, #210, #211, #212, #213, #214).
-**Theme:** an auditor overhaul focused on **recall, precision, and
-consistency** — three new cross-cutting lenses, a prescriptive severity
-procedure, an adaptive multi-run loop, and a data-grounded catalog cleanup —
-plus an IDL-fidelity fix. No breaking changes; no DSL changes (those stay
-reserved for v3.0).
+**Status:** shipped. **Scope:** 16 PRs / 79 commits since v2.41.0.
+**Theme:** the formal-verification lane matures end-to-end — a trusted Kani
+**abstraction library**, the **nested-predicate DSL** that unlocks
+collection/option/enum invariants, and **IDL-driven + Context harness
+construction** that removes the last agent-fill from impl-Kani — alongside an
+**auditor overhaul** (eight cross-cutting passes) and **IDL/Codama fidelity**
+fixes. No breaking changes; no DSL removals (those stay reserved for v3.0).
 
-Every auditor change below was validated against real, independently-audited
-programs (a benchmark corpus of firm-audited Solana protocols across escrow,
-subscription, multisig, vault, lending, and governance domains): each new lens
-is backed by a concrete finding it recovers that the prior passes walked past.
+## 1. Kani abstraction library — `qedgen-kani-prelude` (#182, PR #186)
 
-## What shipped
+The headline. A vendored, soundness-cored abstraction crate that makes
+impl-Kani harnesses tractable by replacing intractable primitives with
+trusted uninterpreted models:
 
-### 1. Three new cross-cutting passes — §3d, §3e, §3f (#207, #210)
+- **Tier 1 — Pubkey abstraction:** abstract equality + ordering, auto-applied
+  (covers `binary_search` / `sort` / equality checks).
+- **Tier 2 — PDA derivation:** abstract `find_program_address` (uninterpreted +
+  injective), so authorization proofs don't unroll the hash.
+- **Tier 4 — runtime/host stubs:** `sol_log_*` no-op + CPI stubs, so a harness
+  that logs or CPIs still closes.
+- The crate ships **dep-free** (byte-level API for robust Shape-1 import), with
+  a **vendor writer** (`project::` delivers it into the target) and a **standing
+  CI soundness pin** (#188, PR #194) proving the abstractions themselves.
+- **Harness tractability:** nested-container harness reductions (**~5× fewer
+  VCCs** on deep-nested-state ensures), drop-suppression that **cracks the R2
+  CBMC wall** on brownfield, fixed-length symbolic `Vec` construction, and a
+  `qedsvm` bump to **v0.10.1**.
 
-The auditor's "Investigate" step now runs **eight** cross-cutting passes
-(§3a–§3h) alongside the per-category catalog. Three are net-new coverage —
-classes the catalog never had:
+## 2. Nested-predicate DSL (composition primitives)
 
-- **§3d — comparison-direction / inverted-guard sweep.** A guard that is
-  present and plausible-looking but enforces the *opposite* of its intent
-  (`<` where `>` was meant, an inverted accumulation sign). The arithmetic
-  probe keys off the operator *symbol*, not direction, so this class slips it;
-  §3d is a read discipline (direction-correctness needs intent), falsifiable
-  via a `.qedspec` Kani/proptest property when a spec exists.
-- **§3e — store-without-validate sweep.** A handler that persists an external
-  account/`Pubkey` into state with no on-curve / owned / signer /
-  PDA-derivation check, so a later handler trusts a value never checked at
-  write time. Distinguished from §3b (role anchoring in *this* handler).
-- **§3f — dead-guard / unwired-error-variant sweep.** An error variant defined
-  in `errors.rs` but wired into no guard — a named-but-never-enforced check.
-  Enumerate the enum, grep each variant for an enforcement call-site, flag the
-  zero-call-site ones. A dead guard inherits the impact ceiling of the path it
-  fails to protect (see the severity procedure below).
+New DSL surface that lets a `.qedspec` state invariants over collections,
+options, and enum payloads — the expressiveness the abstraction library needs:
 
-### 2. Two more passes — §3g, §3h (#210)
+- **Bounded quantifiers:** `exists|forall x in <collection>, pred(x)`
+  (→ `.iter().any|all`).
+- **Collection membership:** `contains(coll, elem)`; `len(coll)` builtin.
+- **Option handling:** `match`/`is` on `Option` fields (builtin `Some`/`None`).
+- **Enum payloads:** variant payload binding via `match` (enum-resolved,
+  shape-correct arms + `_` wildcard); tuple-variant construction (`of <Type>` →
+  `Enum::V(val)`); 3-way `is .Variant` shape.
+- **Richer State/record fields:** `Option<T>` and `Vec<record>` in State and
+  record fields (#173, #174).
 
-- **§3g — state-machine / lifecycle-transition soundness sweep.** Two shapes:
-  a premature transition (a container advanced to active/finalized before all
-  its parts are added, then locked), and a bricked permissionless create/init
-  (revert-DoS when the target address is pre-funded above rent-exempt).
-- **§3h — zero / sentinel-value asymmetry sweep.** A sentinel (`0` / `u64::MAX`
-  / `Pubkey::default()` / empty) one handler rejects while another honors as
-  meaningful, plus a one-sided-bound check (a window guarded on only one end).
+## 3. Kani harness construction — zero-agent-fill (#162, #169, #163)
 
-### 3. Severity as a prescriptive decision-procedure + provenance tag (#211)
+Impl-Kani harnesses are now generated from the spec/IDL with no hand-filled
+account or state construction:
 
-Severity guidance, previously scattered, is now **one four-step procedure**
-applied to every finding — (1) rate the impact ceiling assuming the
-precondition holds, (2) record the gate as a qualifier not a discount, (3)
-downgrade only when capability is absent or unreachable, (4) special cases
-(LOW-composes-to-CRIT; dead-guard inherits the unguarded path's ceiling). A
-prescriptive procedure is applied more consistently than scattered prose. Each
-finding now also carries a mandatory **`Surfaced by:`** tag (the pass /
-category / probe that found it) — a standing fire-rate signal.
+- **IDL-driven symbolic construction (#162):** generate the symbolic `State`
+  and account context directly from the qedspec (`pragma state_struct`),
+  including symbolic enum State-fields (G13a) and fixed-length Vecs.
+- **Context/instruction harness mode (#169, PR #193):** drive the real
+  `try_accounts` + instruction fn over symbolic `AccountInfo`s —
+  instruction-level authorization gates (`pragma context_struct`).
+- **`pragma kani_target` (#163):** zero-agent-fill harness targeting.
+- **A pragma family for harness shaping:** `kani_reject` (guard-enforcement /
+  falsification harness), `kani_panic_free` (panic-freedom), `kani_solver`
+  (bake `#[kani::solver(z3)]`), `kani_abstract_div` (abstract
+  `i64::checked_div`), `kani_vec_empty` / `kani_vec_bound`, `harness_use`,
+  optional invariant-assume, `Clock` sysvar stub.
+- **Brownfield impl-Kani (#168):** brownfield mode + computed unwind +
+  read-only-field fix; in-module harness placement; a **toolchain-scout agent**
+  + dogfooding loop for mining toolchain friction from real runs.
 
-### 4. Passes are primary; catalog is evidence (#212, #214)
+## 4. IDL / Codama fidelity
 
-A cross-reference table establishes the eight passes as the primary read-driven
-surface and maps the catalog categories a pass owns, killing the
-pass↔catalog drift. And the four **qedgen-codegen-only** categories
-(`generated_guard_bypass`, `stored_field_never_written`,
-`spec_impl_drift_user_owned`, `qed_hash_drift_or_forgery`) now carry an explicit
-brownfield-skip callout — a fire-rate analysis across a domain-diverse corpus
-confirmed they are the *only* categories that never fire on a hand-written
-audit target (they apply solely to generated code), so a brownfield audit skips
-them: less always-scanned catalog effort, zero recall loss.
+Brownfield ingest gets sharper on real-world IDLs:
 
-### 5. Adaptive N-run union (#213)
-
-The high-stakes N-run union is now an **outcome-driven loop**, not a fixed
-batch: surface a MED+ finding the instant a run produces it; a find is not a
-stop signal — keep running behind the scenes (runs routinely catch *different*
-top findings); a dry run is under-sampling evidence, not an all-clear, so run
-again; stop on convergence (K consecutive dry runs), budget, or user. N is a
-floor, not a ceiling.
-
-### 6. IDL fidelity — enum `definedTypes` + a test-stack fix (#209, #202)
-
-- Codama/Anchor enum `definedTypes` now render as real DSL sum types
+- **Codama `program.pdas[]` seeds (#200, PR #201):** mine real PDA seed
+  declarations instead of a TODO.
+- **Type mapping (#197):** `Option`/`Vec`/array field types map faithfully
+  instead of collapsing to `U64` (a mint's `Option<Pubkey>` authority no longer
+  becomes `U64`); framework-agnostic scanners everywhere (#196); Codama
+  ingestion (#197, PR #199).
+- **Enum `definedTypes` (#202, PR #209):** render real DSL sum types
   (`type AccountState | Uninitialized | Initialized | Frozen`) instead of a
-  generic `Uninitialized | Active` lifecycle. `IdlTypeBody` gains a `variants`
-  carrier; the Codama normalizer synthesizes it from an `enumTypeNode`.
-- A deeply-nested brownfield-Kani test now runs on a large-stack thread —
-  clears a debug-build stack-overflow that aborted `cargo test` on macOS
-  (release and CI were unaffected; the generator was always correct).
+  generic `Uninitialized | Active` lifecycle.
+- **Probe UTF-8 (#187, PR #195):** snap byte-window offsets to char boundaries.
+
+## 5. The eight-pass auditor (#207–#214)
+
+The auditor "Investigate" step now runs **eight cross-cutting passes**
+(§3a–§3h), each validated against a firm-audited benchmark corpus:
+
+- **§3d comparison-direction / inverted-guard**, **§3e store-without-validate**,
+  **§3f dead-guard / unwired-error-variant** (#207, #210) — three net-new
+  coverage classes.
+- **§3g state-machine / lifecycle-transition soundness**, **§3h zero/sentinel
+  asymmetry** (#210).
+- **Severity → one prescriptive 4-step decision-procedure** + mandatory
+  `Surfaced by:` provenance tag (#211).
+- **Passes-are-primary catalog cross-link** + **brownfield-skip** for the four
+  qedgen-codegen-only categories — a fire-rate analysis across a domain-diverse
+  corpus confirmed they are the only categories that never fire on a
+  hand-written target (#212, #214).
+- **Adaptive N-run union** — surface-on-fire, keep-running, dry-means-run-again,
+  stop-on-convergence (#213).
+
+## 6. Infra / hygiene
+
+- `qedsvm` v0.9.0 → v0.10.1; CI free-disk + rustfmt; clippy fixes for newer CI
+  clippy; the `qedgen-kani-prelude` `[workspace]` collision fix.
+- A big-stack test wrapper clears a macOS debug `cargo test` abort (#209).
 
 ## Compatibility
 
 No breaking changes. Generated codegen output is unchanged except the
-version-tag re-stamp in bundled example `Cargo.toml` pins. The auditor changes
-are all in the skill surface (`skills/qedgen-auditor/`); the CLI/codegen change
-is the IDL enum fix.
+version-tag re-stamp in the bundled example `Cargo.toml` pins. New DSL and
+pragmas are additive; new Kani-prelude delivery is opt-in via emitted harness
+text.

--- a/docs/prds/RELEASE-v2.42.0.md
+++ b/docs/prds/RELEASE-v2.42.0.md
@@ -1,0 +1,96 @@
+# QEDGen v2.42.0 — the eight-pass auditor
+
+**Status:** shipped (PRs #207, #209, #210, #211, #212, #213, #214).
+**Theme:** an auditor overhaul focused on **recall, precision, and
+consistency** — three new cross-cutting lenses, a prescriptive severity
+procedure, an adaptive multi-run loop, and a data-grounded catalog cleanup —
+plus an IDL-fidelity fix. No breaking changes; no DSL changes (those stay
+reserved for v3.0).
+
+Every auditor change below was validated against real, independently-audited
+programs (a benchmark corpus of firm-audited Solana protocols across escrow,
+subscription, multisig, vault, lending, and governance domains): each new lens
+is backed by a concrete finding it recovers that the prior passes walked past.
+
+## What shipped
+
+### 1. Three new cross-cutting passes — §3d, §3e, §3f (#207, #210)
+
+The auditor's "Investigate" step now runs **eight** cross-cutting passes
+(§3a–§3h) alongside the per-category catalog. Three are net-new coverage —
+classes the catalog never had:
+
+- **§3d — comparison-direction / inverted-guard sweep.** A guard that is
+  present and plausible-looking but enforces the *opposite* of its intent
+  (`<` where `>` was meant, an inverted accumulation sign). The arithmetic
+  probe keys off the operator *symbol*, not direction, so this class slips it;
+  §3d is a read discipline (direction-correctness needs intent), falsifiable
+  via a `.qedspec` Kani/proptest property when a spec exists.
+- **§3e — store-without-validate sweep.** A handler that persists an external
+  account/`Pubkey` into state with no on-curve / owned / signer /
+  PDA-derivation check, so a later handler trusts a value never checked at
+  write time. Distinguished from §3b (role anchoring in *this* handler).
+- **§3f — dead-guard / unwired-error-variant sweep.** An error variant defined
+  in `errors.rs` but wired into no guard — a named-but-never-enforced check.
+  Enumerate the enum, grep each variant for an enforcement call-site, flag the
+  zero-call-site ones. A dead guard inherits the impact ceiling of the path it
+  fails to protect (see the severity procedure below).
+
+### 2. Two more passes — §3g, §3h (#210)
+
+- **§3g — state-machine / lifecycle-transition soundness sweep.** Two shapes:
+  a premature transition (a container advanced to active/finalized before all
+  its parts are added, then locked), and a bricked permissionless create/init
+  (revert-DoS when the target address is pre-funded above rent-exempt).
+- **§3h — zero / sentinel-value asymmetry sweep.** A sentinel (`0` / `u64::MAX`
+  / `Pubkey::default()` / empty) one handler rejects while another honors as
+  meaningful, plus a one-sided-bound check (a window guarded on only one end).
+
+### 3. Severity as a prescriptive decision-procedure + provenance tag (#211)
+
+Severity guidance, previously scattered, is now **one four-step procedure**
+applied to every finding — (1) rate the impact ceiling assuming the
+precondition holds, (2) record the gate as a qualifier not a discount, (3)
+downgrade only when capability is absent or unreachable, (4) special cases
+(LOW-composes-to-CRIT; dead-guard inherits the unguarded path's ceiling). A
+prescriptive procedure is applied more consistently than scattered prose. Each
+finding now also carries a mandatory **`Surfaced by:`** tag (the pass /
+category / probe that found it) — a standing fire-rate signal.
+
+### 4. Passes are primary; catalog is evidence (#212, #214)
+
+A cross-reference table establishes the eight passes as the primary read-driven
+surface and maps the catalog categories a pass owns, killing the
+pass↔catalog drift. And the four **qedgen-codegen-only** categories
+(`generated_guard_bypass`, `stored_field_never_written`,
+`spec_impl_drift_user_owned`, `qed_hash_drift_or_forgery`) now carry an explicit
+brownfield-skip callout — a fire-rate analysis across a domain-diverse corpus
+confirmed they are the *only* categories that never fire on a hand-written
+audit target (they apply solely to generated code), so a brownfield audit skips
+them: less always-scanned catalog effort, zero recall loss.
+
+### 5. Adaptive N-run union (#213)
+
+The high-stakes N-run union is now an **outcome-driven loop**, not a fixed
+batch: surface a MED+ finding the instant a run produces it; a find is not a
+stop signal — keep running behind the scenes (runs routinely catch *different*
+top findings); a dry run is under-sampling evidence, not an all-clear, so run
+again; stop on convergence (K consecutive dry runs), budget, or user. N is a
+floor, not a ceiling.
+
+### 6. IDL fidelity — enum `definedTypes` + a test-stack fix (#209, #202)
+
+- Codama/Anchor enum `definedTypes` now render as real DSL sum types
+  (`type AccountState | Uninitialized | Initialized | Frozen`) instead of a
+  generic `Uninitialized | Active` lifecycle. `IdlTypeBody` gains a `variants`
+  carrier; the Codama normalizer synthesizes it from an `enumTypeNode`.
+- A deeply-nested brownfield-Kani test now runs on a large-stack thread —
+  clears a debug-build stack-overflow that aborted `cargo test` on macOS
+  (release and CI were unaffected; the generator was always correct).
+
+## Compatibility
+
+No breaking changes. Generated codegen output is unchanged except the
+version-tag re-stamp in bundled example `Cargo.toml` pins. The auditor changes
+are all in the skill surface (`skills/qedgen-auditor/`); the CLI/codegen change
+is the IDL enum fix.

--- a/examples/rust/cross-program-vault/programs/Cargo.toml
+++ b/examples/rust/cross-program-vault/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 anchor-lang = "0.32.1"
 anchor-spl = "0.32.1"
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]

--- a/examples/rust/escrow/Cargo.toml
+++ b/examples/rust/escrow/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]

--- a/examples/rust/escrow/programs/Cargo.toml
+++ b/examples/rust/escrow/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]

--- a/examples/rust/lending/Cargo.toml
+++ b/examples/rust/lending/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]

--- a/examples/rust/lending/programs/Cargo.toml
+++ b/examples/rust/lending/programs/Cargo.toml
@@ -15,6 +15,6 @@ debug = []
 [dependencies]
 quasar-lang = { version = "0.0.0" }
 quasar-spl = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]

--- a/examples/rust/multisig/Cargo.toml
+++ b/examples/rust/multisig/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]

--- a/examples/rust/multisig/programs/Cargo.toml
+++ b/examples/rust/multisig/programs/Cargo.toml
@@ -14,6 +14,6 @@ debug = []
 
 [dependencies]
 quasar-lang = { version = "0.0.0" }
-qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.41.0" }
+qedgen-macros = { git = "https://github.com/qedgen/solana-skills", tag = "v2.42.0" }
 
 [workspace]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qedgen-solana-skills",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "description": "Agent skill for spec-driven verification and audit of Solana programs \u2014 .qedspec specs generate proptest, Kani, and Lean 4 backends plus agent-fill Anchor / Quasar scaffolds; brownfield probes audit Anchor / Quasar / Pinocchio / native / sBPF programs (Miri verify, scaffold-to-spec interview, deploy-safety ratchet).",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
Cuts **v2.42.0** — **16 PRs / 79 commits** since v2.41.0. No breaking changes, no DSL removals. Full notes: `docs/prds/RELEASE-v2.42.0.md`.

## Scope (six themes)

1. **Kani abstraction library `qedgen-kani-prelude` (#182, #186)** — trusted uninterpreted models: Pubkey abstraction (T1), PDA derivation (T2), log/CPI runtime stubs (T4); dep-free vendored crate + standing CI soundness pin (#188/#194); ~5× VCC reduction on deep-nested ensures + drop-suppression cracks the R2 CBMC wall; qedsvm → v0.10.1.
2. **Nested-predicate DSL** — `exists|forall x in coll, pred`; `contains`/`len`; `match`/`is` on `Option`; enum variant payload binding + tuple-variant construction + `is .Variant`; `Option<T>`/`Vec<record>` State fields.
3. **Kani harness construction, zero-agent-fill (#162, #169, #163)** — IDL-driven symbolic State/account construction (`pragma state_struct`); Context/instruction mode over symbolic `AccountInfo`s (`pragma context_struct`, #193); pragma family (`kani_target`/`kani_reject`/`kani_panic_free`/`kani_solver`/`kani_abstract_div`/`kani_vec_*`/`harness_use`); brownfield impl-Kani + toolchain-scout agent (#168).
4. **IDL / Codama fidelity** — mine `program.pdas[]` seeds (#200); faithful `Option`/`Vec`/array type mapping instead of `U64` (#197); Codama ingestion + agnostic scanners (#196/#199); enum `definedTypes` → real sum types (#202); probe UTF-8 char-boundary snap (#187).
5. **Eight-pass auditor (#207–#214)** — §3d–§3h cross-cutting lenses, prescriptive severity procedure + `Surfaced by:` provenance, passes-primary catalog cross-link + brownfield-skip, adaptive N-run union.
6. **Infra** — CI free-disk/rustfmt, clippy fixes, `[workspace]` collision fix, macOS big-stack `cargo test` fix (#209).

## Release mechanics (this PR)

Version bump `2.41.0 → 2.42.0` (Cargo.toml + package.json, consistency ✓); re-stamped the `qedgen-macros` tag pin in 5 codegen snapshots + bundled example `Cargo.toml`s (every diff is only the version line); full release notes.

## Gates (green)

`version-consistency` · `fmt --check` · `clippy -D warnings` · `cargo test` (1146 unit + all suites, 0 failed) · `readme-drift` · `cargo deny` · frozen · zero-sorry (generated proofs). Lean lake-build unaffected (no `.lean`/proof code changed). Prior commit CI: test + supply-chain both passed.

Tag `v2.42.0` after merge.
