### PR TITLE
#225 Phase 0: probe CLI correctness — canonical schema version, no silent engine skips

### DIFF
--- a/crates/qedgen/src/cli.rs
+++ b/crates/qedgen/src/cli.rs
@@ -242,18 +242,24 @@ pub(crate) enum Commands {
         #[arg(long)]
         root: Option<PathBuf>,
 
-        /// Pinocchio audit mode (v2.19). Walks `<path>` and emits the
-        /// site catalogue + SAFETY-comment metadata the audit subagent
-        /// consumes. Detection auto-routes via `Cargo.toml` (`pinocchio`
-        /// dep), so `--program <path>` is the same as `--bootstrap
-        /// --root <path>` when the runtime is Pinocchio — `--program`
-        /// is the user-facing alias documented in the PRD.
-        #[arg(long, conflicts_with_all = ["spec", "bootstrap"])]
+        /// Program audit mode. Walks `<path>` and routes through the
+        /// runtime's dedicated extractor: Pinocchio emits the site
+        /// catalogue + SAFETY-comment metadata (v2.19); Anchor/Quasar
+        /// route through the anchor extractor (scaffold-to-spec
+        /// interview); native/qedgen-codegen route through the native
+        /// extractor. Runtimes without an extractor fall back to the
+        /// bootstrap envelope. Detection auto-routes via `Cargo.toml`.
+        ///
+        /// This is a static engine only — it conflicts with `--fuzz`
+        /// (use `--fuzz <budget> --root <path>` for brownfield fuzzing
+        /// and merge the two JSON outputs yourself).
+        #[arg(long, conflicts_with_all = ["spec", "bootstrap", "fuzz", "root"])]
         program: Option<PathBuf>,
 
         /// Override runtime detection (`pinocchio`, `anchor`, `quasar`,
-        /// `native`, `sbpf`). Only `pinocchio` has dedicated probe
-        /// output today; the others fall back to the generic bootstrap
+        /// `native`, `sbpf`). Pinocchio, Anchor/Quasar, and native each
+        /// have a dedicated extractor under `--program`; runtimes
+        /// without one (e.g. sbpf) fall back to the generic bootstrap
         /// envelope.
         #[arg(long, value_enum)]
         runtime: Option<RuntimeOverride>,
@@ -261,8 +267,10 @@ pub(crate) enum Commands {
         /// Coverage-guided fuzz probe engine (v2.18). Drives a generated
         /// Crucible harness for the given budget and converts each crash
         /// into a Finding with `Reproducer::Crucible`. Different engine
-        /// from the pattern-match predicates above — both can run; both
-        /// emit into the same `findings[]`.
+        /// from the pattern-match predicates above — a `--fuzz` run
+        /// REPLACES the predicate pass in a single invocation. To get
+        /// both, run `probe --spec` and `probe --fuzz --spec` separately
+        /// and merge the JSON.
         ///
         /// Pair with either `--spec <path>` (spec-driven harness,
         /// asserts spec invariants) or `--root <project-path>` (v2.21

--- a/crates/qedgen/src/probe/mod.rs
+++ b/crates/qedgen/src/probe/mod.rs
@@ -516,6 +516,27 @@ pub struct ProbeOutput {
     pub dispatcher_kind: Option<String>,
 }
 
+impl ProbeOutput {
+    /// Canonical empty envelope at the current schema version. Every
+    /// construction site must start here (struct-update syntax) rather
+    /// than spelling `version:` out — fuzz-mode outputs shipped
+    /// `version: 1` against the v2 schema before this seam existed.
+    pub fn envelope(mode: Mode) -> Self {
+        ProbeOutput {
+            version: SCHEMA_VERSION,
+            mode,
+            spec_path: None,
+            project_root: None,
+            runtime: None,
+            handlers: None,
+            applicable_categories: None,
+            findings: Vec::new(),
+            clusters: None,
+            dispatcher_kind: None,
+        }
+    }
+}
+
 pub fn run_probe(spec_path: &Path) -> Result<ProbeOutput> {
     let spec = parse_spec_file(spec_path)?;
     let spec_models_lifecycle = !spec.lifecycle_states.is_empty()
@@ -558,16 +579,9 @@ pub fn run_probe(spec_path: &Path) -> Result<ProbeOutput> {
     );
 
     Ok(ProbeOutput {
-        version: SCHEMA_VERSION,
-        mode: Mode::SpecAware,
         spec_path: Some(spec_path.display().to_string()),
-        project_root: None,
-        runtime: None,
-        handlers: None,
-        applicable_categories: None,
         findings,
-        clusters: None,
-        dispatcher_kind: None,
+        ..ProbeOutput::envelope(Mode::SpecAware)
     })
 }
 
@@ -630,16 +644,12 @@ pub fn run_bootstrap(project_root: &Path) -> Result<ProbeOutput> {
     let applicable = applicable_categories(&runtime);
 
     Ok(ProbeOutput {
-        version: SCHEMA_VERSION,
-        mode: Mode::SpecLess,
-        spec_path: None,
         project_root: Some(project_root.display().to_string()),
         runtime: Some(runtime),
         handlers: Some(handlers),
         applicable_categories: Some(applicable),
-        findings: Vec::new(),
-        clusters: None,
         dispatcher_kind,
+        ..ProbeOutput::envelope(Mode::SpecLess)
     })
 }
 
@@ -651,12 +661,6 @@ pub fn detect_runtime_public(root: &Path) -> Runtime {
 /// Public wrapper for the main.rs dispatcher.
 pub fn applicable_categories_public(runtime: &Runtime) -> Vec<String> {
     applicable_categories(runtime)
-}
-
-/// Exposed so the Pinocchio dispatcher emits envelopes with the canonical
-/// version rather than hard-coding a duplicate.
-pub fn schema_version() -> u32 {
-    SCHEMA_VERSION
 }
 
 /// Runtime detection by filesystem heuristics. Order matters: a project

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -382,18 +382,14 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     )?;
                 }
                 let output = probe::ProbeOutput {
-                    version: probe::schema_version(),
-                    mode: probe::Mode::SpecLess,
-                    spec_path: None,
                     project_root: Some(prog_root.display().to_string()),
                     runtime: Some(probe::Runtime::Pinocchio),
-                    handlers: None,
                     applicable_categories: Some(probe::applicable_categories_public(
                         &probe::Runtime::Pinocchio,
                     )),
                     findings,
                     clusters,
-                    dispatcher_kind: None,
+                    ..probe::ProbeOutput::envelope(probe::Mode::SpecLess)
                 };
                 // Include the raw catalogue so the subagent has both
                 // `findings[]` and the full site list to cross-reference.
@@ -629,24 +625,18 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                         Ok::<_, anyhow::Error>(report)
                     })
                     .transpose()?;
