### PR TITLE
#227 probe evidence model: candidates[] / engine_runs[] / coverage / outcome (schema v3)

### DIFF
--- a/crates/qedgen/src/probe/mod.rs
+++ b/crates/qedgen/src/probe/mod.rs
@@ -41,12 +41,22 @@ pub(crate) mod spec_predicates;
 use spec_predicates::*;
 
 /// Probe output schema version. Bump on incompatible finding-shape changes;
-/// the auditor pins against this. v2: spec-aware findings carry a
-/// `reproducer` (drop-on-fail pipeline) — the field is typed `Option` as a
-/// transitional shim, but candidates without a constructible reproducer are
-/// dropped, so every emitted finding has one. Spec-less / `--bootstrap`
-/// never emits findings.
-const SCHEMA_VERSION: u32 = 2;
+/// the auditor pins against this.
+///
+/// - v2: spec-aware findings carry a `reproducer` (drop-on-fail pipeline).
+/// - v3 (#227): the evidence model. Every predicate hit that can't (yet)
+///   acquire a reproducer is preserved in `candidates[]` instead of being
+///   silently dropped; `engine_runs[]` records per-engine status (including
+///   candidate-drop counts and skipped files); `coverage` reports what was
+///   discovered/exercised; and `outcome` distinguishes a real pass from a
+///   low-coverage empty result or a budget-zero dry run. `findings[]` keeps
+///   its v2 reproducer-only contract unchanged.
+///
+/// Additive for a v2 reader that ignores unknown fields: `findings[]` still
+/// means the same thing. A v2 reader that treated "empty findings" as
+/// "clean", however, MUST now also consult `candidates[]` and `outcome` —
+/// see `docs/design/probe-schema-v3-migration.md`.
+const SCHEMA_VERSION: u32 = 3;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -483,6 +493,130 @@ pub struct Finding {
     pub gated_by: Option<Vec<String>>,
 }
 
