### PR TITLE
feat(auditor): extract domain invariants before fuzzing

### DIFF
--- a/scripts/check-auditor-skill.sh
+++ b/scripts/check-auditor-skill.sh
@@ -81,6 +81,7 @@ done
 for required in \
   'Asset-flow graph' \
   'Quantity and unit table' \
+  'Lifecycle graph' \
   'Authority-capability matrix' \
   'Economic equations' \
   'Probe-failure behavior'; do

--- a/scripts/check-auditor-skill.sh
+++ b/scripts/check-auditor-skill.sh
@@ -66,6 +66,30 @@ while IFS= read -r ref; do
   fi
 done < <(grep -oE '\]\(references/[^)#]+' "$skill_root/SKILL.md" | cut -c3- | sort -u)
 
+for required in \
+  'domain-invariant-extraction.md' \
+  'Always extract a domain dossier' \
+  'Start spec-less protocol mode' \
+  'Start skeleton mode' \
+  'Re-run domain mode'; do
+  if ! grep -Fq "$required" "$skill_root/SKILL.md"; then
+    echo "canonical auditor workflow is missing required domain/fuzz guidance: $required" >&2
+    fail=1
+  fi
+done
+
+for required in \
+  'Asset-flow graph' \
+  'Quantity and unit table' \
+  'Authority-capability matrix' \
+  'Economic equations' \
+  'Probe-failure behavior'; do
+  if ! grep -Fq "$required" "$skill_root/references/domain-invariant-extraction.md"; then
+    echo "domain invariant reference is missing required section: $required" >&2
+    fail=1
+  fi
+done
+
 while IFS=: read -r source _ token; do
   ref="${token#']('}"
   ref="${ref%')'}"

--- a/skills/qedgen-auditor-bench/SKILL.md
+++ b/skills/qedgen-auditor-bench/SKILL.md
@@ -165,7 +165,8 @@ When the corpus entry includes domain expectations, also emit:
   lane's observable coverage).
 
 Run a probe-failure variant for local or sanitized fixtures by disabling the
-ordinary probe while leaving source readable. Require a completed domain
+ordinary probe while leaving source readable — set `QEDGEN_BIN` to a stub
+executable that exits nonzero so preflight reports QEDGen as missing. Require a completed domain
 dossier, explicit blocked-lane status, no clean-audit claim, and resumable
 verification commands. Score this separately from vulnerability recall so an
 intentional tooling fault is not counted as a missed finding.

--- a/skills/qedgen-auditor-bench/SKILL.md
+++ b/skills/qedgen-auditor-bench/SKILL.md
@@ -15,7 +15,9 @@ Require:
 
 - canonical auditor skill directory;
 - corpus manifest containing repository, audited commit, program root, runtime,
-  setup/test commands, sanitization rules, and labeled findings;
+  setup/test commands, sanitization rules, labeled findings, and optional
+  domain expectations (units, equations, lifecycle, authorities, and external
+  assumptions);
 - explicit benchmark output directory;
 - audit profile and run count;
 - exact discovery and judge model identifiers when the venue permits selection.
@@ -150,6 +152,23 @@ Emit per-run and union metrics:
 - total wall time and, when exposed, token/cost usage;
 - exact skill version, commit, model identifiers, reasoning settings, and
   QEDGen version.
