### PR TITLE
Kani: T2 trusted-crypto stubs, prelude correctness proofs, Bytes32/64 wide-compare, Vec-bound lint (#189–#192)

### DIFF
--- a/crates/qedgen/src/check/lints/arithmetic.rs
+++ b/crates/qedgen/src/check/lints/arithmetic.rs
@@ -430,6 +430,8 @@ pub(super) fn check_map_and_subscript(spec: &ParsedSpec) -> Vec<CompletenessWarn
                             | "I64"
                             | "I128"
                             | "Pubkey"
+                            | "Bytes32"
+                            | "Bytes64"
                     );
                 if !is_known {
                     warnings.push(warn("map_value_unknown", Severity::Error, 0, format!(

--- a/crates/qedgen/src/codegen/codegen_shared/types.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/types.rs
@@ -650,6 +650,11 @@ pub(crate) fn primitive_map(dsl_type: &str, context: TypeMapContext) -> Option<&
             TypeMapContext::Anchor | TypeMapContext::Quasar => "Pubkey",
             TypeMapContext::Standalone => "[u8; 32]",
         },
+        // Opaque byte tokens (#191): hashes/digests (`Bytes32`) and
+        // signatures / recovered secp keys (`Bytes64`). No framework newtype
+        // exists, so they lower to raw arrays in EVERY context.
+        "Bytes32" => "[u8; 32]",
+        "Bytes64" => "[u8; 64]",
         "U8" => "u8",
         "U16" => "u16",
         "U32" => "u32",
@@ -730,8 +735,11 @@ pub(crate) fn default_value_for_type(dsl_type: &str, spec: &ParsedSpec) -> Optio
         return Some("0".to_string());
     }
 
-    if dsl_type == "Pubkey" {
+    if dsl_type == "Pubkey" || dsl_type == "Bytes32" {
         return Some("[0u8; 32]".to_string());
+    }
+    if dsl_type == "Bytes64" {
+        return Some("[0u8; 64]".to_string());
     }
 
     Some("0".to_string())

--- a/crates/qedgen/src/codegen/kani_impl/brownfield.rs
+++ b/crates/qedgen/src/codegen/kani_impl/brownfield.rs
@@ -142,6 +142,18 @@ pub(crate) fn emit_kani_impl_anchor_brownfield(
         out.push('\n');
     }
 
+    // Abstract hash primitives (#189 Tier 2) — emitted once when opted in.
+    if super::state_ctor::wants_hash_stub(spec) {
+        out.push_str(&super::state_ctor::hash_stub_fn());
+        out.push('\n');
+    }
+
+    // Abstract secp256k1 recovery (#189 Tier 2) — emitted once when opted in.
+    if super::state_ctor::wants_secp256k1_stub(spec) {
+        out.push_str(&super::state_ctor::secp256k1_stub_fn());
+        out.push('\n');
+    }
+
     // Clock stub (G14) — emitted once; each proof carries the `#[kani::stub]`.
     if super::state_ctor::wants_clock_stub(spec) {
         out.push_str(&super::state_ctor::clock_stub_fn());

--- a/crates/qedgen/src/codegen/kani_impl/context.rs
+++ b/crates/qedgen/src/codegen/kani_impl/context.rs
@@ -127,6 +127,14 @@ pub(crate) fn emit_kani_impl_anchor_context(
         out.push_str(&super::state_ctor::pda_stub_fn());
         out.push('\n');
     }
+    if super::state_ctor::wants_hash_stub(spec) {
+        out.push_str(&super::state_ctor::hash_stub_fn());
+        out.push('\n');
+    }
+    if super::state_ctor::wants_secp256k1_stub(spec) {
+        out.push_str(&super::state_ctor::secp256k1_stub_fn());
+        out.push('\n');
+    }
     if super::state_ctor::wants_clock_stub(spec) {
         out.push_str(&super::state_ctor::clock_stub_fn());
         out.push('\n');

--- a/crates/qedgen/src/codegen/kani_impl/harness.rs
+++ b/crates/qedgen/src/codegen/kani_impl/harness.rs
@@ -404,6 +404,8 @@ fn is_copy_scalar_ty(t: &str) -> bool {
                 | "I128"
                 | "Bool"
                 | "Pubkey"
+                | "Bytes32"
+                | "Bytes64"
         )
 }
 
@@ -432,9 +434,18 @@ pub(crate) fn emit_impl_proof_attrs(out: &mut String, handler: &ParsedHandler, s
     if abstract_pk {
         out.push_str(super::state_ctor::pubkey_stub_attr());
     }
-    // #182 Tier 2 — redirect PDA derivation to an opaque address (skip sha256).
+    // #182 Tier 2 — redirect PDA derivation to a deterministic uninterpreted
+    // function (skip the sha256 + bump-search bit-blast; #189).
     if super::state_ctor::wants_pda_abstraction(spec) {
         out.push_str(super::state_ctor::pda_stub_attr());
+    }
+    // #189 Tier 2 — hash primitives and secp256k1 recovery as deterministic
+    // uninterpreted functions (opt-in).
+    if super::state_ctor::wants_hash_stub(spec) {
+        out.push_str(super::state_ctor::hash_stub_attr());
+    }
+    if super::state_ctor::wants_secp256k1_stub(spec) {
+        out.push_str(super::state_ctor::secp256k1_stub_attr());
     }
     // G14 — the agent-fill effect calls a `Clock::get()`-reading method; stub it.
     if super::state_ctor::wants_clock_stub(spec) {
@@ -1172,32 +1183,79 @@ fn suggested_unwind(
 ) -> (u32, &'static str) {
     // Impl-targeted harnesses CALL real code (the handler / `invariant()` /
     // helper), which operates on the WHOLE account struct — not just the fields
-    // this harness snapshots. So a `Pubkey` anywhere in the model — a param, or
-    // ANY state field (snapshotted or not) — signals the callee likely does a
-    // 32-byte `memcmp` (owner / `has_one` / dedup / `windows` checks), which
-    // only fully unwinds at N ≥ 34. Bias conservative: a too-low bound fails
-    // with an "unwinding assertion" (the exact trial-and-error F2 removes),
-    // whereas a too-high bound is merely slower.
-    // #182 Tier 1: when Pubkey `==` is abstracted (stubbed to a wide-integer
-    // compare), the 32-byte memcmp that forced ≥34 is gone — the remaining
-    // loops iterate `kani_vec_bound`-sized collections, so a small bound closes.
-    if abstract_pubkey {
-        let bound = super::state_ctor::vec_bound_of(spec) as u32 + 4;
-        return (
-            bound,
+    // this harness snapshots. So a byte-token anywhere in the model — a param,
+    // or ANY state field (snapshotted or not) — signals the callee likely does
+    // a byte-array `memcmp` (owner / `has_one` / dedup / `windows` checks),
+    // which only fully unwinds at N ≥ width + 2. Bias conservative: a too-low
+    // bound fails with an "unwinding assertion" (the exact trial-and-error F2
+    // removes), whereas a too-high bound is merely slower.
+    //
+    // #182 Tier 1 covers `Pubkey` (a NEWTYPE, so its derived `==` is a
+    // stubbable named impl). `Bytes32`/`Bytes64` (#191) lower to raw
+    // `[u8; N]`, whose `PartialEq` is a generic core impl Kani cannot stub
+    // (model-checking/kani#1997) — so a Bytes field keeps the memcmp floor
+    // even when the Pubkey abstraction is active.
+    let (base, why) = if spec_mentions_type(spec, handler, "Bytes64") {
+        (
+            66u32,
+            "Bytes64 in state/params → raw [u8; 64] memcmp (unstubbable, kani#1997); needs ≥ 66",
+        )
+    } else if spec_mentions_type(spec, handler, "Bytes32") {
+        (
+            34,
+            "Bytes32 in state/params → raw [u8; 32] memcmp (unstubbable, kani#1997); needs ≥ 34",
+        )
+    } else if abstract_pubkey {
+        // #182 Tier 1: when Pubkey `==` is abstracted (stubbed to a
+        // wide-integer compare), the 32-byte memcmp that forced ≥34 is gone —
+        // the remaining loops iterate `kani_vec_bound`-sized collections.
+        (
+            super::state_ctor::vec_bound_of(spec) as u32 + 4,
             "Pubkey `==` abstracted (#182) — no memcmp; small bound",
-        );
-    }
-
-    let param_touches_bytes = handler.takes_params.iter().any(|(_, t)| is_pubkey_type(t));
-    let state_has_pubkey = !pubkey_state_field_names(spec).is_empty();
-
-    if param_touches_bytes || state_has_pubkey {
+        )
+    } else if handler.takes_params.iter().any(|(_, t)| is_pubkey_type(t))
+        || !pubkey_state_field_names(spec).is_empty()
+    {
         (
             34,
             "Pubkey in state/params → callee does a 32-byte memcmp; needs ≥ 34",
         )
     } else {
-        (4, "no Pubkey fields — no 32-byte memcmp")
+        (4, "no byte-token fields — no memcmp")
+    };
+
+    // #189: the PDA / hash / secp256k1 uninterpreted-function stubs scan a
+    // CAP=8 memo table per call — the harness bound must cover that loop.
+    let uses_ufmap_stub = super::state_ctor::wants_pda_abstraction(spec)
+        || super::state_ctor::wants_hash_stub(spec)
+        || super::state_ctor::wants_secp256k1_stub(spec);
+    if uses_ufmap_stub && base < 10 {
+        return (10, "UfMap memo scan (CAP 8) in a #189 stub; needs ≥ 10");
     }
+    (base, why)
+}
+
+/// True when any state field, record / sum payload, or handler param mentions
+/// the given DSL type name (word-boundary match, so `Option Bytes32` /
+/// `Vec Bytes64` count). The byte-token analogue of the `Pubkey` scans above.
+fn spec_mentions_type(spec: &ParsedSpec, handler: &ParsedHandler, type_name: &str) -> bool {
+    let mentions = |t: &str| {
+        t.split(|c: char| !c.is_alphanumeric())
+            .any(|w| w == type_name)
+    };
+    spec.state_fields.iter().any(|(_, t)| mentions(t))
+        || spec
+            .account_types
+            .iter()
+            .any(|a| a.fields.iter().any(|(_, t)| mentions(t)))
+        || spec
+            .records
+            .iter()
+            .any(|r| r.fields.iter().any(|(_, t)| mentions(t)))
+        || spec.sum_types.iter().any(|s| {
+            s.variants
+                .iter()
+                .any(|v| v.fields.iter().any(|(_, t)| mentions(t)))
+        })
+        || handler.takes_params.iter().any(|(_, t)| mentions(t))
 }

--- a/crates/qedgen/src/codegen/kani_impl/mod.rs
+++ b/crates/qedgen/src/codegen/kani_impl/mod.rs
@@ -218,6 +218,13 @@ fn generate_from_spec_with_context(
         return Ok(());
     }
 
+    // #192: warn when a property reads into a Vec state field but the
+    // symbolic-length bound is at its silent default (see
+    // `vec_bound_undercoverage_warnings` for the trade-off).
+    for warning in state_ctor::vec_bound_undercoverage_warnings(spec) {
+        eprintln!("warning: {warning}");
+    }
+
     let handlers_with_claims: Vec<&ParsedHandler> = spec
         .handlers
         .iter()

--- a/crates/qedgen/src/codegen/kani_impl/state_ctor.rs
+++ b/crates/qedgen/src/codegen/kani_impl/state_ctor.rs
@@ -231,28 +231,174 @@ pub(crate) fn wants_pda_abstraction(spec: &ParsedSpec) -> bool {
     spec.pragma_value("kani_stub_pda").is_some()
 }
 
-/// The abstract PDA-derivation support fn (emitted once when
-/// `wants_pda_abstraction`). Returns an OPAQUE deterministic address, not the
-/// real sha256. Sound over-approximation for safety — the program must hold for
-/// ANY derived address; we never re-verify that sha256 is sha256.
+/// The abstract PDA-derivation support fns (emitted once when
+/// `wants_pda_abstraction`). Uninterpreted functions over (seeds, program_id):
+/// DETERMINISTIC (same seeds → same address — the property programs rely on
+/// with derive-then-compare, machine-checked in the prelude) and INJECTIVE
+/// across the harness (collision-freedom axiom — mirrors trusting sha256
+/// collision resistance, exactly the Lean side's PDA axiom). #189 upgrade of
+/// the old fresh-`kani::any()` stub, which lost determinism.
 pub(crate) fn pda_stub_fn() -> String {
-    "// Abstract PDA derivation (#182 Tier 2): an OPAQUE address, NOT the real\n\
-     // sha256 + bump search (which bit-blasts catastrophically — the sha2\n\
-     // GenericArray fold doesn't even unwind). Sound over-approximation for\n\
-     // safety properties; verification-only.\n\
+    "// Abstract PDA derivation (#182 Tier 2, deterministic + injective — #189):\n\
+     // an uninterpreted function over (seeds, program_id), NOT the real sha256 +\n\
+     // bump search (which bit-blasts catastrophically — the sha2 GenericArray\n\
+     // fold doesn't even unwind). Same seeds → same address (memoized in the\n\
+     // prelude's UfMap; determinism machine-checked there); distinct seeds →\n\
+     // distinct addresses (collision-freedom AXIOM — the trust argument is in\n\
+     // the prelude's Tier 2 docs). The bump stays fully symbolic, and\n\
+     // `create_program_address` uses a separate domain (its bump-in-seeds\n\
+     // relationship to `find_program_address` is NOT modeled) and may\n\
+     // nondeterministically fail like the real off-curve check.\n\
+     // Verification-only.\n\
+     static QEDGEN_PDA_UF: qedgen_kani_prelude::UfCell32<8> =\n\
+     \x20   qedgen_kani_prelude::UfCell32::new();\n\
      fn find_pda_abstract(\n\
-     \x20   _seeds: &[&[u8]],\n\
-     \x20   _program_id: &anchor_lang::prelude::Pubkey,\n\
+     \x20   seeds: &[&[u8]],\n\
+     \x20   program_id: &anchor_lang::prelude::Pubkey,\n\
      ) -> (anchor_lang::prelude::Pubkey, u8) {\n\
-     \x20   (anchor_lang::prelude::Pubkey::new_from_array(kani::any()), kani::any())\n\
+     \x20   let mut key = qedgen_kani_prelude::UfKey::new().push(b\"find\");\n\
+     \x20   for seed in seeds {\n\
+     \x20       key = key.push(seed);\n\
+     \x20   }\n\
+     \x20   key = key.push(program_id.as_ref());\n\
+     \x20   let addr = QEDGEN_PDA_UF.apply(key);\n\
+     \x20   (anchor_lang::prelude::Pubkey::new_from_array(addr), kani::any())\n\
+     }\n\
+     fn create_pda_abstract(\n\
+     \x20   seeds: &[&[u8]],\n\
+     \x20   program_id: &anchor_lang::prelude::Pubkey,\n\
+     ) -> core::result::Result<anchor_lang::prelude::Pubkey, solana_program::pubkey::PubkeyError> {\n\
+     \x20   if kani::any() {\n\
+     \x20       // Nondeterministic failure keeps the real off-curve error path.\n\
+     \x20       return Err(solana_program::pubkey::PubkeyError::InvalidSeeds);\n\
+     \x20   }\n\
+     \x20   let mut key = qedgen_kani_prelude::UfKey::new().push(b\"create\");\n\
+     \x20   for seed in seeds {\n\
+     \x20       key = key.push(seed);\n\
+     \x20   }\n\
+     \x20   key = key.push(program_id.as_ref());\n\
+     \x20   Ok(anchor_lang::prelude::Pubkey::new_from_array(QEDGEN_PDA_UF.apply(key)))\n\
      }\n"
     .to_string()
 }
 
-/// The `#[kani::stub]` attribute redirecting `find_program_address` to the
-/// abstract (needs `-Z stubbing`).
+/// The `#[kani::stub]` attributes redirecting PDA derivation to the abstract
+/// uninterpreted functions (needs `-Z stubbing`).
 pub(crate) fn pda_stub_attr() -> &'static str {
-    "#[kani::stub(solana_program::pubkey::Pubkey::find_program_address, find_pda_abstract)]\n"
+    "#[kani::stub(solana_program::pubkey::Pubkey::find_program_address, find_pda_abstract)]\n\
+     #[kani::stub(solana_program::pubkey::Pubkey::create_program_address, create_pda_abstract)]\n"
+}
+
+/// `pragma kani_stub_hash = <anything>` → the agent-fill effect calls code
+/// that hashes (sha256 / keccak / blake3) — exhaustively bit-blasted by CBMC
+/// at zero verification value. Stub each to a deterministic uninterpreted
+/// function with the collision-freedom axiom (#189 Tier 2), the Kani mirror of
+/// the Lean side's hash axioms. Opt-in like `kani_stub_pda`: the hashing is
+/// inside called methods, not visible from the spec.
+pub(crate) fn wants_hash_stub(spec: &ParsedSpec) -> bool {
+    spec.pragma_value("kani_stub_hash").is_some()
+}
+
+/// The abstract hash support fns (emitted once when `wants_hash_stub`). One
+/// UfMap per primitive (domain separation by static); `hash(x)` and
+/// `hashv(&[x])` share a key construction, so they agree by construction —
+/// matching the real functions.
+pub(crate) fn hash_stub_fn() -> String {
+    "// Abstract sha256 / keccak / blake3 (#189 Tier 2): deterministic\n\
+     // uninterpreted functions + collision-freedom axiom, per primitive — NOT\n\
+     // the real compression functions (which bit-blast catastrophically). The\n\
+     // trust argument lives in the prelude's Tier 2 docs; verification-only.\n\
+     static QEDGEN_SHA256_UF: qedgen_kani_prelude::UfCell32<8> =\n\
+     \x20   qedgen_kani_prelude::UfCell32::new();\n\
+     static QEDGEN_KECCAK_UF: qedgen_kani_prelude::UfCell32<8> =\n\
+     \x20   qedgen_kani_prelude::UfCell32::new();\n\
+     static QEDGEN_BLAKE3_UF: qedgen_kani_prelude::UfCell32<8> =\n\
+     \x20   qedgen_kani_prelude::UfCell32::new();\n\
+     fn qedgen_uf_key(vals: &[&[u8]]) -> qedgen_kani_prelude::UfKey {\n\
+     \x20   let mut key = qedgen_kani_prelude::UfKey::new();\n\
+     \x20   for v in vals {\n\
+     \x20       key = key.push(v);\n\
+     \x20   }\n\
+     \x20   key\n\
+     }\n\
+     fn sha256_abstract(val: &[u8]) -> solana_program::hash::Hash {\n\
+     \x20   sha256v_abstract(&[val])\n\
+     }\n\
+     fn sha256v_abstract(vals: &[&[u8]]) -> solana_program::hash::Hash {\n\
+     \x20   solana_program::hash::Hash::new_from_array(QEDGEN_SHA256_UF.apply(qedgen_uf_key(vals)))\n\
+     }\n\
+     fn keccak_abstract(val: &[u8]) -> solana_program::keccak::Hash {\n\
+     \x20   keccakv_abstract(&[val])\n\
+     }\n\
+     fn keccakv_abstract(vals: &[&[u8]]) -> solana_program::keccak::Hash {\n\
+     \x20   solana_program::keccak::Hash(QEDGEN_KECCAK_UF.apply(qedgen_uf_key(vals)))\n\
+     }\n\
+     fn blake3_abstract(val: &[u8]) -> solana_program::blake3::Hash {\n\
+     \x20   blake3v_abstract(&[val])\n\
+     }\n\
+     fn blake3v_abstract(vals: &[&[u8]]) -> solana_program::blake3::Hash {\n\
+     \x20   solana_program::blake3::Hash(QEDGEN_BLAKE3_UF.apply(qedgen_uf_key(vals)))\n\
+     }\n"
+    .to_string()
+}
+
+/// The `#[kani::stub]` attributes for the hash primitives (needs `-Z stubbing`).
+pub(crate) fn hash_stub_attr() -> &'static str {
+    "#[kani::stub(solana_program::hash::hash, sha256_abstract)]\n\
+     #[kani::stub(solana_program::hash::hashv, sha256v_abstract)]\n\
+     #[kani::stub(solana_program::keccak::hash, keccak_abstract)]\n\
+     #[kani::stub(solana_program::keccak::hashv, keccakv_abstract)]\n\
+     #[kani::stub(solana_program::blake3::hash, blake3_abstract)]\n\
+     #[kani::stub(solana_program::blake3::hashv, blake3v_abstract)]\n"
+}
+
+/// `pragma kani_stub_secp256k1 = <anything>` → the agent-fill effect calls
+/// `secp256k1_recover` (the one in-program signature primitive — ed25519
+/// verification is a precompile reached via instruction introspection and has
+/// no stubbable in-program entry point). Stub it to a deterministic
+/// uninterpreted function over (hash, recovery_id, signature) with the
+/// collision-freedom axiom, plus a NONDETERMINISTIC failure branch so the real
+/// invalid-signature error path stays explored (#189 Tier 2).
+pub(crate) fn wants_secp256k1_stub(spec: &ParsedSpec) -> bool {
+    spec.pragma_value("kani_stub_secp256k1").is_some()
+}
+
+/// The abstract `secp256k1_recover` support fn (emitted once when
+/// `wants_secp256k1_stub`).
+pub(crate) fn secp256k1_stub_fn() -> String {
+    "// Abstract secp256k1 recovery (#189 Tier 2): a deterministic uninterpreted\n\
+     // function over (hash, recovery_id, signature) — same inputs recover the\n\
+     // same 64-byte pubkey, distinct inputs recover distinct pubkeys\n\
+     // (collision-freedom axiom; trust argument in the prelude's Tier 2 docs).\n\
+     // The `if kani::any()` failure branch keeps the real invalid-input error\n\
+     // path explored. Verification-only.\n\
+     static QEDGEN_SECP_UF: qedgen_kani_prelude::UfCell64<8> =\n\
+     \x20   qedgen_kani_prelude::UfCell64::new();\n\
+     fn secp256k1_recover_abstract(\n\
+     \x20   hash: &[u8],\n\
+     \x20   recovery_id: u8,\n\
+     \x20   signature: &[u8],\n\
+     ) -> core::result::Result<\n\
+     \x20   solana_program::secp256k1_recover::Secp256k1Pubkey,\n\
+     \x20   solana_program::secp256k1_recover::Secp256k1RecoverError,\n\
+     > {\n\
+     \x20   if kani::any() {\n\
+     \x20       return Err(solana_program::secp256k1_recover::Secp256k1RecoverError::InvalidSignature);\n\
+     \x20   }\n\
+     \x20   let key = qedgen_kani_prelude::UfKey::new()\n\
+     \x20       .push(hash)\n\
+     \x20       .push(&[recovery_id])\n\
+     \x20       .push(signature);\n\
+     \x20   Ok(solana_program::secp256k1_recover::Secp256k1Pubkey(\n\
+     \x20       QEDGEN_SECP_UF.apply(key),\n\
+     \x20   ))\n\
+     }\n"
+    .to_string()
+}
+
+/// The `#[kani::stub]` attribute for `secp256k1_recover` (needs `-Z stubbing`).
+pub(crate) fn secp256k1_stub_attr() -> &'static str {
+    "#[kani::stub(solana_program::secp256k1_recover::secp256k1_recover, secp256k1_recover_abstract)]\n"
 }
 
 /// `pragma kani_stub_log` → stub Solana logging (`msg!` / `sol_log` /
@@ -457,6 +603,9 @@ fn emit_value(ty: &Ty, ctx: &CtorCtx, depth: usize) -> Option<String> {
             "kani::any()".to_string()
         }
         Ty::Pubkey => "anchor_lang::prelude::Pubkey::new_from_array(kani::any())".to_string(),
+        // Opaque byte tokens (#191) — raw `[u8; N]` in the real struct;
+        // arrays are `kani::any()`-constructible const-generically.
+        Ty::Bytes32 | Ty::Bytes64 => "kani::any()".to_string(),
         Ty::Custom(s) => {
             // `Option T` / `Vec T` ride as `Ty::Custom("Option T")` / `"Vec T"`
             // (the MIR `Ty` enum has no first-class Option/Vec — see #173/#174);
@@ -564,6 +713,85 @@ pub(crate) fn vec_bound_of(spec: &ParsedSpec) -> usize {
     spec.pragma_value("kani_vec_bound")
         .and_then(|v| v.trim().parse::<usize>().ok())
         .unwrap_or(1)
+}
+
+/// #192 lint: a property that READS INTO a `Vec` state field (membership,
+/// aggregation, per-element invariants) is silently under-covered when the
+/// fixed symbolic length is left at the default 1 — the proof is green while
+/// exploring only 1-element collections. Fires one warning per (surface,
+/// field) at Kani codegen time; pure spec analysis, no new codegen paths.
+///
+/// Deliberately quiet when `pragma kani_vec_bound` is set to ANY value: an
+/// explicit bound is a conscious BMC trade-off, and second-guessing the
+/// number would train users to ignore the lint. Scalar-only properties over
+/// specs with Vec fields stay silent (the default-1 trade-off is exactly
+/// right for them).
+pub(crate) fn vec_bound_undercoverage_warnings(spec: &ParsedSpec) -> Vec<String> {
+    if spec.pragma_value("kani_vec_bound").is_some() {
+        return Vec::new();
+    }
+    // Vec-typed fields across the spec's state shapes.
+    let mut vec_fields: Vec<String> = Vec::new();
+    let mut scan = |fields: &[(String, String)]| {
+        for (name, ty) in fields {
+            let t = ty.trim_start();
+            // Both spellings reach here: canonical `Vec T` and `Option Vec T`.
+            if t.starts_with("Vec ") || t.contains(" Vec ") {
+                vec_fields.push(name.clone());
+            }
+        }
+    };
+    scan(&spec.state_fields);
+    for acct in &spec.account_types {
+        scan(&acct.fields);
+    }
+    if vec_fields.is_empty() {
+        return Vec::new();
+    }
+    vec_fields.sort_unstable();
+    vec_fields.dedup();
+
+    // Property surfaces that could read into a collection: handler ensures,
+    // named invariants, and standalone properties (Rust renderings — the
+    // forms Kani harnesses actually assert).
+    let mut surfaces: Vec<(String, String)> = Vec::new();
+    for h in &spec.handlers {
+        for e in &h.ensures {
+            surfaces.push((format!("handler `{}` ensures", h.name), e.rust_expr.clone()));
+        }
+    }
+    for inv in &spec.invariants {
+        if let Some(expr) = &inv.rust_expr {
+            surfaces.push((format!("invariant `{}`", inv.name), expr.clone()));
+        }
+    }
+    for prop in &spec.properties {
+        if let Some(expr) = &prop.rust_expression {
+            surfaces.push((format!("property `{}`", prop.name), expr.clone()));
+        }
+    }
+
+    let word_mentions = |expr: &str, field: &str| {
+        expr.split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|w| w == field)
+    };
+
+    let mut warnings = Vec::new();
+    for field in &vec_fields {
+        for (surface, expr) in &surfaces {
+            if word_mentions(expr, field) {
+                warnings.push(format!(
+                    "{surface} reads Vec state field `{field}`, but `pragma kani_vec_bound` is \
+                     unset (default 1) — the Kani harness explores ONLY 1-element collections, \
+                     so membership/aggregation behavior is silently under-covered. Set `pragma \
+                     kani_vec_bound = <N>` to the smallest N the property distinguishes \
+                     (usually 2-3)."
+                ));
+                break; // one warning per field, not per surface
+            }
+        }
+    }
+    warnings
 }
 
 /// `Settings` → `settings`, `SmartAccount` → `smart_account`. Struct names are

--- a/crates/qedgen/src/codegen/kani_impl/tests.rs
+++ b/crates/qedgen/src/codegen/kani_impl/tests.rs
@@ -3811,3 +3811,229 @@ handler poke (v : U64) {
         );
     }
 }
+
+/// #191: `Bytes64` anywhere in state/params forces the 66 unwind floor — a
+/// raw `[u8; 64]` compare is a 64-iteration memcmp loop that Kani cannot
+/// stub (generic core impl, kani#1997), so the bound must cover it even
+/// though the Pubkey abstraction is active for the Pubkey field.
+#[test]
+fn bytes64_forces_unwind_floor_over_pubkey_abstraction() {
+    let src = r#"spec SigRegistry
+pragma state_struct = Registry
+state { authority : Pubkey, last_sig : Bytes64, nonce : U64 }
+handler record_sig (sig : Bytes64) {
+  modifies [last_sig, nonce]
+  ensures state.nonce == old(state.nonce) + 1
+  effect {
+    last_sig := sig
+    nonce += 1
+  }
+}"#;
+    let spec = parse_str(src).expect("parse");
+
+    let tmp = std::env::temp_dir().join(format!("kani_impl_b64_{}.rs", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    generate_from_spec_with_mode(
+        &spec,
+        &tmp,
+        /*explicit_flag=*/ true,
+        Target::Anchor,
+        KaniImplMode::Brownfield,
+    )
+    .expect("brownfield kani_impl must emit");
+    let body = std::fs::read_to_string(&tmp).unwrap();
+    let _ = std::fs::remove_file(&tmp);
+
+    assert!(
+        body.contains("#[kani::unwind(66)]"),
+        "Bytes64 present → 66 floor, NOT the abstracted-Pubkey small bound; got:\n{body}"
+    );
+    // The symbolic ctor builds the raw array directly — no Pubkey wrapper.
+    assert!(
+        body.contains("last_sig: kani::any(),"),
+        "Bytes64 field constructs as a plain `kani::any()` array; got:\n{body}"
+    );
+}
+
+/// #191: `Bytes32` (hash/digest) keeps the 34 memcmp floor; without any byte
+/// token the same spec closes at the abstracted small bound (control is
+/// covered by existing unwind tests).
+#[test]
+fn bytes32_forces_unwind_34() {
+    let src = r#"spec MerkleGate
+pragma state_struct = Gate
+state { root : Bytes32, epoch : U64 }
+handler set_root (new_root : Bytes32) {
+  modifies [root, epoch]
+  ensures state.epoch == old(state.epoch) + 1
+  effect {
+    root := new_root
+    epoch += 1
+  }
+}"#;
+    let spec = parse_str(src).expect("parse");
+
+    let tmp = std::env::temp_dir().join(format!("kani_impl_b32_{}.rs", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    generate_from_spec_with_mode(
+        &spec,
+        &tmp,
+        /*explicit_flag=*/ true,
+        Target::Anchor,
+        KaniImplMode::Brownfield,
+    )
+    .expect("brownfield kani_impl must emit");
+    let body = std::fs::read_to_string(&tmp).unwrap();
+    let _ = std::fs::remove_file(&tmp);
+
+    assert!(
+        body.contains("#[kani::unwind(34)]"),
+        "Bytes32 present → 34 memcmp floor; got:\n{body}"
+    );
+}
+
+/// #189: `pragma kani_stub_pda` emits the deterministic uninterpreted-function
+/// PDA stub (UfMap-backed, `find` + `create` domains) and the unwind bound
+/// covers the CAP=8 memo scan even for a numeric-only spec.
+#[test]
+fn pda_stub_is_deterministic_ufmap() {
+    let src = r#"spec VaultInit
+pragma state_struct = Vault
+pragma kani_stub_pda = derive
+state { total : U64 }
+handler deposit (amount : U64) {
+  requires amount > 0 else BadAmount
+  modifies [total]
+  ensures state.total == old(state.total) + amount
+  effect { total += amount }
+}"#;
+    let spec = parse_str(src).expect("parse");
+
+    let tmp = std::env::temp_dir().join(format!("kani_impl_ufpda_{}.rs", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    generate_from_spec_with_mode(
+        &spec,
+        &tmp,
+        /*explicit_flag=*/ true,
+        Target::Anchor,
+        KaniImplMode::Brownfield,
+    )
+    .expect("brownfield kani_impl must emit");
+    let body = std::fs::read_to_string(&tmp).unwrap();
+    let _ = std::fs::remove_file(&tmp);
+
+    assert!(
+        body.contains("static QEDGEN_PDA_UF: qedgen_kani_prelude::UfCell32<8>")
+            && body.contains("fn find_pda_abstract(")
+            && body.contains("fn create_pda_abstract("),
+        "PDA stub is the UfMap-backed deterministic pair; got:\n{body}"
+    );
+    assert!(
+        body.contains("#[kani::stub(solana_program::pubkey::Pubkey::find_program_address, find_pda_abstract)]")
+            && body.contains("#[kani::stub(solana_program::pubkey::Pubkey::create_program_address, create_pda_abstract)]"),
+        "both PDA entry points are stubbed; got:\n{body}"
+    );
+    assert!(
+        body.contains("#[kani::unwind(10)]"),
+        "UfMap memo scan floors the unwind at 10; got:\n{body}"
+    );
+}
+
+/// #189: `pragma kani_stub_hash` / `pragma kani_stub_secp256k1` emit the
+/// per-primitive uninterpreted-function stubs + their `#[kani::stub]` attrs.
+#[test]
+fn hash_and_secp256k1_stub_pragmas_emit() {
+    let src = r#"spec HashGate
+pragma state_struct = Gate
+pragma kani_stub_hash = on
+pragma kani_stub_secp256k1 = on
+state { total : U64 }
+handler bump (amount : U64) {
+  modifies [total]
+  ensures state.total == old(state.total) + amount
+  effect { total += amount }
+}"#;
+    let spec = parse_str(src).expect("parse");
+
+    let tmp = std::env::temp_dir().join(format!("kani_impl_hash_{}.rs", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    generate_from_spec_with_mode(
+        &spec,
+        &tmp,
+        /*explicit_flag=*/ true,
+        Target::Anchor,
+        KaniImplMode::Brownfield,
+    )
+    .expect("brownfield kani_impl must emit");
+    let body = std::fs::read_to_string(&tmp).unwrap();
+    let _ = std::fs::remove_file(&tmp);
+
+    // One UfMap per hash primitive (domain separation) + hash/hashv agreement
+    // by shared key construction.
+    for needle in [
+        "static QEDGEN_SHA256_UF:",
+        "static QEDGEN_KECCAK_UF:",
+        "static QEDGEN_BLAKE3_UF:",
+        "#[kani::stub(solana_program::hash::hash, sha256_abstract)]",
+        "#[kani::stub(solana_program::hash::hashv, sha256v_abstract)]",
+        "#[kani::stub(solana_program::keccak::hash, keccak_abstract)]",
+        "#[kani::stub(solana_program::blake3::hash, blake3_abstract)]",
+        "static QEDGEN_SECP_UF: qedgen_kani_prelude::UfCell64<8>",
+        "#[kani::stub(solana_program::secp256k1_recover::secp256k1_recover, secp256k1_recover_abstract)]",
+    ] {
+        assert!(body.contains(needle), "missing `{needle}` in:\n{body}");
+    }
+}
+
+/// #192: a property that reads into a `Vec` state field with the bound at its
+/// silent default warns (naming the field + pragma); an explicit
+/// `kani_vec_bound` or a scalar-only property stays silent.
+#[test]
+fn vec_bound_undercoverage_lint() {
+    // (a) ensures reads the Vec field, bound unset → warns.
+    let reads = r#"spec Council
+pragma state_struct = Council
+type Member = { key : Pubkey }
+state { members : Vec Member, quorum : U16 }
+handler noop (x : U16) {
+  modifies [quorum]
+  ensures state.members == old(state.members)
+  effect { quorum := x }
+}"#;
+    let spec = parse_str(reads).expect("parse");
+    let warnings = state_ctor::vec_bound_undercoverage_warnings(&spec);
+    assert_eq!(warnings.len(), 1, "one warning per Vec field: {warnings:?}");
+    assert!(
+        warnings[0].contains("members") && warnings[0].contains("kani_vec_bound"),
+        "warning names the field and the pragma; got: {}",
+        warnings[0]
+    );
+
+    // (b) explicit bound (even a low one) → conscious trade-off, silent.
+    let bounded = reads.replace(
+        "pragma state_struct = Council",
+        "pragma state_struct = Council\npragma kani_vec_bound = 1",
+    );
+    let spec = parse_str(&bounded).expect("parse");
+    assert!(
+        state_ctor::vec_bound_undercoverage_warnings(&spec).is_empty(),
+        "explicit kani_vec_bound silences the lint"
+    );
+
+    // (c) scalar-only property over a spec WITH a Vec field → silent (the
+    // default-1 trade-off is exactly right there).
+    let scalar = r#"spec Council
+pragma state_struct = Council
+type Member = { key : Pubkey }
+state { members : Vec Member, quorum : U16 }
+handler noop (x : U16) {
+  modifies [quorum]
+  ensures state.quorum == x
+  effect { quorum := x }
+}"#;
+    let spec = parse_str(scalar).expect("parse");
+    assert!(
+        state_ctor::vec_bound_undercoverage_warnings(&spec).is_empty(),
+        "scalar-only ensures stays silent"
+    );
+}

--- a/crates/qedgen/src/codegen/lean_gen_mir/indexed.rs
+++ b/crates/qedgen/src/codegen/lean_gen_mir/indexed.rs
@@ -207,6 +207,8 @@ pub(super) fn render_ty_indexed(ty: &crate::mir::Ty) -> String {
         Ty::I64 | Ty::I128 => "Int".to_string(),
         Ty::Bool => "Bool".to_string(),
         Ty::Pubkey => "Pubkey".to_string(),
+        Ty::Bytes32 => "Bytes32".to_string(),
+        Ty::Bytes64 => "Bytes64".to_string(),
         Ty::Custom(name) => name.clone(),
         Ty::Map { capacity, value } => {
             // The Map's inner type stays the literal surface type (e.g.
@@ -221,6 +223,8 @@ pub(super) fn render_ty_indexed(ty: &crate::mir::Ty) -> String {
                 Ty::I128 => "I128".to_string(),
                 Ty::Bool => "Bool".to_string(),
                 Ty::Pubkey => "Pubkey".to_string(),
+                Ty::Bytes32 => "Bytes32".to_string(),
+                Ty::Bytes64 => "Bytes64".to_string(),
                 Ty::Custom(n) => n.clone(),
                 Ty::Map { .. } => render_ty_indexed(value),
             };

--- a/crates/qedgen/src/codegen/lean_gen_mir/util.rs
+++ b/crates/qedgen/src/codegen/lean_gen_mir/util.rs
@@ -283,6 +283,11 @@ pub(super) fn render_ty(ty: &crate::mir::Ty) -> String {
         Ty::I64 | Ty::I128 => "Int".to_string(),
         Ty::Bool => "Bool".to_string(),
         Ty::Pubkey => "Pubkey".to_string(),
+        // Opaque byte tokens (#191): equality-only semantics, so both are
+        // Lean abbreviations over the same opaque carrier as `Pubkey`
+        // (`QEDGen.Solana.Account`). Width is a Rust-side concern.
+        Ty::Bytes32 => "Bytes32".to_string(),
+        Ty::Bytes64 => "Bytes64".to_string(),
         Ty::Custom(name) => name.clone(),
         Ty::Map { capacity: _, value } => {
             // Indexed-state has its own renderer; this codepath shouldn't

--- a/crates/qedgen/src/codegen/proptest_gen_mir.rs
+++ b/crates/qedgen/src/codegen/proptest_gen_mir.rs
@@ -39,6 +39,10 @@ fn strategy_for_type(dsl_type: &str) -> &str {
         "I128" => "any::<i128>()",
         "Bool" => "any::<bool>()",
         "Pubkey" => "prop::array::uniform32(0u8..)",
+        // Byte tokens (#191): `uniform32` maxes out at 32, so Bytes64 uses
+        // proptest's const-generic array `Arbitrary` (proptest ≥ 1.0).
+        "Bytes32" => "prop::array::uniform32(0u8..)",
+        "Bytes64" => "any::<[u8; 64]>()",
         // Fin[N] arrives here with the wrapper stripped; modelled as a small
         // usize range since real usage is as an index.
         "Fin" => "0usize..=1024usize",
@@ -62,6 +66,10 @@ fn boundary_strategy_for_type(dsl_type: &str) -> &str {
         "I128" => "any::<i128>()",
         "Bool" => "any::<bool>()",
         "Pubkey" => "prop::array::uniform32(0u8..1u8)",
+        "Bytes32" => "prop::array::uniform32(0u8..1u8)",
+        "Bytes64" => {
+            "prop::collection::vec(0u8..1u8, 64).prop_map(|v| <[u8; 64]>::try_from(v).unwrap())"
+        }
         "Fin" => "prop_oneof![0usize..=3usize, 1020usize..=1024usize]",
         _ => "prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]",
     }

--- a/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
@@ -522,7 +522,7 @@ fn path_is_pod_field(p: &TreePath) -> bool {
         // model the narrow signed widths natively) but stays native:
         // alignment 1 already, no Pod companion.
         Some(Ty::Custom(name)) => matches!(name.as_str(), "I16" | "I32"),
-        Some(Ty::U8 | Ty::Pubkey | Ty::Map { .. }) => false,
+        Some(Ty::U8 | Ty::Pubkey | Ty::Bytes32 | Ty::Bytes64 | Ty::Map { .. }) => false,
         None => false,
     }
 }

--- a/crates/qedgen/src/mir/expr_tree.rs
+++ b/crates/qedgen/src/mir/expr_tree.rs
@@ -322,7 +322,7 @@ pub fn ty_num_kind(ty: &Ty) -> NumKind {
         Ty::U8 | Ty::U16 | Ty::U32 | Ty::U64 | Ty::U128 => NumKind::Nat,
         Ty::I64 | Ty::I128 => NumKind::Int,
         Ty::Bool => NumKind::Bool,
-        Ty::Pubkey => NumKind::Other,
+        Ty::Pubkey | Ty::Bytes32 | Ty::Bytes64 => NumKind::Other,
         Ty::Map { .. } => NumKind::Other,
         Ty::Custom(name) => match name.as_str() {
             "I8" | "I16" | "I32" => NumKind::Int,

--- a/crates/qedgen/src/mir/mod.rs
+++ b/crates/qedgen/src/mir/mod.rs
@@ -561,6 +561,13 @@ pub enum Ty {
     I128,
     Bool,
     Pubkey,
+    /// Opaque 32-byte token (`[u8; 32]`): hash / digest / merkle root.
+    /// Equality-only semantics, like `Pubkey`, but lowers to a raw byte
+    /// array in every Rust-facing backend (#191).
+    Bytes32,
+    /// Opaque 64-byte token (`[u8; 64]`): ed25519/secp256k1 signature,
+    /// recovered secp pubkey. Equality-only semantics (#191).
+    Bytes64,
     /// User-declared type name (a record, sum type, or imported type).
     Custom(Symbol),
     /// Bounded map keyed by `Pubkey`; capacity carried verbatim as a string —
@@ -1704,6 +1711,8 @@ pub(crate) fn parse_ty(s: &str) -> Ty {
         "I128" => Ty::I128,
         "Bool" => Ty::Bool,
         "Pubkey" => Ty::Pubkey,
+        "Bytes32" => Ty::Bytes32,
+        "Bytes64" => Ty::Bytes64,
         other => {
             // `Map[N] T`: numeric literal or constant-name capacity, passed
             // through as a string (see `Ty::Map`). Gated on the strict

--- a/crates/qedgen/src/spec/chumsky_adapter/typecheck.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/typecheck.rs
@@ -136,6 +136,8 @@ fn infer_lean_type(
             let dsl_type = resolve_path_type(p, field_types, param_types);
             match dsl_type {
                 Some("Pubkey") => "Pubkey".to_string(),
+                Some("Bytes32") => "Bytes32".to_string(),
+                Some("Bytes64") => "Bytes64".to_string(),
                 Some("Bool") => "Bool".to_string(),
                 Some(t) if is_signed_int(t) => "Int".to_string(),
                 Some(_) => "Nat".to_string(),
@@ -403,15 +405,17 @@ fn check_effect_typed(
         Some(t) => t,
         None => return Ok(()),
     };
-    if lhs_type == "Pubkey" {
+    if matches!(lhs_type, "Pubkey" | "Bytes32" | "Bytes64") {
         if let Some(v) = numeric_literal_value(&stmt.rhs.node, const_literals) {
             anyhow::bail!(
-                "handler `{}` effect `{} := {}`: Pubkey field cannot be assigned a numeric literal. \
-                 The DSL has no Pubkey-literal syntax — use a handler parameter, a constant, \
-                 or the spec's `program_id` as the source pubkey.",
+                "handler `{}` effect `{} := {}`: {} field cannot be assigned a numeric literal. \
+                 The DSL has no {} literal syntax — use a handler parameter, a constant, \
+                 or the spec's `program_id` as the source value.",
                 handler_name,
                 render_path_human(&stmt.lhs),
-                v
+                v,
+                lhs_type,
+                lhs_type
             );
         }
     }
@@ -499,7 +503,7 @@ fn check_cmp_pair(
             _ => return None,
         };
         let t = resolve_path_type(path, field_types, param_types)?;
-        if t != "Pubkey" {
+        if !matches!(t, "Pubkey" | "Bytes32" | "Bytes64") {
             return None;
         }
         if let Some(v) = numeric_literal_value(i, const_literals) {

--- a/crates/qedgen/src/spec/chumsky_parser/mod.rs
+++ b/crates/qedgen/src/spec/chumsky_parser/mod.rs
@@ -76,7 +76,14 @@ fn pragma_assign_decl<'a>() -> impl Parser<'a, &'a str, TopItem, Err<'a>> + Clon
     // pragmas (`state_repr = adt`) are unaffected. A `*` segment is accepted so
     // `pragma harness_use = crate::foo::bar::*` can request a glob import
     // (`state_module` values never contain `*`, so this is backward-compatible).
-    let path_seg = choice((non_keyword_ident(), just("*").to("*".to_string())));
+    // A bare integer segment is accepted so numeric-valued pragmas parse —
+    // before #192 the grammar REJECTED them, making the documented
+    // `pragma kani_vec_bound = <N>` unusable.
+    let path_seg = choice((
+        non_keyword_ident(),
+        just("*").to("*".to_string()),
+        text::int(10).map(|s: &str| s.to_string()),
+    ));
     let path_value = path_seg
         .separated_by(just("::"))
         .at_least(1)

--- a/kani_prelude/README.md
+++ b/kani_prelude/README.md
@@ -25,10 +25,25 @@ exist only under `cargo kani`.
 Each **exact** abstraction is checked equal to the primitive it replaces on
 every input (sound both ways, so it changes no verification result):
 
-- `pk_eq_abstract` ≡ derived `Pubkey ==`
-- `pk_cmp_abstract` ≡ derived `Pubkey cmp`
-- `checked_div_abstract` ≡ `i64::checked_div`
-- `mul_div_floor_u128` / `mul_div_ceil_u128` ≡ exact `a*b/d` (no-overflow regime)
+- `wide_eq_32` / `wide_cmp_32` ≡ derived `[u8; 32]` `==` / `cmp` (= `Pubkey`)
+- `wide_eq_64` / `wide_cmp_64` ≡ derived `[u8; 64]` `==` / `cmp` (#191 —
+  signature-width tokens)
+- `checked_div_i64` ≡ `i64::checked_div` — i8-exhaustive, plus full-width
+  `None` cases and full-width unit divisors (#190)
+- `mul_div_floor_u128` / `mul_div_ceil_u128` — Euclidean floor/ceil contract
+  (`q·d ≤ a·b < q·d + d` and the ceil dual) over symbolic u8-bounded `a`/`b`
+  × a concrete divisor panel, plus full-width zero-divisor and a
+  symbolic-divisor saturation branch (#190)
+- `mul_bps_floor_u128` — the floor contract over a symbolic in-range `bps` ×
+  a concrete dividend panel up to u64 width, plus the full-width out-of-range
+  guard (#190)
+- `UfMap32` / `UfMap64` **determinism** (memoized apply) and length-prefixed
+  key packing (#189)
+
+**Residual (documented, not machine-checked):** full-width division behavior
+between the bounded boxes rests on the quotient-uniqueness contract argument
+in `checked_div_i64`'s docs — the nonlinear/divider BMC wall recorded in
+`docs/toolchain-backlog.md`.
 
 Proofs run against a dependency-free local `Pubkey` model — a 32-byte newtype
 with derived `Eq`/`Ord`, which is exactly what `anchor_lang::prelude::Pubkey`
@@ -36,15 +51,33 @@ is, so the lemmas transfer to the real type verbatim (see `src/lib.rs` module
 docs). This keeps anchor-lang/solana-program out of the graph: no
 version-unification, fast solving.
 
+## Axioms (Tier 2 — #189)
+
+`UfMap32` / `UfMap64` model trusted crypto (PDA derivation, sha256 / keccak /
+blake3, secp256k1 recovery) as *deterministic uninterpreted functions*:
+
+- **Determinism is real** — the map memoizes, machine-checked
+  (`ufmap32_is_deterministic`).
+- **Collision-freedom is an axiom** — a fresh output is `kani::assume`d
+  distinct from every previous output. This mirrors trusting sha256 collision
+  resistance, exactly the assumption `lean_solana`'s PDA/hash axioms make. Do
+  not use these maps to prove a property that *holds only if* collisions
+  exist.
+- **Capacity is fail-closed** — exceeding `CAP` distinct inputs or the
+  128-byte key budget is an `assert!` failure, never silent degradation.
+
 ## Not proved here (over-approximating stubs)
 
-The PDA / log / CPI stubs (Tiers 2/4) are deliberately weaker than the real
-primitive (opaque symbolic address, no-op logging, assumed-success CPI) — sound
-for safety properties by construction, with no equivalence to prove. They need
-real solana-program types, so they live with the vendor template, not in this
-dependency-free crate.
+The log / CPI stubs (Tier 4) are deliberately weaker than the real primitive
+(no-op logging, assumed-success CPI) — sound for safety properties by
+construction, with no equivalence to prove. They need real solana-program
+types, so they live with the generated harness, not in this dependency-free
+crate. The PDA / hash / secp stubs emitted by codegen are thin adapters over
+the `UfCell32` / `UfCell64` wrappers here.
 
 ## Status
 
-Chunk 1 of the #182 crate-extraction (see `docs/toolchain-backlog.md`). Not yet
-wired into codegen or pinned in CI — those are later chunks.
+Wired into codegen: `--kani-impl` emits `#[kani::stub]` adapters over this
+crate (Pubkey T1 by detection; PDA / hash / secp256k1 / div by pragma opt-in),
+and `qedgen` vendors the crate beside any generated harness that references
+it. See `docs/toolchain-backlog.md` for the #182 history.

--- a/kani_prelude/src/lib.rs
+++ b/kani_prelude/src/lib.rs
@@ -42,15 +42,20 @@
 //! tuple-lexicographic `u128` comparison reproduces the byte-lexicographic order
 //! of the derived `Ord`. Equality is endianness-independent.
 //!
-//! ## Exact vs over-approximating
+//! ## Exact vs over-approximating vs axiomatized
 //!
-//! `wide_eq_32` / `wide_cmp_32` / `checked_div_i64` are **exact** — proved equal
-//! to the primitive they replace on every input (sound both ways, so they change
-//! no verification result). The PDA / log / CPI stubs (Tiers 2/4) are
-//! deliberately *over-approximating* (opaque symbolic address, no-op logging,
-//! assumed-success CPI): sound for safety by construction, nothing to prove
-//! equal, and they need real solana-program types — so they live with the
-//! generated harness, not in this dependency-free crate.
+//! `wide_eq_32` / `wide_cmp_32` / `wide_eq_64` / `wide_cmp_64` /
+//! `checked_div_i64` are **exact** — proved equal to the primitive they replace
+//! on every input (sound both ways, so they change no verification result).
+//! The log / CPI stubs (Tier 4) are deliberately *over-approximating* (no-op
+//! logging, assumed-success CPI): sound for safety by construction, nothing to
+//! prove equal, and they need real solana-program types — so they live with the
+//! generated harness, not in this dependency-free crate. The Tier 2
+//! trusted-crypto stubs (PDA derivation, hashes, secp256k1 recovery — #189)
+//! are **axiomatized**: their `UfMap32`/`UfMap64` cores below are
+//! deterministic by construction (machine-checked) and injective by a
+//! collision-freedom `kani::assume` — see the Tier 2 section for the trust
+//! argument.
 #![cfg(kani)]
 
 use core::cmp::Ordering;
@@ -82,6 +87,36 @@ pub fn wide_cmp_32(a: [u8; 32], b: [u8; 32]) -> Ordering {
     (a[0].swap_bytes(), a[1].swap_bytes()).cmp(&(b[0].swap_bytes(), b[1].swap_bytes()))
 }
 
+/// Abstract 64-byte equality (#191) — the T1 core for signature-width tokens
+/// (`[u8; 64]`: ed25519/secp256k1 signatures, recovered secp pubkeys). Four
+/// `u128` word-comparisons instead of a 64-byte memcmp/lex loop (Kani unwind
+/// 2 vs ≥ 66). Proved equivalent to elementwise `[u8; 64]` equality by
+/// [`wide_eq_64_agrees_with_array`].
+#[allow(clippy::missing_transmute_annotations)]
+pub fn wide_eq_64(a: [u8; 64], b: [u8; 64]) -> bool {
+    let a: [u128; 4] = unsafe { core::mem::transmute(a) };
+    let b: [u128; 4] = unsafe { core::mem::transmute(b) };
+    a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3]
+}
+
+/// Abstract 64-byte lexicographic ordering (#191) — byte 0 most significant,
+/// mirroring [`wide_cmp_32`]'s big-endian reinterpretation. Proved equivalent
+/// to the derived `[u8; 64]` `cmp` by [`wide_cmp_64_agrees_with_array`].
+#[allow(clippy::missing_transmute_annotations)]
+pub fn wide_cmp_64(a: [u8; 64], b: [u8; 64]) -> Ordering {
+    let a: [u128; 4] = unsafe { core::mem::transmute(a) };
+    let b: [u128; 4] = unsafe { core::mem::transmute(b) };
+    let key = |w: [u128; 4]| {
+        (
+            w[0].swap_bytes(),
+            w[1].swap_bytes(),
+            w[2].swap_bytes(),
+            w[3].swap_bytes(),
+        )
+    };
+    key(a).cmp(&key(b))
+}
+
 // ---------------------------------------------------------------------------
 // Arithmetic tier — abstract `i64::checked_div` (#182). A symbolic 64-bit
 // divisor forces CBMC/z3 to bit-blast a sequential divider that stalls; replace
@@ -110,9 +145,11 @@ pub fn checked_div_i64(a: i64, b: i64) -> Option<i64> {
 // ---------------------------------------------------------------------------
 // Saturating `mul_div` helpers — emitted today by the spec-model path
 // (`kani_mir/prefix.rs`) when a guard references them. Not stubs of a std fn;
-// correctness proofs are DEFERRED (their spec compares against a symbolic u128
-// divider — the same stall `checked_div_i64` sidesteps; a tractable proof needs
-// the same divider-free contract encoding).
+// each carries a machine-checked contract harness (#190): the SPEC side is
+// stated multiplicatively (`q*d ≤ prod < (q+1)*d`), so only the helper's own
+// divider runs — over bounded operands, the same encoding that makes
+// `checked_div_i64_agrees_with_std_bounded` tractable. Full-width residual:
+// see each harness's doc comment.
 // ---------------------------------------------------------------------------
 
 /// `floor(a*b/d)` with saturation on overflow; `0` when `d == 0`.
@@ -150,6 +187,188 @@ pub fn mul_bps_floor_u128(a: u128, bps: u128) -> u128 {
     let r = a % 10000;
     q.wrapping_mul(b).wrapping_add(r.wrapping_mul(b) / 10000)
 }
+
+// ---------------------------------------------------------------------------
+// Tier 2 — deterministic uninterpreted functions with a collision-freedom
+// axiom (#189). The Kani mirror of `lean_solana`'s 'Trust (axioms)' boundary
+// for trusted crypto: PDA derivation (sha256 + bump search), sha256 / keccak /
+// blake3, and secp256k1 recovery are exhaustively bit-blasted by CBMC when a
+// harness reaches them, at zero verification value — the program must hold for
+// ANY hash output; we never re-verify that sha256 is sha256.
+//
+// What each map models, and its trust argument:
+//   * DETERMINISM is REAL (machine-checked, `ufmap32_is_deterministic`): the
+//     map memoizes, so equal inputs return the SAME output — the property the
+//     old fresh-`kani::any()` PDA stub lost, and the one programs actually
+//     rely on (derive-then-compare).
+//   * COLLISION-FREEDOM is an AXIOM (`kani::assume`): a fresh output is
+//     assumed distinct from every previous output, making the modeled
+//     function injective across the harness. This mirrors trusting sha256
+//     collision resistance — exactly the assumption the Lean side's PDA/hash
+//     axioms make (`lean_solana` axiom docs). It is an over-approximation in
+//     one direction only: a real collision, were one findable, could only
+//     REMOVE behaviors from the model, and BMC harnesses assert safety over
+//     the modeled behaviors. Do not use these maps to prove a property that
+//     HOLDS ONLY IF collisions exist.
+//   * CAPACITY is fail-closed: exceeding `CAP` distinct inputs (or the 128-
+//     byte key budget) is an `assert!` failure — the harness fails loudly and
+//     names the fix, never silently degrades.
+//
+// Kani-mechanics notes: key bytes are packed with `copy_nonoverlapping`
+// (CBMC models memcpy natively — no unwind cost), keys/values compare as
+// `u128` words (no memcmp loops), and the memo scan is bounded by the
+// CONCRETE `CAP` — a harness needs `#[kani::unwind(CAP + 2)]` or higher.
+// ---------------------------------------------------------------------------
+
+/// Fixed-size key for the T2 uninterpreted-function maps: parts are packed
+/// with a length prefix (so `["ab","c"]` ≠ `["a","bc"]`) into a 128-byte
+/// buffer compared as eight `u128` words. Overflow is fail-closed (`assert!`).
+#[derive(Clone, Copy)]
+pub struct UfKey {
+    bytes: [u8; 128],
+    used: usize,
+}
+
+impl UfKey {
+    pub const fn new() -> Self {
+        UfKey {
+            bytes: [0u8; 128],
+            used: 0,
+        }
+    }
+
+    /// Append one part (length-prefixed). Fail-closed: a part longer than 255
+    /// bytes or a key past 128 bytes is a harness assertion failure (raise the
+    /// budget in the prelude), never a silent truncation.
+    pub fn push(mut self, part: &[u8]) -> Self {
+        assert!(
+            part.len() <= 255,
+            "qedgen_kani_prelude::UfKey: part exceeds 255 bytes"
+        );
+        assert!(
+            self.used + 1 + part.len() <= 128,
+            "qedgen_kani_prelude::UfKey: key exceeds the 128-byte budget"
+        );
+        self.bytes[self.used] = part.len() as u8;
+        self.used += 1;
+        // memcpy intrinsic — CBMC models it natively, no copy-loop to unwind.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                part.as_ptr(),
+                self.bytes.as_mut_ptr().add(self.used),
+                part.len(),
+            );
+        }
+        self.used += part.len();
+        self
+    }
+
+    /// The key as eight `u128` words (word-compares, no memcmp loop).
+    #[allow(clippy::missing_transmute_annotations)]
+    fn words(&self) -> [u128; 8] {
+        unsafe { core::mem::transmute(self.bytes) }
+    }
+}
+
+impl Default for UfKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Eight explicit word-compares — NOT `[u128; 8] ==`, whose lexicographic
+/// slice loop would reintroduce an unwind bound.
+fn words_eq(a: &[u128; 8], b: &[u128; 8]) -> bool {
+    a[0] == b[0]
+        && a[1] == b[1]
+        && a[2] == b[2]
+        && a[3] == b[3]
+        && a[4] == b[4]
+        && a[5] == b[5]
+        && a[6] == b[6]
+        && a[7] == b[7]
+}
+
+macro_rules! define_ufmap {
+    ($map:ident, $cell:ident, $width:literal, $wide_eq:ident) => {
+        /// Deterministic uninterpreted function `UfKey → [u8; $width]` with a
+        /// collision-freedom axiom — see the Tier 2 section docs for the trust
+        /// argument. `CAP` bounds DISTINCT inputs per harness (fail-closed).
+        pub struct $map<const CAP: usize> {
+            keys: [[u128; 8]; CAP],
+            vals: [[u8; $width]; CAP],
+            len: usize,
+        }
+
+        impl<const CAP: usize> $map<CAP> {
+            pub const fn new() -> Self {
+                $map {
+                    keys: [[0u128; 8]; CAP],
+                    vals: [[0u8; $width]; CAP],
+                    len: 0,
+                }
+            }
+
+            /// Memoized apply: a seen key returns its recorded value
+            /// (determinism, machine-checked); a fresh key draws a symbolic
+            /// value ASSUMED distinct from every previous one
+            /// (collision-freedom, axiom).
+            pub fn apply(&mut self, key: UfKey) -> [u8; $width] {
+                let words = key.words();
+                for i in 0..self.len {
+                    if words_eq(&self.keys[i], &words) {
+                        return self.vals[i];
+                    }
+                }
+                let fresh: [u8; $width] = kani::any();
+                for i in 0..self.len {
+                    kani::assume(!$wide_eq(fresh, self.vals[i])); // collision-freedom axiom
+                }
+                assert!(
+                    self.len < CAP,
+                    concat!(
+                        "qedgen_kani_prelude::",
+                        stringify!($map),
+                        " capacity exhausted — raise CAP in the generated stub"
+                    )
+                );
+                self.keys[self.len] = words;
+                self.vals[self.len] = fresh;
+                self.len += 1;
+                fresh
+            }
+        }
+
+        impl<const CAP: usize> Default for $map<CAP> {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        /// Interior-mutable, harness-`static`-friendly wrapper: generated
+        /// stubs hold `static UF: $cell<CAP> = $cell::new();` and call
+        /// `UF.apply(key)` with no `unsafe` at the call site. Sound under
+        /// Kani: single-threaded, and `apply` never re-enters.
+        pub struct $cell<const CAP: usize>(core::cell::UnsafeCell<$map<CAP>>);
+
+        // Kani executes harnesses single-threaded; there is no data race to
+        // guard against, and the crate never compiles off-kani.
+        unsafe impl<const CAP: usize> Sync for $cell<CAP> {}
+
+        impl<const CAP: usize> $cell<CAP> {
+            pub const fn new() -> Self {
+                $cell(core::cell::UnsafeCell::new($map::new()))
+            }
+
+            pub fn apply(&self, key: UfKey) -> [u8; $width] {
+                unsafe { &mut *self.0.get() }.apply(key)
+            }
+        }
+    };
+}
+
+define_ufmap!(UfMap32, UfCell32, 32, wide_eq_32);
+define_ufmap!(UfMap64, UfCell64, 64, wide_eq_64);
 
 // ===========================================================================
 // Soundness proofs — each `exact` abstraction agrees with the primitive it
@@ -194,4 +413,197 @@ fn checked_div_i64_agrees_with_std_bounded() {
     kani::assume(a >= i8::MIN as i64 && a <= i8::MAX as i64);
     kani::assume(b >= i8::MIN as i64 && b <= i8::MAX as i64);
     assert_eq!(checked_div_i64(a, b), a.checked_div(b));
+}
+
+/// T1 (#191): `wide_eq_64` ≡ derived `[u8; 64]` equality, for all byte pairs.
+/// The array `==` is a 64-element loop — hence `unwind(65)`; the abstraction
+/// itself is unwind-free.
+#[kani::proof]
+#[kani::unwind(65)]
+fn wide_eq_64_agrees_with_array() {
+    let a: [u8; 64] = kani::any();
+    let b: [u8; 64] = kani::any();
+    assert_eq!(wide_eq_64(a, b), a == b);
+}
+
+/// T1 (#191): `wide_cmp_64` ≡ derived `[u8; 64]` `cmp`, for all byte pairs.
+#[kani::proof]
+#[kani::unwind(65)]
+fn wide_cmp_64_agrees_with_array() {
+    let a: [u8; 64] = kani::any();
+    let b: [u8; 64] = kani::any();
+    assert_eq!(wide_cmp_64(a, b), a.cmp(&b));
+}
+
+// ---------------------------------------------------------------------------
+// #190 — `checked_div_i64` beyond the i8 box: the two `None` cases and the
+// unit divisors hold at FULL 64-bit dividend width (a concrete divisor
+// constant-propagates the divider circuit away; the `None` cases never reach
+// it). Together with the i8-exhaustive harness above, the residual gap is
+// "symbolic dividend × symbolic non-unit divisor at full width" — the
+// nonlinear/divider BMC wall documented in docs/toolchain-backlog.md, covered
+// by the quotient-uniqueness contract argument in `checked_div_i64`'s docs.
+// ---------------------------------------------------------------------------
+
+/// #190: both `None` cases at full width — `b == 0` for every `a`, and the
+/// `(i64::MIN, -1)` overflow pair. Neither path executes a divider.
+#[kani::proof]
+fn checked_div_i64_none_cases_full_width() {
+    let a: i64 = kani::any();
+    assert_eq!(checked_div_i64(a, 0), a.checked_div(0));
+    assert_eq!(checked_div_i64(i64::MIN, -1), i64::MIN.checked_div(-1));
+}
+
+/// #190: unit divisors at full dividend width — `b == 1` is the identity and
+/// `b == -1` is negation (minus the `i64::MIN` overflow pair). The concrete
+/// divisor constant-propagates the divider circuit, so the full 64-bit
+/// dividend stays tractable.
+#[kani::proof]
+fn checked_div_i64_unit_divisors_full_width() {
+    let a: i64 = kani::any();
+    assert_eq!(checked_div_i64(a, 1), a.checked_div(1));
+    kani::assume(a != i64::MIN);
+    assert_eq!(checked_div_i64(a, -1), a.checked_div(-1));
+}
+
+// ---------------------------------------------------------------------------
+// #190 — `mul_div_*` contract harnesses. The spec side is multiplicative
+// (`q*d ≤ prod < (q+1)*d`), so only the helper's OWN divider runs; operands
+// are bounded to u8 range (the same box that makes the `checked_div` proof
+// tractable) except where a branch never divides (`d == 0`, `bps > 10000`) or
+// divides by a CONSTANT (`mul_bps_floor`'s `/ 10000`), which hold at full or
+// u64 width. Residual: the in-range division behavior between u8-bounded and
+// full-width operands rests on the same documented divider argument as
+// `checked_div_i64`.
+// ---------------------------------------------------------------------------
+
+/// #190: `mul_div_floor_u128` returns exactly `⌊a·b / d⌋` — stated as the
+/// Euclidean bracketing `q*d ≤ a*b < q*d + d` over fully-symbolic u8-bounded
+/// `a`/`b` and a CONCRETE divisor panel. A fully-symbolic divisor alongside a
+/// symbolic dividend is the 128-bit divider wall (the harness ran > 3 min);
+/// concrete divisors constant-propagate the circuit while the panel still
+/// exercises d = 1, d > prod, remainder-zero and remainder-nonzero cases.
+/// The complementary symbolic-DIVISOR shape (with a concrete dividend) is
+/// covered by `mul_div_floor_u128_saturation_bounded_divisor` below.
+#[kani::proof]
+fn mul_div_floor_u128_floor_contract_bounded() {
+    let a: u128 = kani::any();
+    let b: u128 = kani::any();
+    kani::assume(a <= u8::MAX as u128 && b <= u8::MAX as u128);
+    let prod = a * b; // ≤ 255² — never saturates in this box
+    for d in [1u128, 2, 3, 7, 10, 255, 70000] {
+        let q = mul_div_floor_u128(a, b, d);
+        assert!(q * d <= prod);
+        assert!(prod < q * d + d);
+    }
+}
+
+/// #190: `mul_div_ceil_u128` returns exactly `⌈a·b / d⌉` — `q*d ≥ a*b` and
+/// `q*d - a*b < d`, over the same symbolic-operand × concrete-divisor panel
+/// as the floor harness (see its doc for the divider-wall rationale).
+#[kani::proof]
+fn mul_div_ceil_u128_ceil_contract_bounded() {
+    let a: u128 = kani::any();
+    let b: u128 = kani::any();
+    kani::assume(a <= u8::MAX as u128 && b <= u8::MAX as u128);
+    let prod = a * b;
+    for d in [1u128, 2, 3, 7, 10, 255, 70000] {
+        let q = mul_div_ceil_u128(a, b, d);
+        assert!(q * d >= prod);
+        assert!(q * d - prod < d);
+    }
+}
+
+/// #190: the `d == 0` guard of both `mul_div` helpers returns 0 at FULL
+/// operand width — the branch never reaches a divider.
+#[kani::proof]
+fn mul_div_zero_divisor_full_width() {
+    let a: u128 = kani::any();
+    let b: u128 = kani::any();
+    assert_eq!(mul_div_floor_u128(a, b, 0), 0);
+    assert_eq!(mul_div_ceil_u128(a, b, 0), 0);
+}
+
+/// #190: the saturation branch — when `a·b` overflows u128, both helpers
+/// divide the saturated product, so floor returns `u128::MAX / d` (concrete
+/// dividend; u8-bounded divisor keeps the circuit constant-propagatable).
+#[kani::proof]
+fn mul_div_floor_u128_saturation_bounded_divisor() {
+    let d: u128 = kani::any();
+    kani::assume(d >= 1 && d <= u8::MAX as u128);
+    // u128::MAX * 2 saturates; the helper must then divide the saturated MAX.
+    assert_eq!(mul_div_floor_u128(u128::MAX, 2, d), u128::MAX / d);
+}
+
+/// #190: `mul_bps_floor_u128` returns exactly `⌊a·bps / 10000⌋` — stated as
+/// the Euclidean bracketing `q·10^4 ≤ a·bps < q·10^4 + 10^4` (multiplication
+/// only on the spec side) over a symbolic in-range `bps` and a CONCRETE `a`
+/// panel spanning the quotient/remainder split's regimes: below / at / above
+/// the 10^4 divisor, and up to a full u64-width dividend. The all-symbolic
+/// direct-equality form pays for four 128-bit division circuits (both sides
+/// divide) and exceeded the solver budget even u16-bounded; with `a`
+/// concrete, `a / 10^4` and `a % 10^4` constant-fold and the one remaining
+/// divider (`r·bps / 10^4`, a ≤ 27-bit dividend by a constant) closes — the
+/// same shape as the floor/ceil panels above. Also pins the out-of-range
+/// guard (`bps > 10000 → u128::MAX`) at full symbolic width.
+#[kani::proof]
+fn mul_bps_floor_u128_floor_contract_bounded() {
+    let bps: u128 = kani::any();
+    if bps <= 10000 {
+        for a in [0u128, 1, 9999, 10000, 10001, 65535, 123_456_789, u64::MAX as u128] {
+            // a·bps ≤ (2^64-1)·10^4 < 2^128 — the bracket math cannot overflow.
+            let q = mul_bps_floor_u128(a, bps);
+            assert!(q * 10000 <= a * bps);
+            assert!(a * bps < q * 10000 + 10000);
+        }
+    } else {
+        let a: u128 = kani::any();
+        assert_eq!(mul_bps_floor_u128(a, bps), u128::MAX);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #189 — Tier 2 UfMap sanity harnesses. Determinism is a genuine machine
+// check; the distinctness harness checks the collision-freedom AXIOM is wired
+// (it asserts what `apply` assumes — see the Tier 2 section docs for why the
+// axiom itself is trusted, not proven). CAP = 2 keeps the memo scan cheap.
+// ---------------------------------------------------------------------------
+
+/// #189: determinism (machine-checked) — applying the SAME key twice returns
+/// the same value, even with a different key interleaved.
+#[kani::proof]
+#[kani::unwind(8)]
+fn ufmap32_is_deterministic() {
+    let mut uf: UfMap32<2> = UfMap32::new();
+    let k1 = UfKey::new().push(&[1, 2, 3]);
+    let k2 = UfKey::new().push(&[4]).push(&[5]);
+    let v1 = uf.apply(k1);
+    let _ = uf.apply(k2);
+    assert!(wide_eq_32(uf.apply(k1), v1));
+}
+
+/// #189: key packing is length-prefixed — `["ab","c"]` and `["a","bc"]` are
+/// DIFFERENT keys (same concatenated bytes), so they draw distinct values
+/// under the collision-freedom axiom.
+#[kani::proof]
+#[kani::unwind(8)]
+fn ufmap32_distinct_keys_distinct_values() {
+    let mut uf: UfMap32<2> = UfMap32::new();
+    let v1 = uf.apply(UfKey::new().push(b"ab").push(b"c"));
+    let v2 = uf.apply(UfKey::new().push(b"a").push(b"bc"));
+    assert!(!wide_eq_32(v1, v2));
+}
+
+/// #189: the 64-byte-valued map (secp256k1 recovery shape) — determinism and
+/// axiom wiring in one harness.
+#[kani::proof]
+#[kani::unwind(8)]
+fn ufmap64_deterministic_and_distinct() {
+    let mut uf: UfMap64<2> = UfMap64::new();
+    let k1 = UfKey::new().push(&[9; 32]);
+    let k2 = UfKey::new().push(&[7; 32]);
+    let v1 = uf.apply(k1);
+    let v2 = uf.apply(k2);
+    assert!(!wide_eq_64(v1, v2));
+    assert!(wide_eq_64(uf.apply(k1), v1));
 }

--- a/lean_solana/QEDGen/Solana/Account.lean
+++ b/lean_solana/QEDGen/Solana/Account.lean
@@ -9,6 +9,16 @@ namespace QEDGen.Solana.Account
     and `Pubkey.ne_iff` come from `SVM.Pubkey` too. -/
 abbrev Pubkey := SVM.Pubkey
 
+/-- Opaque 32-byte token (hash / digest / merkle root) — DSL `Bytes32` (#191).
+    Equality-only semantics, so it shares `Pubkey`'s opaque carrier: the
+    spec-level meaning is "an unforgeable token compared for equality"; the
+    32-vs-64-byte width is a Rust-side layout concern the proofs never see. -/
+abbrev Bytes32 := SVM.Pubkey
+
+/-- Opaque 64-byte token (signature / recovered secp pubkey) — DSL `Bytes64`
+    (#191). Same opaque carrier as `Bytes32`; see its docstring. -/
+abbrev Bytes64 := SVM.Pubkey
+
 abbrev U64 := Nat
 abbrev U128 := Nat
 abbrev I128 := Int

--- a/references/qedspec-dsl.md
+++ b/references/qedspec-dsl.md
@@ -316,8 +316,8 @@ for subscripting a `Map[N] T` field.
 
 ### Parameterised and map types
 
-Type expressions: `Pubkey`, `U8`, `U16`, `U64`, `U128`, `I128`, `Vec U64`,
-`Option Pubkey`, `Map[N] T`, `Fin[N]`.
+Type expressions: `Pubkey`, `Bytes32`, `Bytes64`, `U8`, `U16`, `U64`, `U128`,
+`I128`, `Vec U64`, `Option Pubkey`, `Map[N] T`, `Fin[N]`.
 
 ```fsharp
 accounts : Map[MAX_ACCOUNTS] Account
@@ -331,6 +331,20 @@ state fields lower to `[u8; 32]` automatically — the structurally-
 equivalent byte array that proptest's `prop::array::uniform32(0u8..)`
 strategy already generates. P6 fires at `Info` severity as a note,
 not as a `Warning`; no spec-side action is required.
+
+**`Bytes32` / `Bytes64` — opaque byte tokens (#191):** hashes / digests /
+merkle roots (`Bytes32`, `[u8; 32]`) and signatures / recovered secp keys
+(`Bytes64`, `[u8; 64]`). Equality-only semantics like `Pubkey`, but with **no
+framework newtype** — they lower to raw byte arrays in *every* Rust backend
+(Anchor structs included) and to an opaque token in Lean. Needed to mirror a
+brownfield `#[account]` struct with `merkle_root: [u8; 32]` or
+`last_sig: [u8; 64]` fields, which `Pubkey` can't cover (its ctor emits the
+newtype). Kani note: a raw byte-array compare is a real memcmp loop Kani
+**cannot stub** (generic core impl — model-checking/kani#1997), so a
+`Bytes32`/`Bytes64` field raises the suggested `#[kani::unwind]` to 34/66 even
+when the Pubkey wide-compare abstraction is active. The prelude ships
+`wide_eq_64`/`wide_cmp_64` (machine-checked, like the 32-byte pair) for
+hand-written adapters over *named* 64-byte newtypes, which are stubbable.
 
 ### `state` (sugar)
 
@@ -1343,6 +1357,44 @@ bit-blasts a sequential divider circuit that stalls both SAT (CaDiCaL) and SMT
 (z3); the abstraction removes the circuit while staying sound (the quotient is
 unique, so it's exact — no false proofs). Same discipline as the Pubkey/PDA
 stubs. Needs `-Z stubbing`.
+
+**`pragma kani_stub_hash = on`** — the **#189 Tier-2 trusted-crypto stubs**:
+replace `solana_program::{hash,keccak,blake3}::{hash,hashv}` with
+*deterministic uninterpreted functions* backed by the prelude's `UfMap32` —
+same input ⇒ same digest (memoized; determinism machine-checked in the
+prelude), distinct inputs ⇒ distinct digests (**collision-freedom axiom** —
+the Kani mirror of trusting sha256 collision resistance, exactly the Lean
+side's hash axioms). One map per primitive (domain separation); `hash(x)` and
+`hashv(&[x])` agree by shared key construction. Without the stub, CBMC
+bit-blasts the real compression function at zero verification value. Opt-in
+like `kani_stub_pda` (the hashing is inside called methods, invisible to the
+spec). Needs `-Z stubbing`.
+
+**`pragma kani_stub_secp256k1 = on`** — #189: stub
+`solana_program::secp256k1_recover::secp256k1_recover` to a deterministic
+uninterpreted function over `(hash, recovery_id, signature)` (UfMap64-backed,
+collision-freedom axiom), with a *nondeterministic* failure branch so the
+real invalid-input error path stays explored. This is the one in-program
+signature primitive; **ed25519 verification has no stubbable in-program
+entry point** (it's a precompile reached via instruction introspection).
+Needs `-Z stubbing`.
+
+> The pre-existing `pragma kani_stub_pda` (#182 Tier 2) is upgraded by #189:
+> `find_program_address` / `create_program_address` now route through the same
+> deterministic + injective UfMap machinery instead of returning a fresh
+> `kani::any()` address per call — restoring the derive-then-compare
+> determinism real programs rely on. The bump stays fully symbolic; the two
+> entry points use separate domains (the bump-in-seeds relationship between
+> them is not modeled). Any harness using a #189 UfMap stub gets its suggested
+> `#[kani::unwind]` floored at 10 to cover the CAP=8 memo scan.
+
+**Vec under-coverage lint (#192)** — at Kani codegen time, a handler
+`ensures`, `invariant`, or `property` that reads a `Vec`-typed state field
+while `pragma kani_vec_bound` is **unset** (default 1) emits a warning naming
+the field and the pragma: the harness would explore only 1-element
+collections, silently under-covering membership/aggregation behavior. Setting
+the pragma to any explicit value — including 1 — silences it (an explicit
+bound is a conscious BMC trade-off). Scalar-only properties stay silent.
 
 ## Interface declarations
 


### PR DESCRIPTION
Folds the four open Kani good-to-haves into one pass. Closes #189, closes #190, closes #191, closes #192.

## #189 — Tier-2 trusted-crypto stubs (uninterpreted + injective)

- `kani_prelude` gains **`UfMap32` / `UfMap64`** (+ `UfCell*` interior-mutable wrappers for `static` use in generated stubs): deterministic uninterpreted functions — memoized apply, **determinism machine-checked** (`ufmap32_is_deterministic`) — with a **collision-freedom axiom** (`kani::assume`), the Kani mirror of `lean_solana`'s hash/PDA axioms. Fail-closed `assert!` on CAP / 128-byte key-budget overflow; length-prefixed key packing (`["ab","c"] ≠ ["a","bc"]`, proven).
- **`pragma kani_stub_pda` upgraded**: `find_program_address` / `create_program_address` now route through the UfMap pair (separate domains; nondeterministic `create` failure keeps the off-curve error path) instead of returning a fresh `kani::any()` per call — restoring the derive-then-compare determinism programs rely on.
- **New `pragma kani_stub_hash`**: `solana_program::{hash,keccak,blake3}::{hash,hashv}` → one UfMap per primitive; `hash(x)` and `hashv(&[x])` agree by shared key construction.
- **New `pragma kani_stub_secp256k1`**: `secp256k1_recover` → UfMap64 over `(hash, recovery_id, signature)` with a nondeterministic failure branch. ed25519 documented as not stubbable (precompile via instruction introspection — no in-program entry point).
- Suggested `#[kani::unwind]` floors at 10 when any UfMap stub is active (CAP=8 memo scan).

## #190 — prelude correctness proofs for every public helper

- `mul_div_floor_u128` / `mul_div_ceil_u128`: Euclidean-contract harnesses (`q·d ≤ a·b < q·d + d` and the ceil dual — multiplicative spec side) over symbolic u8-bounded operands × a concrete divisor panel, plus full-width zero-divisor and a symbolic-divisor saturation branch. The all-symbolic 128-bit divider form ran >4 min; the panel closes in 20–34 s.
- `mul_bps_floor_u128`: floor contract over symbolic in-range `bps` × concrete dividend panel up to u64 width, + full-width out-of-range guard. (The direct-equality form pays for four 128-bit dividers and stalled even u16-bounded.)
- `checked_div_i64`: full-width `None` cases and full-width unit divisors added on top of the i8-exhaustive proof.
- Residual (symbolic dividend × symbolic non-unit divisor at full width) documented in-file against the quotient-uniqueness contract argument.
- **`cd kani_prelude && cargo kani` = 15/15 verified** with stock CaDiCaL — no external solver required.

## #191 — T1 wide-compare extension to hashes/signatures

- Prelude: `wide_eq_64` / `wide_cmp_64` (`[u128; 4]`, big-endian-keyed cmp) with equivalence proofs (unwind 65 on the spec side only).
- DSL: new opaque byte-token types **`Bytes32` / `Bytes64`** — first-class MIR `Ty` variants riding the exhaustive-match discipline through all four codegens (Kani ctor `kani::any()`, Rust `[u8; N]` in every context, Lean opaque abbrevs in `QEDGen.Solana.Account`, proptest strategies, Pubkey-literal typecheck guards, Map-value lint). This is what lets a brownfield spec mirror a real struct's `merkle_root: [u8; 32]` / `last_sig: [u8; 64]` fields, which `Pubkey` can't (its ctor emits the newtype).
- Detection: Kani **cannot** stub raw-array `PartialEq` (generic core trait impl — model-checking/kani#1997, verified empirically on 0.67), so `Bytes32`/`Bytes64` in state/params raise the suggested unwind floor to 34/66 — including when the Pubkey wide-compare abstraction is active, which previously would have under-bounded.

## #192 — Vec under-coverage lint at Kani codegen time

- A handler `ensures` / `invariant` / `property` that reads a `Vec`-typed state field while `pragma kani_vec_bound` is **unset** (default 1) warns, naming the field and the pragma. Any explicit bound — a conscious BMC trade-off — or a scalar-only property stays silent. Pure spec analysis; wired into all three `--kani-impl` modes.
- Drive-by fix this surfaced: the pragma-assignment grammar **rejected numeric values** — `pragma kani_vec_bound = 2` was a parse error (verified against the shipped binary), making the documented remedy impossible to apply. Pragma values now accept bare integer segments.

## Validation

- `cargo test`: green across all targets (1151 bin tests incl. 5 new, all snapshot suites).
- `cd kani_prelude && cargo kani`: 15/15 harnesses verified.
- `lake build QEDGen.Solana.Account`: green.
- End-to-end: a brownfield spec using every new pragma + `Bytes32`/`Bytes64` fields generates a harness that **compiles under `cargo kani` against real `solana-program` 1.18** (thin `anchor_lang` shim), with the UfMap stubs, per-primitive statics, and 66-floor unwind all present.