+/// A predicate hit or static pattern that warrants investigation but is
+/// NOT a demonstrated vulnerability. The evidence tier below `findings[]`:
+/// deliberately carries **no severity and no reproducer** so it can never
+/// be mistaken for a confirmed finding (the "no advisory tier" rule applies
+/// to `findings[]`, and candidates stay clearly on the other side of that
+/// line). The auditor surfaces these as a work list, not as results.
+#[derive(Debug, Clone, Serialize)]
+pub struct Candidate {
+    pub category: Category,
+    pub category_tag: String,
+    pub handler: String,
+    /// What the spec is silent on (human-readable) — same text a finding
+    /// would carry, minus any claim of exploitability.
+    pub spec_silent_on: String,
+    /// Minimal spec edit that would close it, if it is a real gap.
+    pub suppression_hint: String,
+    /// Where/how to investigate the impl to confirm or dismiss.
+    pub investigation_hint: String,
+    /// Why this predicate hit is a candidate rather than a finding — almost
+    /// always "no constructible reproducer yet" (the constructor for this
+    /// category is not implemented). Distinguishes "we can't prove it" from
+    /// "we proved it safe".
+    pub reason: String,
+}
+
+/// Per-engine execution record. `findings[]`/`candidates[]` say *what* was
+/// found; this says *whether the engine that would find it actually ran to
+/// completion* — the difference between "no bugs" and "the scanner skipped
+/// half the files".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // `failed`/`skipped` are constructed by #228/#229 engines
+pub enum EngineStatus {
+    /// Ran to completion over all inputs.
+    Passed,
+    /// Ran, but skipped some inputs (unreadable/unparseable files, dropped
+    /// candidates) — results are incomplete.
+    Partial,
+    /// Could not run because a precondition was unmet (e.g. budget-zero
+    /// harness dry run, missing IDL) — not a failure, but no coverage.
+    Blocked,
+    /// Attempted and errored (build failure, crash) — coverage unknown.
+    Failed,
+    /// Not requested this invocation.
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EngineRun {
+    /// Stable engine id: `spec_predicates`, `crucible_fuzz`,
+    /// `arithmetic_symbol`, `paired_validator`, `lifecycle`,
+    /// `pinocchio_sites`, …
+    pub engine: String,
+    pub status: EngineStatus,
+    /// One-line human explanation of a non-`passed` status.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// Predicate hits this engine produced that were demoted to candidates
+    /// (or dropped) for want of a reproducer. `0` for engines that don't
+    /// run the reproducer pipeline.
+    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default)]
+    pub candidates_dropped: u32,
+    /// Source files the engine could not read or parse, relative to the
+    /// project root. Empty unless `status == partial`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub skipped_files: Vec<String>,
+}
+
+fn is_zero(n: &u32) -> bool {
+    *n == 0
+}
+
+/// What the probe actually discovered, generated, executed, and asserted —
+/// so a zero-finding result is interpretable. All counts are best-effort
+/// and engine-dependent; `None` fields mean "this engine doesn't measure
+/// that", not "zero".
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ProbeCoverage {
+    /// Handlers the probe saw (spec handlers, or discovered brownfield
+    /// handlers).
+    pub handlers_discovered: u32,
+    /// Fuzz actions generated from those handlers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions_generated: Option<u32>,
+    /// Generated actions still carrying an agent-fill `todo!()` (cannot be
+    /// exercised until filled).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions_stubbed: Option<u32>,
+    /// Spec invariants actually evaluated by the fuzz harness.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invariants_evaluated: Option<u32>,
+    /// Fuzz corpus size after the run (seeds on disk).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub corpus_size: Option<u32>,
+    /// Deepest stateful action sequence reached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_sequence_depth: Option<u32>,
+    /// Whether minimized crashes replayed successfully (Crucible triage).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_success: Option<bool>,
+}
+
+/// Top-level interpretation of the run. Lets a consumer branch on outcome
+/// instead of guessing from an empty `findings[]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // `blocked_incomplete_harness`/`engine_failed` land with #228/#229
+pub enum ProbeOutcome {
+    /// Engines ran to completion; findings/candidates reflect real coverage.
+    PassedWithCoverage,
+    /// Engines ran but exercised little — an empty result here is weak
+    /// evidence, not a clean bill of health.
+    NoFindingsLowCoverage,
+    /// A harness was required but is incomplete (stubbed actions,
+    /// budget-zero emit) — the probe did not really run.
+    BlockedIncompleteHarness,
+    /// An engine errored; results are unreliable.
+    EngineFailed,
+    /// Harness was emitted for preview only (budget 0) — nothing executed.
+    DryRun,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ProbeOutput {
     pub version: u32,
@@ -503,11 +637,28 @@ pub struct ProbeOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub applicable_categories: Option<Vec<String>>,
     /// Findings (spec-aware mode only — spec-less is investigation-by-auditor).
+    /// v2 reproducer-only contract unchanged: every entry has a reproducer.
     pub findings: Vec<Finding>,
+    /// v3 (#227): predicate hits preserved as investigation candidates when
+    /// no reproducer could be constructed — ends the silent drop. Always
+    /// present (may be empty); a v2 consumer ignores it.
+    #[serde(default)]
+    pub candidates: Vec<Candidate>,
+    /// v3 (#227): per-engine execution status, so an empty `findings[]` can
+    /// be told apart from an engine that skipped files or didn't run.
+    #[serde(default)]
+    pub engine_runs: Vec<EngineRun>,
+    /// v3 (#227): what the run discovered/exercised/asserted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<ProbeCoverage>,
+    /// v3 (#227): top-level interpretation — a consumer branches on this
+    /// instead of guessing from `findings.is_empty()`.
+    pub outcome: ProbeOutcome,
     /// Candidate spec clauses derived from findings + runtime signals.
     /// Populated only under `--emit-spec-candidates` (additive — older
     /// consumers ignore it). The auditor reads these to drive the
-    /// scaffold-to-spec interview.
+    /// scaffold-to-spec interview. (Distinct from `candidates[]`: these are
+    /// clustered proto-spec-clauses, not investigation candidates.)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clusters: Option<Vec<crate::cluster::Cluster>>,
     /// Structural shape of the native dispatcher when detected. Only
@@ -531,8 +682,31 @@ impl ProbeOutput {
             handlers: None,
             applicable_categories: None,
             findings: Vec::new(),
+            candidates: Vec::new(),
+            engine_runs: Vec::new(),
+            coverage: None,
+            // Overwritten by every real construction site; the neutral
+            // default suits a bare/empty envelope (bootstrap work list).
+            outcome: ProbeOutcome::PassedWithCoverage,
             clusters: None,
             dispatcher_kind: None,
+        }
+    }
+}
+
+impl Candidate {
+    /// Demote a predicate `Finding` whose reproducer couldn't be built into
+    /// an investigation candidate. Drops severity + reproducer + gate info —
+    /// a candidate makes no exploitability claim.
+    pub fn from_dropped_finding(f: Finding, reason: impl Into<String>) -> Self {
+        Candidate {
+            category: f.category,
+            category_tag: f.category_tag,
+            handler: f.handler,
+            spec_silent_on: f.spec_silent_on,
+            suppression_hint: f.suppression_hint,
+            investigation_hint: f.investigation_hint,
+            reason: reason.into(),
         }
     }
 }
@@ -565,22 +739,59 @@ pub fn run_probe(spec_path: &Path) -> Result<ProbeOutput> {
     }
     findings.extend(predicate_stored_field_never_written(&spec));
 
-    // Drop-on-fail: every candidate must acquire a concrete reproducer
-    // or be silently dropped. No advisory tier.
+    // v3 (#227): a predicate hit either acquires a concrete reproducer and
+    // becomes a `finding`, or is preserved as an investigation `candidate`.
+    // The old pipeline dropped the latter silently, making a spec with live
+    // predicate hits indistinguishable from a clean one.
     let ctx = crate::probe_repro::ReproducerContext::from_spec_path(&spec, spec_path);