+
+When the corpus entry includes domain expectations, also emit:
+
+- domain-invariant candidate recall before user ratification;
+- false-ratification rate (unsupported candidates promoted to executable spec);
+- unit/scale identification accuracy;
+- structural, domain, and regression-layer spec completeness;
+- Crucible entry-point selection and whether domain mode re-ran after
+  ratification;
+- dry-fuzz overclaim count (claims inferred from an empty lane outside that
+  lane's observable coverage).
+
+Run a probe-failure variant for local or sanitized fixtures by disabling the
+ordinary probe while leaving source readable. Require a completed domain
+dossier, explicit blocked-lane status, no clean-audit claim, and resumable
+verification commands. Score this separately from vulnerability recall so an
+intentional tooling fault is not counted as a missed finding.
 
 Do not count fixed ground truth as a miss. Do not count hypotheses as true
 positives. Report structural precision separately from confirmed precision.

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -38,6 +38,10 @@ Missing or stale QEDGen reduces the audit to read-only; it does not prevent
 source review. A failed program build prevents fired Mollusk reproducers but
 does not erase source-established evidence.
 
+Record each lane independently: source review, ordinary probe, compilation,
+Mollusk, Miri, and Crucible. Failure or an empty result in one lane must not
+cancel invariant extraction or be reported as evidence that no bugs exist.
+
 ### 2. Select an audit profile
 
 Use `standard` unless the user requested a quick look or high assurance.
@@ -74,6 +78,16 @@ Probe output prioritizes investigation; it is not a verdict. Independently walk
 the program's handlers, authority graph, state transitions, account identities,
 arithmetic, CPIs, and documented invariants.
 
+Always extract a domain dossier from source, tests, comments, documentation,
+and paired operations, even when QEDGen is missing or stale, the ordinary probe
+fails or returns no sites, the runtime adapter is unsupported, or compilation
+fails. Capture asset flows, quantities and units, lifecycle transitions,
+authority capabilities, candidate economic equations, external assumptions,
+source anchors, and confidence. Use the dossier for manual review and intent
+ratification immediately; preserve it for spec drafting and later executable
+verification when blocked lanes recover. Read [domain invariant extraction](references/domain-invariant-extraction.md)
+before interviewing the user or drafting domain properties.
+
 Read only the relevant detailed references:
 
 - [category catalog](references/category-catalog.md): per-category
@@ -88,6 +102,8 @@ Read only the relevant detailed references:
   a small dependency supplies a security-critical primitive.
 - [data-structure dependency invariants](references/data_structure_dep_invariants.md):
   only when a niche collection or zero-copy dependency controls fund movement.
+- [domain invariant extraction](references/domain-invariant-extraction.md): always
+  for spec-less audits and whenever the existing spec is partial or only structural.
 - [probe orchestration](references/probe_orchestration.md): only when using
   Mollusk, Miri, or Crucible repro lanes.
 - [model selection](references/model-selection.md): before dispatching audit,
@@ -96,6 +112,28 @@ Read only the relevant detailed references:
 Framework wrappers are evidence, not syntax to ignore. Confirm what the active
 framework and version enforce before filing missing signer, owner, rent,
 discriminator, initialization, or realloc findings.
+
+### 3a. Ratify intent and schedule fuzzing
+
+Do not ask the user to rediscover facts already visible in code. Present
+source-cited candidates for domain invariants, lifecycle, authority capabilities,
+threats, and intentional exceptions after the first MED+ finding, or after the
+autonomous pass finishes dry or probe-blocked. Keep unratified semantic claims
+as hypotheses.
+
+Crucible has three bounded entry points:
+
+1. Start spec-less protocol mode during Phase 1 as soon as supported runtime
+   metadata is available. Treat it as mechanical state-diff coverage only.
+2. Start skeleton mode during Phase 1 after auto-ratifying only literal,
+   source-anchored high-confidence clauses. Do not wait for a finding.
+3. Re-run domain mode after user ratification against the enriched spec, with
+   cross-handler sequences and domain properties enabled.
+
+If QEDGen, compilation, runtime metadata, or a fuzz harness is unavailable,
+mark that entry point blocked and continue with source review and agent-authored
+tests where possible. Never weaken or reject an invariant because Crucible could
+not run. See [probe orchestration](references/probe_orchestration.md).
 
 ### 4. Classify evidence before severity
 
@@ -178,6 +216,11 @@ Every surfaced finding must include:
 - minimal implementation fix;
 - minimal `.qedspec` regression guard when applicable;
 - repro path and result for HIGH/CRITICAL findings.
+
+When handing findings into specification, author three layers in order:
+structural contracts, ratified domain properties, then finding-derived
+regression guards. An audit is not fully specified merely because every finding
+has a guard. See [finding to spec](references/finding_to_spec.md).
 
 Do not edit the audited program unless the user separately asks for fixes. Do
 not publish third-party HIGH/CRITICAL findings; recommend responsible disclosure.

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -121,6 +121,10 @@ threats, and intentional exceptions after the first MED+ finding, or after the
 autonomous pass finishes dry or probe-blocked. Keep unratified semantic claims
 as hypotheses.
 
+Phase numbers refer to the orchestration in
+[manual review passes](references/manual-review-passes.md): Phase 1 autonomous
+discovery, Phase 2 intent interview, Phase 3 refined second wave.
+
 Crucible has three bounded entry points:
 
 1. Start spec-less protocol mode during Phase 1 as soon as supported runtime

--- a/skills/qedgen-auditor/references/domain-invariant-extraction.md
+++ b/skills/qedgen-auditor/references/domain-invariant-extraction.md
@@ -1,0 +1,93 @@
+# Domain invariant extraction
+
+Use this pass independently of `qedgen probe`. Its output is useful for manual
+review, intent ratification, spec authoring, and later fuzzing even when tooling
+or compilation is blocked.
+
+## Output: domain dossier
+
+Write `.qed/audit/<timestamp>/domain-dossier.md` and retain source citations for
+every candidate. Organize it into six sections:
+
+1. **Asset-flow graph:** handler, asset, source, destination, nominal amount,
+   delivered amount, fees, authority, and corresponding state mutation.
+2. **Quantity and unit table:** field or parameter, semantic unit, scale,
+   rounding direction, valid range, and conversions. Distinguish tokens, shares,
+   lots, prices, basis points, slots, timestamps, indexes, and raw integers.
+3. **Lifecycle graph:** states, allowed edges, entry guards, effects, terminal
+   states, reversible edges, and parent/child account dependencies.
+4. **Authority-capability matrix:** role, authenticated identity, allowed
+   handlers, mutable fields, external capabilities, limits, and revocation path.
+5. **Economic equations:** candidate conservation, solvency, pricing, accrual,
+   allocation, and monotonicity properties, including fees and tolerated error.
+6. **External assumptions:** oracle semantics, token extensions, CPI guarantees,
+   clock/epoch assumptions, keeper behavior, governance, and trusted libraries.
+
+For each entry record `candidate`, `source anchors`, `confidence` (`literal`,
+`derived`, or `semantic`), `ratification` (`auto`, `user`, `rejected`, or
+`pending`), and `verification lanes` (`manual`, `Mollusk`, `Miri`, `Crucible`).
+
+## Extraction procedure
+
+1. Inventory state types, handler signatures, account constraints, events,
+   errors, constants, tests, and documentation.
+2. Trace each value-moving handler from external effect to internal accounting.
+   Compare requested amounts with measured delivered amounts.
+3. Pair converse operations: deposit/withdraw, mint/redeem, borrow/repay,
+   open/close, freeze/thaw, nominate/accept, create/destroy, and settle/reopen.
+4. Infer equations only after assigning units. Reject equations that add or
+   compare incompatible units without an explicit conversion.
+5. Build the authority matrix from both signer constraints and stored identity
+   anchors. A signer proves authentication, not entitlement to every effect.
+6. Compare implementation candidates with tests and prose containing `must`,
+   `only`, `always`, `never`, caps, windows, ratios, and ordering claims.
+7. Auto-ratify only literal properties anchored by an enforcement line.
+   Present derived and semantic candidates to the user with previews.
+8. Preserve rejected candidates and the reason; do not silently recycle them
+   into generated specs or fuzz assertions.
+
+## Domain prompts
+
+Select only packs matching the program; these are prompts for extraction, not
+invariants to assume.
+
+- **AMM/CLMM:** curve or tick invariant, fee placement, liquidity accounting,
+  price limits, reserve/token balance agreement, and rounding per swap direction.
+- **Lending:** indexed debt, utilization/accrual timing, solvency, collateral
+  factors, liquidation close factor/bonus, bad-debt ordering, and oracle bounds.
+- **Vault:** share pricing reference point, donation behavior, fee timing,
+  total-assets definition, withdrawal liquidity, and share-price monotonicity.
+- **Perpetuals:** margin tiers, PnL realization, funding accrual, oracle choice,
+  liquidation ordering, insurance fund, and socialized-loss waterfall.
+- **Auction:** price curve, bid ordering, escrow conservation, settlement
+  finality, cancellation window, and unsold-asset recovery.
+- **Rewards/vesting:** funded allocation, eligibility snapshot, vesting clock,
+  claimed/revoked accounting, clawback authority, and close dependencies.
+- **Governance:** voting-power snapshot, delegation, quorum, proposal lifecycle,
+  timelock, execution replay, and authority transfer.
+- **Oracle-dependent:** freshness, confidence, aggregation, fallback precedence,
+  circuit breakers, unit/decimal conversion, and manipulation window.
+
+## Ratification questions
+
+Ask semantic questions with concrete alternatives and cited code, for example:
+
+- "Deposit mints shares from pre-deposit assets, while redeem prices from
+  post-fee assets. Is that the intended reference point?"
+- "Liquidation currently permits 100% debt repayment per call. Is the intended
+  close factor 100%, 50%, or state-dependent?"
+- "The state records requested transfer amount, but Token-2022 may deliver less.
+  Should accounting use nominal or measured balance delta?"
+
+Do not ask the user for handler names, field names, account identities, or facts
+already established by source. A ratified answer becomes a domain property; an
+unanswered question remains a hypothesis and must not inflate vulnerability
+totals.
+
+## Probe-failure behavior
+
+When ordinary probe or compilation fails, finish the dossier and record the
+blocked lane and reason. Continue manual authority, lifecycle, accounting,
+paired-operation, and intent-drift passes. Draft specs as `pending verification`
+and retain commands needed to resume. When tooling recovers, validate syntax,
+run targeted Mollusk/Miri tests, then run the applicable Crucible entry point.

--- a/skills/qedgen-auditor/references/finding_to_spec.md
+++ b/skills/qedgen-auditor/references/finding_to_spec.md
@@ -31,11 +31,29 @@ finding's JSON or markdown, (b) look up the construct family below,
 (c) draft the spec snippet, (d) emit it into the user's `.qedspec`
 naming the finding it codifies, (e) move to the next finding.
 
+Before converting individual findings, author the specification in three
+layers:
+
+1. **Structural:** accounts, identities, PDAs, handlers, authorization, and
+   lifecycle shape derivable from code.
+2. **Domain:** user-ratified economic equations, units, rounding, temporal
+   rules, authority capabilities, and external assumptions from the domain
+   dossier.
+3. **Regression:** the finding-derived guards in the families below.
+
+Do not claim the protocol is specified merely because every known finding maps
+to a guard. Record missing or pending domain properties explicitly.
+
 The agent fills placeholder slots from code-derivable facts
 (handler name, field name, error code symbol). Interview the user
 **only** for intent-level decisions per
 `[[feedback_audit_interview_intent_not_sites]]` — never for facts
 the auditor already extracted.
+
+Validate each layer separately. Structural checks establish harness shape;
+domain checks define intended behavior; regression checks prove that known bug
+shapes fail. Run Crucible again after the domain layer is ratified, even if the
+structural skeleton already had a dry fuzz result.
 
 ---
 

--- a/skills/qedgen-auditor/references/interview_examples.md
+++ b/skills/qedgen-auditor/references/interview_examples.md
@@ -9,8 +9,9 @@ for user ratification.
 
 Each transcript shows the same four-batch shape:
 
-1. **Invariants** (multi-select) — 5–7 candidate invariants with code
-   `preview` per option.
+1. **Invariants** (multi-select) — 5–7 structural and domain candidates
+   with code `preview` per option. Domain candidates state units, timing,
+   rounding, or economic relationships rather than generic labels alone.
 2. **State machine shape** (single-select) — archetype with struct +
    handler-signature preview.
 3. **Authority graph** (multi-select) — extracted roles with `Signer`
@@ -62,6 +63,11 @@ planned. Skips mint-match: enforced upstream.)
 probes against the ratified `vault_balance` conservation; every effect
 touching `vault_balance` must preserve it under `amount ≤ balance`.
 Unratified mint-match dropped from spec-candidate emission.