+                let probe_mode = if matches!(mode, crucible_gen::InvariantMode::Protocol) {
+                    probe::Mode::SpecLess
+                } else {
+                    probe::Mode::SpecAware
+                };
                 // Budget 0 = emit the harness and exit (dry-run preview
                 // without the Crucible build cost).
                 if budget_secs == 0 {
                     let output = probe::ProbeOutput {
-                        version: 1,
-                        mode: if matches!(mode, crucible_gen::InvariantMode::Protocol) {
-                            probe::Mode::SpecLess
-                        } else {
-                            probe::Mode::SpecAware
-                        },
                         spec_path: spec.as_ref().map(|p| p.display().to_string()),
                         project_root: root.as_ref().map(|p| p.display().to_string()),
-                        runtime: None,
-                        handlers: None,
-                        applicable_categories: None,
-                        findings: Vec::new(),
-                        clusters: None,
-                        dispatcher_kind: None,
+                        ..probe::ProbeOutput::envelope(probe_mode)
                     };
                     eprintln!(
                         "Budget = 0: harness ready at {}; skipping build + fuzz run.",
@@ -671,20 +661,10 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 }
                 let findings = crucible_probe::run_fuzz_probe(&ctx)?;
                 let output = probe::ProbeOutput {
-                    version: 1,
-                    mode: if matches!(mode, crucible_gen::InvariantMode::Protocol) {
-                        probe::Mode::SpecLess
-                    } else {
-                        probe::Mode::SpecAware
-                    },
                     spec_path: spec.as_ref().map(|p| p.display().to_string()),
                     project_root: root.as_ref().map(|p| p.display().to_string()),
-                    runtime: None,
-                    handlers: None,
-                    applicable_categories: None,
                     findings,
-                    clusters: None,
-                    dispatcher_kind: None,
+                    ..probe::ProbeOutput::envelope(probe_mode)
                 };
                 println!("{}", serde_json::to_string_pretty(&output)?);
                 return Ok(());

--- a/crates/qedgen/src/run_helpers.rs
+++ b/crates/qedgen/src/run_helpers.rs
@@ -818,16 +818,13 @@ pub(crate) fn run_anchor_probe(
     }
 
     let output = probe::ProbeOutput {
-        version: probe::schema_version(),
-        mode: probe::Mode::SpecLess,
-        spec_path: None,
         project_root: Some(prog_root.display().to_string()),
         runtime: Some(runtime_final),
         handlers: handlers_opt,
         applicable_categories: Some(applicable),
         findings: runtime_agnostic_findings(prog_root)?,
         clusters,
-        dispatcher_kind: None,
+        ..probe::ProbeOutput::envelope(probe::Mode::SpecLess)
     };
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
@@ -894,9 +891,6 @@ pub(crate) fn run_native_probe(
     };
 
     let output = probe::ProbeOutput {
-        version: probe::schema_version(),
-        mode: probe::Mode::SpecLess,
-        spec_path: None,
         project_root: Some(prog_root.display().to_string()),
         runtime: Some(runtime_final),
         handlers,
@@ -904,6 +898,7 @@ pub(crate) fn run_native_probe(
         findings: runtime_agnostic_findings(prog_root)?,
         clusters,
         dispatcher_kind,
+        ..probe::ProbeOutput::envelope(probe::Mode::SpecLess)
     };
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())

--- a/crates/qedgen/tests/probe_cli.rs
+++ b/crates/qedgen/tests/probe_cli.rs
@@ -1,0 +1,109 @@
+//! CLI-surface tests for `qedgen probe` mode combinations (#225 Phase 0).
+//!
+//! Two invariants pinned here:
+//! 1. Invalid / ambiguous flag combinations fail loudly through clap —
+//!    no engine is ever silently skipped (`--program` used to win over
+//!    `--fuzz` by dispatch order, dropping the requested fuzz run).
+//! 2. Every probe envelope carries the same canonical schema version,
+//!    whichever engine produced it (fuzz-mode outputs shipped a
+//!    hardcoded `version: 1` against the v2 schema).
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn qedgen(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_qedgen"))
+        .args(args)
+        .output()
+        .expect("spawn qedgen")
+}
+
+fn fixture(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(rel)
+}
+
+/// `--program` + `--fuzz` used to silently skip the fuzz engine
+/// (`--program` dispatches first and returns). Now a clap conflict.
+#[test]
+fn probe_program_plus_fuzz_is_rejected() {
+    let out = qedgen(&["probe", "--program", "some/dir", "--fuzz", "60"]);
+    assert!(!out.status.success(), "conflicting flags must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--fuzz") && stderr.contains("cannot be used with"),
+        "expected clap conflict naming --fuzz, got:\n{stderr}"
+    );
+}
+
+/// `--program` ignores `--root`; reject the pair instead of dropping it.
+#[test]
+fn probe_program_plus_root_is_rejected() {
+    let out = qedgen(&["probe", "--program", "some/dir", "--root", "other/dir"]);
+    assert!(!out.status.success(), "conflicting flags must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected clap conflict, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn probe_program_plus_spec_is_rejected() {
+    let out = qedgen(&["probe", "--program", "some/dir", "--spec", "x.qedspec"]);
+    assert!(!out.status.success(), "conflicting flags must fail");
+}
+
+/// `--fuzz` without a target has a dedicated (non-clap) error that names
+/// both valid pairings.
+#[test]
+fn probe_fuzz_without_spec_or_root_names_both_options() {
+    let out = qedgen(&["probe", "--fuzz", "60"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--spec") && stderr.contains("--root"),
+        "error must name both valid pairings, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn probe_bootstrap_requires_root() {
+    let out = qedgen(&["probe", "--bootstrap"]);
+    assert!(!out.status.success());
+}
+
+/// Acceptance criterion (#225): fuzz and non-fuzz outputs use the same
+/// canonical schema version. Budget-0 exercises the fuzz-mode envelope
+/// without paying the Crucible build cost.
+#[test]
+fn fuzz_and_spec_probe_agree_on_schema_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = tmp.path().join("counter.qedspec");
+    std::fs::copy(fixture("descriptor/counter.qedspec"), &spec).unwrap();
+    let spec_str = spec.to_str().unwrap();
+
+    let spec_out = qedgen(&["probe", "--spec", spec_str]);
+    assert!(
+        spec_out.status.success(),
+        "spec-aware probe failed:\n{}",
+        String::from_utf8_lossy(&spec_out.stderr)
+    );
+    let fuzz_out = qedgen(&["probe", "--fuzz", "0", "--spec", spec_str]);
+    assert!(
+        fuzz_out.status.success(),
+        "budget-0 fuzz probe failed:\n{}",
+        String::from_utf8_lossy(&fuzz_out.stderr)
+    );
+
+    let spec_json: serde_json::Value = serde_json::from_slice(&spec_out.stdout).unwrap();
+    let fuzz_json: serde_json::Value = serde_json::from_slice(&fuzz_out.stdout).unwrap();
+    assert_eq!(
+        spec_json["version"], fuzz_json["version"],
+        "fuzz-mode envelope drifted from the canonical probe schema version"
+    );
+    // Pin the canonical value so both paths can't drift in lockstep by
+    // accident; bump alongside probe::SCHEMA_VERSION on a conscious change.
+    assert_eq!(spec_json["version"], serde_json::json!(2));
+}

--- a/references/cli.md
+++ b/references/cli.md
@@ -361,10 +361,10 @@ spec-less emits `runtime`, `handlers`, `applicable_categories`.
 v2.16 schema bumps to `version: 2` with the addition of an optional
 `reproducer` field on findings (drop-on-fail pipeline; findings
 without a confirmed reproducer are silently dropped — see
-`feedback_probes_reproducible_only.md`). v2.19 schema bumps to
-`version: 3` when `--emit-spec-candidates` is set, adding a
-`clusters[]` array that the auditor subagent surfaces through the
-scaffold-to-spec interview. v2.20 extends the bootstrap envelope
+`feedback_probes_reproducible_only.md`). v2.19 adds an optional
+`clusters[]` array under `--emit-spec-candidates` (additive — the
+schema stays `version: 2`) that the auditor subagent surfaces
+through the scaffold-to-spec interview. v2.20 extends the bootstrap envelope
 with `dispatcher_kind: "shank_central_match"` for native programs
 where `qedgen probe --bootstrap` detects a central-match dispatcher
 in `lib.rs` (S2.1 Shank adapter), and each `handlers[]` entry now
@@ -429,11 +429,11 @@ $QEDGEN probe --fuzz 300 --crucible-mode domain \
 | `--spec` | Path | optional | Path to `.qedspec` (spec-aware mode) — conflicts with `--bootstrap` and `--program` |
 | `--bootstrap` | bool | false | Spec-less mode — walk a project root and emit the auditor work list. Requires `--root`. |
 | `--root` | Path | optional | Project root for spec-less mode (the program crate dir). v2.21 also paired with `--fuzz` (no `--spec`) for brownfield protocol-mode Crucible — emits a harness at `<root>/.qed/fuzz/<prog>/` whose `invariant_test()` body is empty so only intrinsic crashes (panic / unwrap-on-None / `BorrowMutError` / arithmetic overflow) fire. v2.22 lifts the runtime gate for Pinocchio when a Codama / Anchor 0.30 IDL is on disk (canonical paths: `idl.json`, `program/idl.json`, `idl/*.json`, `target/idl/*.json`); native + sBPF still bail with a deferral message targeting v2.24+ (v2.23 shipped the pre/post property lowering trust fix + brownfield first-contact onboarding flow instead of touching this gate). |
-| `--program` | Path | optional | v2.19 user-facing alias for `--bootstrap --root <path>` (the Pinocchio-shape probe entry point; auto-routes via `Cargo.toml` detection so the same flag works for Anchor / native crates too, falling back to the generic spec-less envelope when not Pinocchio) |
-| `--runtime` | enum | auto | Override runtime detection. Values: `pinocchio`, `anchor`, `quasar`, `native`, `sbpf`. Only `pinocchio` has dedicated probe output today; the others fall back to the generic bootstrap envelope. |
+| `--program` | Path | optional | Program audit mode entry point. Auto-routes via `Cargo.toml` detection to the runtime's dedicated extractor: Pinocchio → site catalogue + SAFETY metadata (v2.19), Anchor/Quasar → anchor extractor (scaffold-to-spec interview), native/qedgen-codegen → native extractor; runtimes without an extractor fall back to the generic bootstrap envelope. Static engine only: conflicts with `--spec`, `--bootstrap`, `--root`, and `--fuzz` (fuzz brownfield targets via `--fuzz <budget> --root <path>`; merge the two JSON outputs to combine engines). |
+| `--runtime` | enum | auto | Override runtime detection. Values: `pinocchio`, `anchor`, `quasar`, `native`, `sbpf`. Pinocchio, Anchor/Quasar, and native each have a dedicated extractor under `--program`; runtimes without one (e.g. `sbpf`) fall back to the generic bootstrap envelope. |
 | `--emit-spec-candidates` | bool | false | v2.19 — lift findings into candidate spec clauses (clusters) the auditor subagent surfaces through the scaffold-to-spec interview. Schema bumps to v3 with a `clusters[]` field. v2-shape consumers see no change when the flag is off. |
 | `--audit-dir` | Path | optional | v2.19 — when paired with `--emit-spec-candidates`, write the full audit working set (`interview.md`, `clusters.json`, `skeleton.qedspec`) to this directory. Companion `qedgen ratify --audit-dir <path>` consumes the three files to produce the final spec. Conventionally `.qed/audit/<timestamp>/`. |
-| `--fuzz` | u64 | none | Wall-clock seconds. Runs the coverage-guided fuzz engine alongside (or instead of) the pattern-match predicates. v2.21+: requires `--spec <path>` (spec-driven invariants) OR `--root <project-path>` (brownfield protocol-mode); passing both layers spec invariants on top of protocol crash detection. Findings come back in the same `findings[]` with `category: crucible_fuzz_crash` and a `Reproducer::Crucible`. Budget `0` emits the harness scaffold (brownfield only) and exits without building / running the fuzzer — handy for previewing what the agent needs to fill before paying the Crucible build cost. |
+| `--fuzz` | u64 | none | Wall-clock seconds. Runs the coverage-guided fuzz engine INSTEAD of the pattern-match predicates for that invocation (run `probe --spec` separately and merge the JSON to combine engines). v2.21+: requires `--spec <path>` (spec-driven invariants) OR `--root <project-path>` (brownfield protocol-mode); passing both layers spec invariants on top of protocol crash detection. Findings come back in the same `findings[]` with `category: crucible_fuzz_crash` and a `Reproducer::Crucible`. Budget `0` emits the harness scaffold (brownfield only) and exits without building / running the fuzzer — handy for previewing what the agent needs to fill before paying the Crucible build cost. |
 | `--harness-dir` | Path | `./fuzz/<prog>/` | Crucible harness directory. Matches `codegen --crucible` output. An existing harness is reused, never regenerated (agent-filled `todo!()` account literals survive re-runs); delete it to pick up spec or binding changes. When the directory leaf differs from the program name it is treated as a parent and the `<prog>` leaf is appended. |
 | `--no-smoke` | bool | false | Skip the 30s smoke pre-flight that stops early on high-rate duplicate findings. |
 | `--stateful` | bool | false | Stateful action-chain mode. Higher throughput, longer crash chains. |


### PR DESCRIPTION
Part of #225 (Phase 0 of the split). Pure correctness + CLI-surface cleanup; no schema or behavior redesign.

## What

- **Single construction seam for `ProbeOutput`**: new `ProbeOutput::envelope(mode)` carries `version: SCHEMA_VERSION`; every emit site (`run.rs` ×3, `run_helpers.rs` ×2, `probe/mod.rs` ×2) builds via struct-update from it. Fixes the fuzz-mode envelopes that shipped `version: 1` against the v2 schema (`run.rs` budget-0 + post-fuzz sites). The now-redundant `probe::schema_version()` is removed.
- **No silent engine skips**: `--program` dispatches before `--fuzz`, so combining them silently dropped the requested fuzz run; same for `--root`. Both are now clap conflicts (`conflicts_with_all = ["spec", "bootstrap", "fuzz", "root"]`).
- **Help-text de-staling**: `--program` documents the Anchor/Quasar and native extractor routes (was described as Pinocchio-only); `--runtime` likewise; `--fuzz` now says a fuzz run *replaces* the predicate pass for that invocation instead of implying an in-process merge; `references/cli.md` drops the incorrect claim that `--emit-spec-candidates` bumps the schema to v3 (clusters are additive under v2 — no v3 exists in code).

## Tests

New `crates/qedgen/tests/probe_cli.rs` (6 tests):
- conflict matrix: `--program` × `--fuzz` / `--root` / `--spec`, `--bootstrap` without `--root`, `--fuzz` with neither `--spec` nor `--root`
- schema agreement: `probe --spec` and `probe --fuzz 0 --spec` emit the same `version`, pinned to the canonical `2`

Full `cargo test` green; clippy clean; `check-readme-drift.sh` clean.

## Acceptance criteria from #225 closed here

- [x] Fuzz and non-fuzz outputs use the same canonical schema version.
- [x] Invalid/ambiguous flag combinations fail clearly; no requested engine is silently skipped.
- [x] Schema and CLI behavior have integration tests (for the Phase 0 surface).