-    findings.retain_mut(
-        |finding| match crate::probe_repro::construct_reproducer(finding, &ctx) {
+    let mut kept: Vec<Finding> = Vec::new();
+    let mut candidates: Vec<Candidate> = Vec::new();
+    for mut finding in findings {
+        match crate::probe_repro::construct_reproducer(&finding, &ctx) {
             Ok(repro) => {
                 finding.reproducer = Some(repro);
-                true
+                kept.push(finding);
             }
-            Err(_) => false,
-        },
-    );
+            Err(reason) => {
+                candidates.push(Candidate::from_dropped_finding(
+                    finding,
+                    crate::probe_repro::describe_failure(&reason),
+                ));
+            }
+        }
+    }
+
+    let coverage = ProbeCoverage {
+        handlers_discovered: spec.handlers.len() as u32,
+        ..ProbeCoverage::default()
+    };
+    // The predicate engine ran to completion over every handler — `passed`
+    // even when all hits demoted to candidates (that's an honest scan, not
+    // an incomplete one). The demotions are recorded, not hidden.
+    let engine_runs = vec![EngineRun {
+        engine: "spec_predicates".to_string(),
+        status: EngineStatus::Passed,
+        detail: (!candidates.is_empty()).then(|| {
+            format!(
+                "{} predicate hit(s) preserved as candidates (no reproducer constructor yet)",
+                candidates.len()
+            )
+        }),
+        candidates_dropped: candidates.len() as u32,
+        skipped_files: Vec::new(),
+    }];
 
     Ok(ProbeOutput {
         spec_path: Some(spec_path.display().to_string()),
-        findings,
+        findings: kept,
+        candidates,
+        engine_runs,
+        coverage: Some(coverage),
+        // The predicate engine visits every handler, so its coverage is
+        // always complete — a clean result here is a real (predicate-scoped)
+        // pass, and live candidates are surfaced explicitly rather than
+        // hidden behind an empty `findings[]`.
+        outcome: ProbeOutcome::PassedWithCoverage,
         ..ProbeOutput::envelope(Mode::SpecAware)
     })
 }

--- a/crates/qedgen/src/probe/probe_repro.rs
+++ b/crates/qedgen/src/probe/probe_repro.rs
@@ -1,18 +1,20 @@
 //! `qedgen probe` reproducer construction pipeline.
 //!
 //! Every emitted `Finding` must carry a concrete `Reproducer` (Kani trace,
-//! proptest seed, or sandbox tx); candidates whose reproducer can't be
-//! constructed are **silently dropped** — no advisory tier. A finding
-//! without a reproducer is auditor-grade noise and can't defend against
-//! "we don't think that's reachable"; silent is more honest than
-//! "possibly vulnerable." Artifacts live under
-//! `target/qedgen-repros/<finding.id>/` — ephemeral, never committed.
+//! proptest seed, or sandbox tx) — the reproducer-only contract on
+//! `findings[]` still holds. What changed in v3 (#227): a predicate hit
+//! whose reproducer can't be constructed is no longer *silently dropped* —
+//! `run_probe` demotes it to an investigation `Candidate` (carrying
+//! [`describe_failure`]'s reason), so a spec with live predicate hits is
+//! never indistinguishable from a clean one. Candidates make no
+//! exploitability claim, so the "no advisory tier" rule on `findings[]` is
+//! preserved. Artifacts live under `target/qedgen-repros/<finding.id>/` —
+//! ephemeral, never committed.
 //!
-//! All constructors are currently stubs (`NotImplemented`), so every probe
-//! finding is dropped — correct under the reproducible-only contract. v3
-//! replaces them with agent-authored repros via structured prompts; today
-//! the auditor SKILL writes Mollusk repros directly, bypassing this
-//! dispatcher.
+//! All constructors are currently stubs (`NotImplemented`), so today every
+//! predicate hit surfaces as a candidate. The reproducer vertical slice
+//! (#228) lands real constructors category by category; the auditor SKILL
+//! writes Mollusk repros directly in the meantime.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -48,6 +50,28 @@ pub enum ConstructFailure {
     /// I/O writing artifacts — drop rather than emit half-written
     /// artifacts.
     Io(String),
+}
+
+/// Human-readable `reason` for a candidate demoted from a finding — the
+/// text that travels in `Candidate.reason` so a consumer can tell "no
+/// constructor yet" from "Kani found nothing" from "the build broke".
+pub fn describe_failure(failure: &ConstructFailure) -> String {
+    match failure {
+        ConstructFailure::NotImplemented => {
+            "no reproducer constructor implemented for this category yet".to_string()
+        }
+        ConstructFailure::KaniTimeout { budget } => {
+            format!("Kani exhausted its {}s budget without a counterexample", budget.as_secs())
+        }
+        ConstructFailure::KaniNoCounterexample => {
+            "Kani found no counterexample within its search depth".to_string()
+        }
+        ConstructFailure::ProptestNoFailure => {
+            "no proptest seed reproduced the predicate".to_string()
+        }
+        ConstructFailure::BuildError(e) => format!("reproducer build failed: {e}"),
+        ConstructFailure::Io(e) => format!("reproducer I/O error: {e}"),
+    }
 }
 
 /// Inputs every category constructor needs. Paths are absolute.