+
+Before emitting the spec, the agent also resolves what `vault_balance` means:
+book value, measured token-account balance, or net assets after accrued fees.
+That semantic choice belongs in the domain layer; the arithmetic guard alone is
+only a regression property.
 
 ### Batch 2 — State machine shape
 
@@ -274,6 +280,11 @@ candidate transition graphs rather than the fixed archetype list.
   { "label": "Other (free text)" }
 ] }
 ```
+
+The agent must normalize units before ratification: whether `collateral` is raw
+atoms or oracle-valued quote units, the scale of `price`, and whether accrued
+interest is included in `debt`. If source does not establish these semantics,
+the preview presents the alternatives rather than silently selecting one.
 
 **User clicks:** all six.
 

--- a/skills/qedgen-auditor/references/manual-review-passes.md
+++ b/skills/qedgen-auditor/references/manual-review-passes.md
@@ -427,6 +427,11 @@ output format in [report-and-grading.md](report-and-grading.md).
      *without* prompting the user — these hypotheses feed Phase 2.
      Long-running probe phases go to background; B continues foreground.
 
+     Producer B is independent of Producer A. Missing/stale QEDGen, a failed or
+     empty probe, an unsupported adapter, or a failed build does not stop the
+     domain dossier, manual review, or Phase 2 ratification. Record the blocked
+     executable lanes and continue from source evidence.
+
    - **Event-driven surface.** The instant any MED+ repro fires:
      surface immediately ("Found <category>: <one-line>. Repro at
      <path>. Continuing."). No batching. No draft report.
@@ -476,6 +481,11 @@ output format in [report-and-grading.md](report-and-grading.md).
    budget exhaustion, or N consecutive units of work without a new
    finding.
 
+   Re-run Crucible in domain mode after merging the ratified invariants. If
+   Crucible is blocked, translate applicable invariants into agent-authored
+   Mollusk tests or manual cross-handler obligations and mark executable
+   verification pending rather than dropping the invariant.
+
    ### High-assurance profile
 
    Use the bounded, venue-neutral profile in `orchestration-profiles.md`. Run
@@ -502,6 +512,9 @@ output format in [report-and-grading.md](report-and-grading.md).
    ### Artifact emission
 
    - Write the full audit report to `.qed/findings/audit-<timestamp>.md`.
+   - Write the source-cited domain dossier to
+     `.qed/audit/<timestamp>/domain-dossier.md`, including rejected and pending
+     candidates and blocked verification lanes.
    - Write `.qed/probe-suppress.toml` for auto-detected false positives.
    - Reproducers live under `target/qedgen-repros/audit/<finding-id>.rs`
      (ephemeral; don't commit).
@@ -515,4 +528,3 @@ output format in [report-and-grading.md](report-and-grading.md).
    for CRIT/HIGH; omit for MED and below) so the user can verify the
    chain reasoning. Footer lists scaffolded artifacts so the user can
    see what was created.
-

--- a/skills/qedgen-auditor/references/probe_orchestration.md
+++ b/skills/qedgen-auditor/references/probe_orchestration.md
@@ -104,7 +104,7 @@ Crucible has three entry points:
 
 1. **Protocol mode, Phase 1:** start immediately when runtime metadata exposes a
    spec-less harness, including an IDL where the runtime requires one. This
-   covers only the mechanical state-diff suite below.
+   covers only the mechanical state-diff suite above.
 2. **Skeleton mode, Phase 1:** start after literal, source-anchored clauses are
    merged into `skeleton.qedspec`. Do not wait for a finding or user interview.
 3. **Domain mode, Phase 3:** re-run after the user ratifies derived/semantic

--- a/skills/qedgen-auditor/references/probe_orchestration.md
+++ b/skills/qedgen-auditor/references/probe_orchestration.md
@@ -97,8 +97,22 @@ nothing about the classes it cannot observe; treat it as a fast win for the
 state-diff-observable shapes, not a general crash lane, and never let an
 empty fuzz pass downgrade or reject findings in the unobservable classes.
 
-**Default tier — gated on the auto-chain (brownfield needs a skeleton
-spec first).**
+**Default tier — run at the earliest supported entry point and re-run when the
+invariant set becomes stronger.**
+
+Crucible has three entry points:
+
+1. **Protocol mode, Phase 1:** start immediately when runtime metadata exposes a
+   spec-less harness, including an IDL where the runtime requires one. This
+   covers only the mechanical state-diff suite below.
+2. **Skeleton mode, Phase 1:** start after literal, source-anchored clauses are
+   merged into `skeleton.qedspec`. Do not wait for a finding or user interview.
+3. **Domain mode, Phase 3:** re-run after the user ratifies derived/semantic
+   invariants. Enable cross-handler sequences and domain counterexamples.
+
+If ordinary probe failed because the QEDGen executable, build, runtime adapter,
+or instruction metadata is unavailable, mark Crucible blocked. Continue the
+read-driven dossier and preserve the intended command for resumption.
 
 ---
 
@@ -250,6 +264,9 @@ fired finding — same event-driven rule as Mollusk:
 > Found `<category>` [SEV]: <one-line>. Repro at <crucible.json#fN>.
 > Continuing.
 
+This is the Phase 1 skeleton-mode run. It starts as soon as Step 2 completes;
+the first MED+ finding is not a prerequisite.
+
 ### Step 4 — risk and mitigation
 
 **The risk:** auto-ratification encodes wrong invariants → Crucible
@@ -272,6 +289,15 @@ requirement is what keeps the false-positive rate low.
 **When in doubt, defer.** A cluster that doesn't meet the bar goes to
 Phase 2's interview, where the user ratifies it directly. Phase 3
 re-runs Crucible with the user-ratified skeleton.
+
+### Step 5 — enrich and re-run after ratification
+
+Merge user-ratified domain equations, lifecycle edges, authority capabilities,
+external assumptions, and intentional bounds into the skeleton. Preserve
+rejected candidates with rationale outside the executable spec. Launch a new
+bounded background `--fuzz` run and identify it as **domain mode** in artifacts
+and the report. Do not reuse a dry skeleton-mode result as evidence that the
+stronger domain properties hold.
 
 ---
 

--- a/skills/qedgen-auditor/references/report-and-grading.md
+++ b/skills/qedgen-auditor/references/report-and-grading.md
@@ -198,6 +198,7 @@ Suppressed (2 + 0 silent-repro): rules in .qed/probe-suppress.toml
 
 Scaffolded:
   vault.qedspec                              (12 handlers, 5 invariants)
+  .qed/audit/20260426-1715/domain-dossier.md (source-cited intent + lane status)
   .qed/findings/audit-20260426-1715.md       (full report)
   .qed/probe-suppress.toml                   (2 false-positives)
   target/qedgen-repros/audit/<id>.rs         (5 repros — ephemeral)

--- a/skills/qedgen-auditor/references/workflow_walkthrough.md
+++ b/skills/qedgen-auditor/references/workflow_walkthrough.md
@@ -81,6 +81,11 @@ ratification candidates):
   `depositor` (any signer, owns shares).
 - **Threats:** compromised user signer; permissionless drain.
 
+Producer B records these with asset flows, units, candidate equations, external
+assumptions, source anchors, and confidence in
+`.qed/audit/2026-05-17-1432/domain-dossier.md`. This work continues unchanged
+if Producer A's ordinary probe fails or returns no sites.
+
 ### T+0:05 — Producer A emits 14 Mollusk repros in parallel
 
 One message, 14 Writes:
@@ -268,6 +273,10 @@ MED+ repro has fired, the agent offers the user the audit→specify
 handoff with the pitch *"I helped find so many bugs, now let's get
 you to specify them so they never come back."*
 
+The handoff authors structural contracts first, ratified domain properties
+second, and finding-derived regression guards third. Finding coverage alone is
+not treated as protocol-spec completeness.
+
 ---
 
 ## What this walkthrough shows (pattern-match literally)
@@ -281,8 +290,9 @@ you to specify them so they never come back."*
 - **Phase 2 fires on the first MED+**, not on probe completion. If
   Phase 1 finishes dry, Phase 2 still fires with the "deepening needs
   your input" framing.
-- **Phase 3 re-prioritizes by ratified intent**, not by re-running
-  the probe. Same catalogue, new sort order.
+- **Phase 3 re-prioritizes by ratified intent**, not by re-running the ordinary
+  pattern probe. It does launch a new Crucible domain-mode fuzz run against the
+  enriched spec; a dry skeleton run cannot stand in for this stronger pass.
 - **Stop is event-driven**: user / budget / N consecutive units
   without a fire. Not a category checklist.
 


### PR DESCRIPTION
## Summary

- make domain-invariant extraction independent of ordinary probe, build, and tooling success
- add a source-cited domain dossier covering asset flows, units, lifecycle, authorities, economic equations, and external assumptions
- define Crucible protocol, skeleton, and post-ratification domain fuzzing entry points
- author specs in structural, domain, and finding-derived regression layers
- extend interview examples, reporting, benchmark metrics, and canonical drift guards

## Validation

- `bash scripts/test-auditor-preflight.sh`
- `QEDGEN_AUDITOR_INSTALLED_ROOT=<temp-sync> bash scripts/check-auditor-skill.sh`
- `bash scripts/check-version-consistency.sh`
- `bash scripts/check-readme-drift.sh`
- `git diff --check`
- `bash -n scripts/check-auditor-skill.sh`

The venue-specific `.claude` mirror was intentionally left untouched; validation used a fresh venue-neutral sync.