@@ -231,11 +255,13 @@ mod tests {
         }
     }
 
-    /// Pins the contract: every constructor returns `NotImplemented`, so
-    /// the probe emits zero findings. Update when a category gains a real
-    /// constructor.
+    /// Categories whose constructors are still stubbed report
+    /// `NotImplemented` — the caller demotes them to candidates rather than
+    /// dropping them. As #228 lands real constructors, entries move OUT of
+    /// this list (and gain their own positive/negative tests); the list
+    /// shrinking is the retrofit's progress bar.
     #[test]
-    fn all_constructors_stub_during_retrofit() {
+    fn stubbed_constructors_report_not_implemented() {
         let categories = [
             (Category::MissingSigner, "missing_signer"),
             (Category::ArbitraryCpi, "arbitrary_cpi"),
@@ -271,6 +297,22 @@ mod tests {
                 result
             );
         }
+    }
+
+    /// `describe_failure` renders a distinct, human reason per variant so a
+    /// candidate's `reason` tells "not built yet" apart from "proved
+    /// nothing" apart from "build broke".
+    #[test]
+    fn describe_failure_is_distinct_per_variant() {
+        let reasons = [
+            describe_failure(&ConstructFailure::NotImplemented),
+            describe_failure(&ConstructFailure::KaniNoCounterexample),
+            describe_failure(&ConstructFailure::ProptestNoFailure),
+            describe_failure(&ConstructFailure::BuildError("boom".into())),
+        ];
+        let unique: std::collections::HashSet<_> = reasons.iter().collect();
+        assert_eq!(unique.len(), reasons.len(), "reasons must be distinguishable");
+        assert!(reasons[3].contains("boom"), "build error must carry detail");
     }
 
     #[test]

--- a/crates/qedgen/src/probe/probe_repro.rs
+++ b/crates/qedgen/src/probe/probe_repro.rs
@@ -61,7 +61,10 @@ pub fn describe_failure(failure: &ConstructFailure) -> String {
             "no reproducer constructor implemented for this category yet".to_string()
         }
         ConstructFailure::KaniTimeout { budget } => {
-            format!("Kani exhausted its {}s budget without a counterexample", budget.as_secs())
+            format!(
+                "Kani exhausted its {}s budget without a counterexample",
+                budget.as_secs()
+            )
         }
         ConstructFailure::KaniNoCounterexample => {
             "Kani found no counterexample within its search depth".to_string()
@@ -311,7 +314,11 @@ mod tests {
             describe_failure(&ConstructFailure::BuildError("boom".into())),
         ];
         let unique: std::collections::HashSet<_> = reasons.iter().collect();
-        assert_eq!(unique.len(), reasons.len(), "reasons must be distinguishable");
+        assert_eq!(
+            unique.len(),
+            reasons.len(),
+            "reasons must be distinguishable"
+        );
         assert!(reasons[3].contains("boom"), "build error must carry detail");
     }
 

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -381,6 +381,8 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                         /*lenient_skeleton=*/ false,
                     )?;
                 }
+                let engine_run = run_helpers::source_scan_engine_run(prog_root);
+                let outcome = run_helpers::source_scan_outcome(&engine_run);
                 let output = probe::ProbeOutput {
                     project_root: Some(prog_root.display().to_string()),
                     runtime: Some(probe::Runtime::Pinocchio),
@@ -388,6 +390,8 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                         &probe::Runtime::Pinocchio,
                     )),
                     findings,
+                    engine_runs: vec![engine_run],
+                    outcome,
                     clusters,
                     ..probe::ProbeOutput::envelope(probe::Mode::SpecLess)
                 };
@@ -631,11 +635,25 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     probe::Mode::SpecAware
                 };
                 // Budget 0 = emit the harness and exit (dry-run preview
-                // without the Crucible build cost).
+                // without the Crucible build cost). v3 (#227): this is a
+                // DRY RUN, not a successful probe — the outcome + a blocked
+                // engine run say so explicitly, so an empty `findings[]`
+                // here can't be read as "clean".
                 if budget_secs == 0 {
                     let output = probe::ProbeOutput {
                         spec_path: spec.as_ref().map(|p| p.display().to_string()),
                         project_root: root.as_ref().map(|p| p.display().to_string()),
+                        engine_runs: vec![probe::EngineRun {
+                            engine: "crucible_fuzz".to_string(),
+                            status: probe::EngineStatus::Blocked,
+                            detail: Some(format!(
+                                "budget 0: harness emitted at {} for preview; not built or run",
+                                harness.display()
+                            )),
+                            candidates_dropped: 0,
+                            skipped_files: Vec::new(),
+                        }],
+                        outcome: probe::ProbeOutcome::DryRun,
                         ..probe::ProbeOutput::envelope(probe_mode)
                     };
                     eprintln!(
@@ -660,10 +678,28 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     ctx.domain_seed_report = Some(report);
                 }
                 let findings = crucible_probe::run_fuzz_probe(&ctx)?;
+                // A completed fuzz run that found nothing is `passed` (it
+                // executed) but low-coverage evidence — distinct from a
+                // finding-bearing run. Fine-grained coverage counts arrive
+                // with #229's replay work; the outcome split is the #227
+                // deliverable.
+                let fuzz_outcome = if findings.is_empty() {
+                    probe::ProbeOutcome::NoFindingsLowCoverage
+                } else {
+                    probe::ProbeOutcome::PassedWithCoverage
+                };
                 let output = probe::ProbeOutput {
                     spec_path: spec.as_ref().map(|p| p.display().to_string()),
                     project_root: root.as_ref().map(|p| p.display().to_string()),
+                    engine_runs: vec![probe::EngineRun {
+                        engine: "crucible_fuzz".to_string(),
+                        status: probe::EngineStatus::Passed,
+                        detail: None,
+                        candidates_dropped: 0,
+                        skipped_files: Vec::new(),
+                    }],
                     findings,
+                    outcome: fuzz_outcome,
                     ..probe::ProbeOutput::envelope(probe_mode)
                 };
                 println!("{}", serde_json::to_string_pretty(&output)?);

--- a/crates/qedgen/src/run_helpers.rs
+++ b/crates/qedgen/src/run_helpers.rs
@@ -788,12 +788,7 @@ pub(crate) fn source_scan_engine_run(prog_root: &Path) -> probe::EngineRun {
     let mut skipped: Vec<String> = files
         .iter()
         .filter(|f| std::fs::read_to_string(f).is_err())
-        .map(|f| {
-            f.strip_prefix(prog_root)
-                .unwrap_or(f)
-                .display()
-                .to_string()
-        })
+        .map(|f| f.strip_prefix(prog_root).unwrap_or(f).display().to_string())
         .collect();
     skipped.sort();
     if skipped.is_empty() {

--- a/crates/qedgen/src/run_helpers.rs
+++ b/crates/qedgen/src/run_helpers.rs
@@ -775,6 +775,57 @@ pub(crate) fn runtime_agnostic_findings(prog_root: &Path) -> Result<Vec<probe::F
     Ok(findings)
 }
 
+/// v3 (#227): report the source-walk engine's status for a `--program`
+/// envelope. The regex scanners silently `continue` past any `.rs` file
+/// they can't read; this re-walks the same file set and surfaces the
+/// unreadable ones as a `partial` engine run so a zero-finding result
+/// can't hide half-skipped source. Returns a single `EngineRun` named
+/// `source_scan` (the arithmetic-symbol / paired-validator / lifecycle
+/// scanners share one file walk, so one status covers them).
+pub(crate) fn source_scan_engine_run(prog_root: &Path) -> probe::EngineRun {
+    let src_dir = prog_root.join("src");
+    let files = crate::fs_walk::collect_rs_files(&src_dir, crate::fs_walk::DEFAULT_SKIP_DIRS);
+    let mut skipped: Vec<String> = files
+        .iter()
+        .filter(|f| std::fs::read_to_string(f).is_err())
+        .map(|f| {
+            f.strip_prefix(prog_root)
+                .unwrap_or(f)
+                .display()
+                .to_string()
+        })
+        .collect();
+    skipped.sort();
+    if skipped.is_empty() {
+        probe::EngineRun {
+            engine: "source_scan".to_string(),
+            status: probe::EngineStatus::Passed,
+            detail: None,
+            candidates_dropped: 0,
+            skipped_files: Vec::new(),
+        }
+    } else {
+        probe::EngineRun {
+            engine: "source_scan".to_string(),
+            status: probe::EngineStatus::Partial,
+            detail: Some(format!("{} source file(s) unreadable", skipped.len())),
+            candidates_dropped: 0,
+            skipped_files: skipped,
+        }
+    }
+}
+
+/// Outcome for a `--program` source-walk envelope: a `partial` engine run
+/// downgrades an empty result to low-coverage; otherwise the scan is a
+/// real (scanner-scoped) pass.
+pub(crate) fn source_scan_outcome(engine: &probe::EngineRun) -> probe::ProbeOutcome {
+    if engine.status == probe::EngineStatus::Partial {
+        probe::ProbeOutcome::NoFindingsLowCoverage
+    } else {
+        probe::ProbeOutcome::PassedWithCoverage
+    }
+}
+
 /// Anchor (and Quasar) probe path used by `qedgen probe --program <root>`.
 /// Mirrors the Pinocchio branch's shape: runs the runtime-specific
 /// extractor, clusters proto-clauses, optionally materializes the audit
@@ -817,12 +868,16 @@ pub(crate) fn run_anchor_probe(
         )?;
     }
 
+    let engine_run = source_scan_engine_run(prog_root);
+    let outcome = source_scan_outcome(&engine_run);
     let output = probe::ProbeOutput {
         project_root: Some(prog_root.display().to_string()),
         runtime: Some(runtime_final),
         handlers: handlers_opt,
         applicable_categories: Some(applicable),
         findings: runtime_agnostic_findings(prog_root)?,
+        engine_runs: vec![engine_run],
+        outcome,
         clusters,
         ..probe::ProbeOutput::envelope(probe::Mode::SpecLess)
     };
@@ -890,12 +945,16 @@ pub(crate) fn run_native_probe(
         None => (None, None),
     };
 
+    let engine_run = source_scan_engine_run(prog_root);
+    let outcome = source_scan_outcome(&engine_run);
     let output = probe::ProbeOutput {
         project_root: Some(prog_root.display().to_string()),
         runtime: Some(runtime_final),
         handlers,
         applicable_categories: Some(applicable),
         findings: runtime_agnostic_findings(prog_root)?,
+        engine_runs: vec![engine_run],
+        outcome,
         clusters,
         dispatcher_kind,
         ..probe::ProbeOutput::envelope(probe::Mode::SpecLess)

--- a/crates/qedgen/tests/probe_cli.rs
+++ b/crates/qedgen/tests/probe_cli.rs
@@ -157,8 +157,14 @@ handler withdraw (amount : U64) : State.Active -> State.Active {
     );
     // Contract: candidates carry NO severity and NO reproducer.
     for c in candidates {
-        assert!(c.get("severity").is_none(), "candidate must not carry severity");
-        assert!(c.get("reproducer").is_none(), "candidate must not carry a reproducer");
+        assert!(
+            c.get("severity").is_none(),
+            "candidate must not carry severity"
+        );
+        assert!(
+            c.get("reproducer").is_none(),
+            "candidate must not carry a reproducer"
+        );
         assert!(
             c["reason"].as_str().is_some_and(|r| !r.is_empty()),
             "candidate must explain why it isn't a finding"

--- a/crates/qedgen/tests/probe_cli.rs
+++ b/crates/qedgen/tests/probe_cli.rs
@@ -105,5 +105,79 @@ fn fuzz_and_spec_probe_agree_on_schema_version() {
     );
     // Pin the canonical value so both paths can't drift in lockstep by
     // accident; bump alongside probe::SCHEMA_VERSION on a conscious change.
-    assert_eq!(spec_json["version"], serde_json::json!(2));
+    assert_eq!(spec_json["version"], serde_json::json!(3));
+    // v3 (#227): budget-0 fuzz is a dry run, not a clean pass.
+    assert_eq!(fuzz_json["outcome"], serde_json::json!("dry_run"));
+    assert_eq!(
+        fuzz_json["engine_runs"][0]["status"],
+        serde_json::json!("blocked"),
+        "budget-0 must report the fuzz engine as blocked, not passed"
+    );
+}
+
+/// The headline #227 fix: a spec whose predicates fire but whose
+/// reproducers aren't built yet must expose those hits as `candidates[]` —
+/// NOT return an empty result indistinguishable from a clean spec. And a
+/// candidate must never masquerade as a finding (no severity, no
+/// reproducer, findings[] stays empty under the all-stubs constructors).
+#[test]
+fn spec_probe_preserves_predicate_hits_as_candidates() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = tmp.path().join("unbounded.qedspec");
+    // `permissionless` + unbounded `amount` in a transfer → multiple
+    // predicates fire (unbounded_amount_param, permissionless_state_writer).
+    std::fs::write(
+        &spec,
+        r#"spec Drain
+
+type State
+  | Active
+
+handler withdraw (amount : U64) : State.Active -> State.Active {
+  permissionless
+  effect { balance -= amount }
+}
+"#,
+    )
+    .unwrap();
+
+    let out = qedgen(&["probe", "--spec", spec.to_str().unwrap()]);
+    assert!(
+        out.status.success(),
+        "probe failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+
+    let candidates = json["candidates"].as_array().expect("candidates[] present");
+    assert!(
+        !candidates.is_empty(),
+        "predicate hits must surface as candidates, got empty:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    // Contract: candidates carry NO severity and NO reproducer.
+    for c in candidates {
+        assert!(c.get("severity").is_none(), "candidate must not carry severity");
+        assert!(c.get("reproducer").is_none(), "candidate must not carry a reproducer");
+        assert!(
+            c["reason"].as_str().is_some_and(|r| !r.is_empty()),
+            "candidate must explain why it isn't a finding"
+        );
+    }
+    // findings[] keeps its reproducer-only contract — empty while all
+    // constructors are stubs.
+    assert_eq!(
+        json["findings"].as_array().map(Vec::len),
+        Some(0),
+        "no reproducer constructors exist yet, so findings must be empty"
+    );
+    // The predicate engine ran to completion and recorded the demotions.
+    let engine = &json["engine_runs"][0];
+    assert_eq!(engine["engine"], serde_json::json!("spec_predicates"));
+    assert_eq!(engine["status"], serde_json::json!("passed"));
+    assert!(
+        engine["candidates_dropped"].as_u64().unwrap() >= 1,
+        "engine run must account for the demoted candidates"
+    );
+    assert!(json["coverage"]["handlers_discovered"].as_u64().unwrap() >= 1);
 }

--- a/docs/design/probe-schema-v3-migration.md
+++ b/docs/design/probe-schema-v3-migration.md
@@ -1,0 +1,58 @@
+# Probe output schema v3 — migration note (#227)
+
+`qedgen probe` output moves from `version: 2` to `version: 3`. The change is
+**additive at the field level** but **semantically breaking for one specific
+consumer habit**: reading an empty `findings[]` as "the program is clean".
+
+## What's new
+
+Four fields on the `ProbeOutput` envelope:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `candidates[]` | array | Predicate hits / static patterns to investigate. **No severity, no reproducer.** Not a claim of exploitability. |
+| `engine_runs[]` | array | Per-engine `passed \| partial \| blocked \| failed \| skipped`, plus `candidates_dropped` and `skipped_files`. |
+| `coverage` | object \| absent | What the run discovered/exercised/asserted (`handlers_discovered`, `actions_generated`, `corpus_size`, …). |
+| `outcome` | enum | `passed_with_coverage \| no_findings_low_coverage \| blocked_incomplete_harness \| engine_failed \| dry_run`. |
+
+`findings[]` is unchanged: every entry still carries a reproducer (the
+reproducible-only contract). What changed is that a predicate hit whose
+reproducer can't be constructed is now **preserved in `candidates[]`** instead
+of being silently dropped — so a spec with live predicate hits is no longer
+indistinguishable from a clean one.
+
+## Why the tier split
+
+`candidates[]` sits deliberately below `findings[]`:
+
+- `findings[]` — reproducer-backed, confirmed-subject-to-review. The "no
+  advisory tier" rule keeps unproven claims out of here.
+- `candidates[]` — a work list. Because candidates carry no severity and no
+  reproducer, they can't be mistaken for confirmed issues, which is what keeps
+  the no-advisory-tier rule intact rather than reversing it.
+
+## Migrating a consumer
+
+1. **If you only read `findings[]`** and treat entries as reproducer-backed
+   issues: no change required. Same field, same contract.
+
+2. **If you treated empty `findings[]` as "clean"**: you must now branch on
+   `outcome`. Only `passed_with_coverage` licenses that reading. The others
+   mean the probe under-ran:
+   - `no_findings_low_coverage` — engines ran but exercised little.
+   - `blocked_incomplete_harness` — a required harness was incomplete.
+   - `dry_run` — budget-0 preview; nothing executed.
+   - `engine_failed` — an engine errored.
+   Also consult `candidates[]`: a non-empty candidate list next to an empty
+   `findings[]` means "investigate", not "clean".
+
+3. **If you want per-engine health** (which files were skipped, whether an
+   engine was blocked): read `engine_runs[]`. A `partial` run lists the
+   unreadable `skipped_files`.
+
+## Version gate
+
+The envelope's `version` field is the single source of truth; the auditor
+skill and any tooling should gate on `version == 3`. A v2 reader that ignores
+unknown fields keeps working against `findings[]` but silently loses the
+empty-vs-underran distinction — upgrade the "empty means clean" check first.

--- a/references/cli.md
+++ b/references/cli.md
@@ -359,12 +359,24 @@ walk a brownfield project root and emit a per-handler work list
 consumed by the auditor subagent. Spec-aware emits `findings`;
 spec-less emits `runtime`, `handlers`, `applicable_categories`.
 v2.16 schema bumps to `version: 2` with the addition of an optional
-`reproducer` field on findings (drop-on-fail pipeline; findings
-without a confirmed reproducer are silently dropped — see
-`feedback_probes_reproducible_only.md`). v2.19 adds an optional
-`clusters[]` array under `--emit-spec-candidates` (additive — the
-schema stays `version: 2`) that the auditor subagent surfaces
-through the scaffold-to-spec interview. v2.20 extends the bootstrap envelope
+`reproducer` field on findings (findings without a confirmed
+reproducer are demoted, not emitted — see
+`feedback_probes_reproducible_only.md`). **v3 (#227) — the evidence
+model**: a predicate hit that can't (yet) acquire a reproducer is
+preserved in a new `candidates[]` array (no severity, no reproducer —
+an investigation lead, not a finding) instead of being silently
+dropped; `engine_runs[]` records per-engine status (`passed | partial
+| blocked | failed | skipped`, with `candidates_dropped` and
+`skipped_files`); `coverage` reports what was discovered/exercised;
+and `outcome` (`passed_with_coverage | no_findings_low_coverage |
+blocked_incomplete_harness | engine_failed | dry_run`) lets a consumer
+tell a real clean pass from a probe that under-ran (only
+`passed_with_coverage` licenses "found nothing"). `findings[]` keeps
+its reproducer-only contract. Budget-0 fuzz reports `outcome: dry_run`
+with the fuzz engine `blocked`. Migration: `docs/design/probe-schema-v3-migration.md`.
+v2.19 adds an optional `clusters[]` array under `--emit-spec-candidates`
+(additive; distinct from `candidates[]` — clusters are proto-spec-clauses
+for the scaffold-to-spec interview). v2.20 extends the bootstrap envelope
 with `dispatcher_kind: "shank_central_match"` for native programs
 where `qedgen probe --bootstrap` detects a central-match dispatcher
 in `lib.rs` (S2.1 Shank adapter), and each `handlers[]` entry now

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -78,6 +78,25 @@ Probe output prioritizes investigation; it is not a verdict. Independently walk
 the program's handlers, authority graph, state transitions, account identities,
 arithmetic, CPIs, and documented invariants.
 
+Read the probe envelope by evidence tier (schema v3, `version: 3`):
+
+- **`findings[]`** — issues backed by a replayable reproducer. Treat as
+  confirmed subject to your own review.
+- **`candidates[]`** — predicate hits and static patterns that warrant
+  investigation but carry **no severity and no reproducer**. These are a work
+  list, never results: each is a lead to confirm or dismiss by reading the
+  impl, and each `reason` says why it isn't yet a finding (usually "no
+  reproducer constructor yet"). Never file a candidate as a finding without
+  independently confirming it and attaching a reproducer.
+- **`engine_runs[]`** — per-engine `passed | partial | blocked | failed |
+  skipped`. A `partial` run lists `skipped_files` it could not read; a
+  `blocked` run (e.g. budget-0 fuzz) did not execute. An empty `findings[]`
+  next to a `partial`/`blocked` engine is weak evidence, not a clean pass.
+- **`outcome`** — `passed_with_coverage` | `no_findings_low_coverage` |
+  `blocked_incomplete_harness` | `engine_failed` | `dry_run`. Only
+  `passed_with_coverage` licenses "the probe found nothing here"; the rest
+  mean the probe under-ran and you must lean on manual review.
+
 Always extract a domain dossier from source, tests, comments, documentation,
 and paired operations, even when QEDGen is missing or stale, the ordinary probe
 fails or returns no sites, the runtime adapter is unsupported, or compilation


### PR DESCRIPTION
Closes #227. First milestone of the #225 split — makes an empty probe result *interpretable* without writing a single reproducer.

## The bug

`run_probe()` fires the spec-aware predicates, then a `retain_mut` drops every hit whose reproducer can't be constructed. Since **all** `probe_repro.rs` constructors are `NotImplemented` (there's a test that pins that), `qedgen probe --spec` silently returned an empty `findings[]` — byte-for-byte identical to a genuinely clean spec. That's the worst failure mode for a security tool: it can't tell 'nothing fired' from 'everything fired and I threw it away'.

## The fix — schema v2 → v3, additive

`findings[]` keeps its reproducer-only contract. Four new fields make the evidence level explicit:

- **`candidates[]`** — predicate hits preserved for investigation. **No severity, no reproducer**, plus a `reason` ("no reproducer constructor implemented for this category yet"). Because candidates make no exploitability claim, the *no-advisory-tier* rule on `findings[]` is preserved rather than reversed. `Candidate::from_dropped_finding` does the demotion.
- **`engine_runs[]`** — per-engine `passed | partial | blocked | failed | skipped`, with `candidates_dropped` and `skipped_files`. `spec_predicates` reports `passed` + the demotion count; the `--program` source-walk paths report `partial` + the unreadable files (`source_scan_engine_run`); budget-0 fuzz reports `blocked`.
- **`coverage`** — `handlers_discovered` today; fuzz action/corpus/depth counts arrive with #229.
- **`outcome`** — `passed_with_coverage | no_findings_low_coverage | blocked_incomplete_harness | engine_failed | dry_run`. **Budget-0 fuzz is now `dry_run`, not a silent empty pass** (a #225 acceptance criterion).

## End-to-end

```
$ qedgen probe --spec …/fee_split.qedspec
version: 3   outcome: passed_with_coverage
findings: 0  candidates: 1
engine_runs: [(spec_predicates, passed, dropped=1)]
coverage: {handlers_discovered: 1}
```

The one candidate is a `permissionless_state_writer` hit with full investigation context, no severity, no reproducer.

## Consumers

- Auditor `SKILL.md`: new 'read the envelope by evidence tier' section — only `passed_with_coverage` licenses 'the probe found nothing'; candidates are a work list, never findings.
- `docs/design/probe-schema-v3-migration.md`: migration note (the one breaking habit is 'empty findings == clean').
- `references/cli.md` updated.

## Tests

`tests/probe_cli.rs`: candidate-preservation (candidates carry no severity/reproducer; `findings[]` stays empty under stubbed constructors; the engine run accounts for the demotions), budget-0 `dry_run` outcome, schema pinned to 3. `probe_repro.rs` retrofit test now tracks *which* constructors remain stubbed (it shrinks as #228 lands real ones) instead of asserting all-stubbed-forever.

Full `cargo test` green; clippy clean; readme-drift + auditor-skill checks pass.

## Acceptance criteria (#227)

- [x] `probe --spec` exposes predicate hits as candidates, not an indistinguishable empty result.
- [x] Every `finding` still has a reproducer; candidates carry no severity/reproducer.
- [x] Skipped source files and failed/blocked engines visible in `engine_runs[]`.
- [x] Output states whether coverage was complete/partial/low/blocked; budget-0 is a dry run.
- [x] Schema v3 integration tests + migration note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)