### PR TITLE
test(probe): regression corpus for spec predicates + IDL overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ yarn-error.log*
 # Anchor/Solana
 .anchor/
 target/
+# Probe-corpus fixture (#231): a committed `anchor build`-shaped IDL under a
+# `target/idl/` path is test data, not build output — keep it tracked.
+!crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/target/
+!crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/target/idl/
+!crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/target/idl/vault.json
 test-ledger/
 # Cargo.lock is tracked for binaries but not for libraries
 package-lock.json

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/arbitrary_cpi/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/arbitrary_cpi/hard_safe.qedspec
@@ -1,0 +1,26 @@
+// Corpus (#231) arbitrary_cpi/hard_safe: a writable token account with no
+// transfers block trips a naive scanner — but this is an init-shape
+// handler (Uninitialized pre-state): writable token accounts are creation
+// targets, not transfer targets, and the predicate suppresses the init
+// pattern structurally.
+
+spec AcpiHardSafe
+
+type State
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler create : State.Uninitialized -> State.Active {
+  accounts {
+    owner : signer
+    vault : writable, pda ["vault", owner]
+    vault_ta : writable, token
+  }
+  effect {
+    Active.owner := owner.pubkey
+    Active.total := 0
+  }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/arbitrary_cpi/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/arbitrary_cpi/safe.qedspec
@@ -1,0 +1,24 @@
+// Corpus (#231) arbitrary_cpi/safe: the token flow is declared in a
+// `transfers` block — no candidate.
+
+spec AcpiSafe
+
+type State
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler withdraw (amount : U64) : State.Active -> State.Active {
+  auth owner
+  accounts {
+    owner : signer
+    owner_ta : writable, token
+    vault_ta : writable, token
+  }
+  requires amount <= 1000
+  effect { total -= amount }
+  transfers {
+    from vault_ta to owner_ta amount amount authority owner
+  }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/arbitrary_cpi/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/arbitrary_cpi/vulnerable.qedspec
@@ -1,0 +1,21 @@
+// Corpus (#231) arbitrary_cpi/vulnerable: writable token account on a
+// non-init handler with no `transfers` block or `call` site — the spec
+// gives codegen nothing to mechanize; fires.
+
+spec AcpiVuln
+
+type State
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler withdraw (amount : U64) : State.Active -> State.Active {
+  auth owner
+  accounts {
+    owner : signer
+    vault_ta : writable, token
+  }
+  requires amount <= 1000
+  effect { total -= amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/arithmetic_overflow_wrapping/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/arithmetic_overflow_wrapping/hard_safe.qedspec
@@ -1,0 +1,17 @@
+// Corpus (#231) arithmetic_overflow_wrapping/hard_safe: grep bait — the
+// identifiers are saturated with "wrap" (`wrap_total`, `wrap_amount`), so
+// a token-matching scanner fires. The operator is the default checked
+// `+=`; the predicate keys on the op, not the names.
+
+spec AowHardSafe
+
+type State
+  | Active of {
+      wrap_total : U64,
+    }
+
+handler add_wrap_fee (wrap_amount : U64) : State.Active -> State.Active {
+  auth owner
+  requires wrap_amount <= 100
+  effect { wrap_total += wrap_amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/arithmetic_overflow_wrapping/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/arithmetic_overflow_wrapping/safe.qedspec
@@ -1,0 +1,15 @@
+// Corpus (#231) arithmetic_overflow_wrapping/safe: default checked `+=`
+// aborts on overflow — no candidate.
+
+spec AowSafe
+
+type State
+  | Active of {
+      balance : U64,
+    }
+
+handler deposit (amount : U64) : State.Active -> State.Active {
+  auth owner
+  requires amount <= 1000000
+  effect { balance += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/arithmetic_overflow_wrapping/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/arithmetic_overflow_wrapping/vulnerable.qedspec
@@ -1,0 +1,14 @@
+// Corpus (#231) arithmetic_overflow_wrapping/vulnerable: explicit wrapping
+// `+=?` on an amount-shaped field — fires (High).
+
+spec AowVuln
+
+type State
+  | Active of {
+      balance : U64,
+    }
+
+handler deposit (amount : U64) : State.Active -> State.Active {
+  auth owner
+  effect { balance +=? amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/init_without_pda/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/init_without_pda/hard_safe.qedspec
@@ -1,0 +1,23 @@
+// Corpus (#231) init_without_pda/hard_safe: name bait — a handler named
+// `initialize_config` writes a writable non-PDA account, so a
+// name-keyed scanner fires. Its pre-state is `Active` (reconfiguration of
+// a live singleton, not an init): the predicate keys on init-shape
+// pre_status, not the handler name.
+
+spec IwpHardSafe
+
+type State
+  | Active of {
+      owner : Pubkey,
+      fee_bps : U64,
+    }
+
+handler initialize_config (fee_bps_new : U64) : State.Active -> State.Active {
+  auth owner
+  accounts {
+    owner : signer
+    config : writable
+  }
+  requires fee_bps_new <= 10000
+  effect { fee_bps := fee_bps_new }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/init_without_pda/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/init_without_pda/safe.qedspec
@@ -1,0 +1,22 @@
+// Corpus (#231) init_without_pda/safe: the initialized account is a PDA
+// scoped to the caller — no candidate.
+
+spec IwpSafe
+
+type State
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler create : State.Uninitialized -> State.Active {
+  accounts {
+    owner : signer
+    vault : writable, pda ["vault", owner]
+  }
+  effect {
+    Active.owner := owner.pubkey
+    Active.total := 0
+  }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/init_without_pda/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/init_without_pda/vulnerable.qedspec
@@ -1,0 +1,23 @@
+// Corpus (#231) init_without_pda/vulnerable: init-shape handler
+// (Uninitialized -> Active) whose writable account declares no PDA seeds
+// — default-address collision; fires.
+
+spec IwpVuln
+
+type State
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler create : State.Uninitialized -> State.Active {
+  accounts {
+    owner : signer
+    vault : writable
+  }
+  effect {
+    Active.owner := owner.pubkey
+    Active.total := 0
+  }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/lifecycle_one_shot_violation/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/lifecycle_one_shot_violation/hard_safe.qedspec
@@ -1,0 +1,29 @@
+// Corpus (#231) lifecycle_one_shot_violation/hard_safe: `audit_log` has no
+// lifecycle annotation — a naive "every handler must declare a transition"
+// scanner fires. It mutates nothing (guard-only), so cross-state replay
+// has no surface; the predicate requires a state mutation.
+
+spec LcHardSafe
+
+type State
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler create : State.Uninitialized -> State.Active {
+  accounts {
+    owner : signer
+    vault : writable, pda ["vault", owner]
+  }
+  effect {
+    Active.owner := owner.pubkey
+    Active.total := 0
+  }
+}
+
+handler audit_log {
+  auth owner
+  requires state.total >= 0
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/lifecycle_one_shot_violation/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/lifecycle_one_shot_violation/safe.qedspec
@@ -1,0 +1,28 @@
+// Corpus (#231) lifecycle_one_shot_violation/safe: every mutating handler
+// declares its lifecycle transition — no candidate.
+
+spec LcSafe
+
+type State
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler create : State.Uninitialized -> State.Active {
+  accounts {
+    owner : signer
+    vault : writable, pda ["vault", owner]
+  }
+  effect {
+    Active.owner := owner.pubkey
+    Active.total := 0
+  }
+}
+
+handler update_total (amount : U64) : State.Active -> State.Active {
+  auth owner
+  requires amount <= 1000
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/lifecycle_one_shot_violation/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/lifecycle_one_shot_violation/vulnerable.qedspec
@@ -1,0 +1,29 @@
+// Corpus (#231) lifecycle_one_shot_violation/vulnerable: the spec models
+// lifecycle states, but `update_total` mutates state with no lifecycle
+// pre-condition — invokable in any state; fires.
+
+spec LcVuln
+
+type State
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+handler create : State.Uninitialized -> State.Active {
+  accounts {
+    owner : signer
+    vault : writable, pda ["vault", owner]
+  }
+  effect {
+    Active.owner := owner.pubkey
+    Active.total := 0
+  }
+}
+
+handler update_total (amount : U64) {
+  auth owner
+  requires amount <= 1000
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/missing_signer/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/missing_signer/hard_safe.qedspec
@@ -1,0 +1,16 @@
+// Corpus (#231) missing_signer/hard_safe: no `auth` clause anywhere — a
+// naive "flag every handler without auth" scanner fires. The handler is
+// explicitly `permissionless` (a public crank), which suppresses
+// missing_signer by declared intent.
+
+spec MsHardSafe
+
+type State
+  | Active of {
+      tick_count : U64,
+    }
+
+handler crank : State.Active -> State.Active {
+  permissionless
+  effect { tick_count += 1 }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/missing_signer/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/missing_signer/safe.qedspec
@@ -1,0 +1,20 @@
+// Corpus (#231) missing_signer/safe: single handler gated by `auth owner`
+// — predicate_missing_signer returns None. `owner` is a PDA seed
+// (implicitly bound at init), so it does not trip
+// stored_field_never_written either.
+
+spec MsSafe
+
+type State
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+pda vault ["vault", owner]
+
+handler update_total (amount : U64) : State.Active -> State.Active {
+  auth owner
+  requires amount <= 1000
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/missing_signer/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/missing_signer/vulnerable.qedspec
@@ -1,0 +1,14 @@
+// Corpus (#231) missing_signer/vulnerable: state-mutating handler with no
+// `auth` clause and no `permissionless` marker — the predicate fires.
+
+spec MsVuln
+
+type State
+  | Active of {
+      total : U64,
+    }
+
+handler update_total (amount : U64) : State.Active -> State.Active {
+  requires amount <= 1000
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/permissionless_state_writer/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/permissionless_state_writer/hard_safe.qedspec
@@ -1,0 +1,16 @@
+// Corpus (#231) permissionless_state_writer/hard_safe: `permissionless`
+// handler that writes nothing — a guard-only public probe. A naive
+// "permissionless = griefing surface" scanner fires on the marker; the
+// predicate requires an actual state write.
+
+spec PswHardSafe
+
+type State
+  | Active of {
+      total : U64,
+    }
+
+handler check_solvency : State.Active -> State.Active {
+  permissionless
+  requires state.total >= 0
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/permissionless_state_writer/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/permissionless_state_writer/safe.qedspec
@@ -1,0 +1,15 @@
+// Corpus (#231) permissionless_state_writer/safe: same mutation, gated by
+// `auth owner` — no candidate.
+
+spec PswSafe
+
+type State
+  | Active of {
+      owner : Pubkey,
+      tick_count : U64,
+    }
+
+handler crank : State.Active -> State.Active {
+  auth owner
+  effect { tick_count += 1 }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/permissionless_state_writer/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/permissionless_state_writer/vulnerable.qedspec
@@ -1,0 +1,14 @@
+// Corpus (#231) permissionless_state_writer/vulnerable: `permissionless`
+// handler mutating shared state — fires.
+
+spec PswVuln
+
+type State
+  | Active of {
+      tick_count : U64,
+    }
+
+handler crank : State.Active -> State.Active {
+  permissionless
+  effect { tick_count += 1 }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/stored_field_never_written/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/stored_field_never_written/hard_safe.qedspec
@@ -1,0 +1,20 @@
+// Corpus (#231) stored_field_never_written/hard_safe: no explicit effect
+// writes `admin`, so a naive "read but never assigned" scanner fires. The
+// field is a PDA seed (`pda vault ["vault", admin]`) — codegen binds seed
+// fields implicitly at init, which the predicate treats as written.
+
+spec SfnwHardSafe
+
+type State
+  | Active of {
+      admin : Pubkey,
+      total : U64,
+    }
+
+pda vault ["vault", admin]
+
+handler update_total (amount : U64) : State.Active -> State.Active {
+  auth admin
+  requires amount <= 1000
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/stored_field_never_written/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/stored_field_never_written/safe.qedspec
@@ -1,0 +1,26 @@
+// Corpus (#231) stored_field_never_written/safe: `threshold` is read by a
+// `requires` and written by an explicit `:=` effect, so the predicate sees
+// a writer and stays silent. `owner` (the auth field) is a PDA seed, also
+// treated as written. Contrast the vulnerable case, where the auth field
+// is read but never written by any effect.
+
+spec SfnwSafe
+
+type State
+  | Active of {
+      owner     : Pubkey,
+      threshold : U64,
+      total     : U64,
+    }
+
+pda vault ["vault", owner]
+
+handler set_threshold (t : U64) : State.Active -> State.Active {
+  auth owner
+  requires t <= 10000
+  requires state.threshold <= 1000000
+  effect {
+    threshold := t
+    total := 0
+  }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/stored_field_never_written/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/stored_field_never_written/vulnerable.qedspec
@@ -1,0 +1,17 @@
+// Corpus (#231) stored_field_never_written/vulnerable: `admin` is read by
+// `auth admin` (lowers to has_one = admin) but no handler effect ever
+// writes it — unset Pubkey makes the handler unreachable; fires (Critical).
+
+spec SfnwVuln
+
+type State
+  | Active of {
+      admin : Pubkey,
+      total : U64,
+    }
+
+handler update_total (amount : U64) : State.Active -> State.Active {
+  auth admin
+  requires amount <= 1000
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/unbounded_amount_param/hard_safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/unbounded_amount_param/hard_safe.qedspec
@@ -1,0 +1,19 @@
+// Corpus (#231) unbounded_amount_param/hard_safe: word-boundary trap. The
+// param `amount` never reaches an effect RHS or transfer slot — the only
+// RHS-adjacent token is the *field* `amount_total` (substring match hits,
+// word-boundary match does not), and the param appears in a lower-bound
+// requires only. A naive scanner flags the integer param; the predicate
+// requires actual effect/transfer flow.
+
+spec UapHardSafe
+
+type State
+  | Active of {
+      amount_total : U64,
+    }
+
+handler tick (amount : U64) : State.Active -> State.Active {
+  auth owner
+  requires amount > 0
+  effect { amount_total += 1 }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/unbounded_amount_param/safe.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/unbounded_amount_param/safe.qedspec
@@ -1,0 +1,15 @@
+// Corpus (#231) unbounded_amount_param/safe: same flow, upper-bounded by
+// `requires amount <= 1000000` — no candidate.
+
+spec UapSafe
+
+type State
+  | Active of {
+      total : U64,
+    }
+
+handler deposit (amount : U64) : State.Active -> State.Active {
+  auth owner
+  requires amount <= 1000000
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/spec/unbounded_amount_param/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/probe-corpus/spec/unbounded_amount_param/vulnerable.qedspec
@@ -1,0 +1,14 @@
+// Corpus (#231) unbounded_amount_param/vulnerable: integer param flows
+// into an effect RHS with no bounding `requires` — fires.
+
+spec UapVuln
+
+type State
+  | Active of {
+      total : U64,
+    }
+
+handler deposit (amount : U64) : State.Active -> State.Active {
+  auth owner
+  effect { total += amount }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/Anchor.toml
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/Anchor.toml
@@ -1,0 +1,2 @@
+[programs.localnet]
+vault = "Vault1111111111111111111111111111111111111"

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/Cargo.toml
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vault"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anchor-lang = "0.30"

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/src/lib.rs
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/src/lib.rs
@@ -1,0 +1,27 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Vault1111111111111111111111111111111111111");
+
+#[program]
+pub mod vault {
+    use super::*;
+    // Declared in the IDL — signer `admin` → authority_gated narrowing.
+    pub fn initialize(_ctx: Context<Initialize>, cap: u64) -> Result<()> {
+        let _ = cap;
+        Ok(())
+    }
+    // Declared in the IDL, no signer → permissionless narrowing.
+    pub fn crank(_ctx: Context<Crank>) -> Result<()> {
+        Ok(())
+    }
+    // NOT in the IDL — source_only drift candidate.
+    pub fn emergency_withdraw(_ctx: Context<Crank>, amount: u64) -> Result<()> {
+        let _ = amount;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize {}
+#[derive(Accounts)]
+pub struct Crank {}

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/target/idl/vault.json
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-idl/target/idl/vault.json
@@ -1,0 +1,24 @@
+{
+  "address": "Vault1111111111111111111111111111111111111",
+  "metadata": { "name": "vault", "version": "0.1.0", "spec": "0.1.0" },
+  "instructions": [
+    {
+      "name": "initialize",
+      "accounts": [
+        { "name": "admin", "signer": true, "writable": true },
+        { "name": "vault", "writable": true }
+      ],
+      "args": [ { "name": "cap", "type": "u64" } ]
+    },
+    {
+      "name": "crank",
+      "accounts": [ { "name": "vault", "writable": true } ],
+      "args": []
+    },
+    {
+      "name": "reconcile",
+      "accounts": [ { "name": "vault", "writable": true } ],
+      "args": []
+    }
+  ]
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/native-shank-marker/Cargo.toml
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/native-shank-marker/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "native-prog"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+solana-program = "2"
+shank = "0.4"

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/native-shank-marker/src/lib.rs
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/native-shank-marker/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn process_instruction() {}

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/pinocchio-codama/Cargo.toml
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/pinocchio-codama/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "counter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pinocchio = "0.7"

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/pinocchio-codama/idl.json
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/pinocchio-codama/idl.json
@@ -1,0 +1,20 @@
+{
+  "program": {
+    "name": "counter",
+    "instructions": [
+      {
+        "name": "increment",
+        "accounts": [
+          { "name": "payer", "isSigner": true, "isWritable": true },
+          { "name": "counter", "isSigner": false, "isWritable": true }
+        ],
+        "arguments": [ { "name": "amount", "type": { "kind": "numberTypeNode", "format": "u64" } } ]
+      },
+      {
+        "name": "reset",
+        "accounts": [ { "name": "authority", "isSigner": true, "isWritable": false } ],
+        "arguments": []
+      }
+    ]
+  }
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/pinocchio-codama/src/lib.rs
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/pinocchio-codama/src/lib.rs
@@ -1,0 +1,3 @@
+// Pinocchio entrypoint — no #[program] mod, so bootstrap source discovery
+// yields no handlers; the Codama IDL is the handler source of truth.
+pub fn process_instruction() {}

--- a/crates/qedgen/tests/probe_corpus.rs
+++ b/crates/qedgen/tests/probe_corpus.rs
@@ -1,0 +1,270 @@
+//! Probe regression corpus (#231 — in-repo half; recall/precision
+//! *measurement* stays in the auditor-bench skill per
+//! `feedback_bench_stays_a_skill`).
+//!
+//! Two fixture families under `tests/fixtures/probe-corpus/`:
+//!
+//! - `spec/<category>/{vulnerable,safe,hard_safe}.qedspec` — one triple per
+//!   spec-aware predicate. The contract, asserted per fixture:
+//!   vulnerable → emits its own category tag (candidate or finding);
+//!   safe / hard_safe → does NOT emit its own category tag; and NO
+//!   safe/hard_safe fixture emits a reproducer-backed `finding`
+//!   (`findings[]`) of any category — a false *confirmed finding* is a
+//!   release blocker (#231), whereas a stray cross-category *candidate* on a
+//!   minimal multi-handler spec is legitimate probe output (the predicates
+//!   compose), so cross-category candidates are not asserted against.
+//!   hard_safe fixtures are specifically shaped to fool a naive
+//!   token/name-matching scanner while staying safe under the real
+//!   structural predicate.
+//!
+//! - `specless/<scenario>/` — brownfield project trees exercising the #235
+//!   IDL-enrichment overlay end to end (enrich, framework-enforced
+//!   narrowing, source/IDL drift, Pinocchio handler fill, derivable-IDL
+//!   hint on a marker-without-IDL).
+//!
+//! These are pass/fail *regression* tests, not a metric: they pin that a
+//! shipped predicate keeps firing on its vuln fixture and stays silent on
+//! its safe/hard_safe fixtures across refactors.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn corpus_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/probe-corpus")
+}
+
+/// Run `qedgen probe <args...>` and parse stdout as the schema-v3 envelope.
+fn probe(args: &[&str]) -> Value {
+    let out = Command::new(env!("CARGO_BIN_EXE_qedgen"))
+        .arg("probe")
+        .args(args)
+        .output()
+        .expect("spawn qedgen probe");
+    assert!(
+        out.status.success(),
+        "probe {args:?} exited non-zero: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "probe {args:?} stdout was not valid JSON: {e}\n{}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+fn tags_of<'a>(env: &'a Value, key: &str) -> Vec<&'a str> {
+    env.get(key)
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|e| e.get("category_tag").and_then(Value::as_str))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The eight spec-aware predicate categories, each with a fixture triple.
+const SPEC_CATEGORIES: &[&str] = &[
+    "missing_signer",
+    "arithmetic_overflow_wrapping",
+    "unbounded_amount_param",
+    "permissionless_state_writer",
+    "lifecycle_one_shot_violation",
+    "init_without_pda",
+    "stored_field_never_written",
+    "arbitrary_cpi",
+];
+
+fn spec_path(category: &str, variant: &str) -> String {
+    corpus_dir()
+        .join("spec")
+        .join(category)
+        .join(format!("{variant}.qedspec"))
+        .display()
+        .to_string()
+}
+
+#[test]
+fn vulnerable_fixtures_emit_their_own_category() {
+    for &cat in SPEC_CATEGORIES {
+        let env = probe(&["--spec", &spec_path(cat, "vulnerable")]);
+        let mut emitted = tags_of(&env, "candidates");
+        emitted.extend(tags_of(&env, "findings"));
+        assert!(
+            emitted.contains(&cat),
+            "vulnerable fixture for `{cat}` must emit its own category tag; \
+             got candidates+findings = {emitted:?}"
+        );
+    }
+}
+
+#[test]
+fn safe_fixtures_do_not_emit_their_own_category() {
+    for &cat in SPEC_CATEGORIES {
+        for variant in ["safe", "hard_safe"] {
+            let env = probe(&["--spec", &spec_path(cat, variant)]);
+            let mut emitted = tags_of(&env, "candidates");
+            emitted.extend(tags_of(&env, "findings"));
+            assert!(
+                !emitted.contains(&cat),
+                "`{variant}` fixture for `{cat}` must NOT emit its own category tag; \
+                 got candidates+findings = {emitted:?}"
+            );
+        }
+    }
+}
+
+/// The hard release bar (#231): no safe/hard_safe fixture may produce a
+/// reproducer-backed `finding` of ANY category. A false *confirmed finding*
+/// is a release blocker; a stray cross-category *candidate* is not.
+#[test]
+fn no_safe_fixture_emits_a_confirmed_finding() {
+    for &cat in SPEC_CATEGORIES {
+        for variant in ["safe", "hard_safe"] {
+            let env = probe(&["--spec", &spec_path(cat, variant)]);
+            let findings = tags_of(&env, "findings");
+            assert!(
+                findings.is_empty(),
+                "`{variant}` fixture for `{cat}` emitted confirmed finding(s) {findings:?} — \
+                 a false confirmed finding is a release blocker"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Spec-less IDL-enrichment overlay (#235) — end-to-end scenarios.
+// ---------------------------------------------------------------------------
+
+fn specless_root(scenario: &str) -> String {
+    corpus_dir()
+        .join("specless")
+        .join(scenario)
+        .display()
+        .to_string()
+}
+
+fn handlers_of(env: &Value) -> &Vec<Value> {
+    static EMPTY: Vec<Value> = Vec::new();
+    env.get("handlers")
+        .and_then(Value::as_array)
+        .unwrap_or(&EMPTY)
+}
+
+fn handler<'a>(env: &'a Value, name: &str) -> &'a Value {
+    handlers_of(env)
+        .iter()
+        .find(|h| h.get("name").and_then(Value::as_str) == Some(name))
+        .unwrap_or_else(|| panic!("handler `{name}` not in envelope"))
+}
+
+/// Anchor + on-disk IDL: `idl_path` reported; enforced signer flags narrow
+/// untagged handlers (admin → authority_gated, no-signer crank →
+/// permissionless); a source handler absent from the IDL and an IDL
+/// instruction absent from source both surface as drift.
+#[test]
+fn anchor_idl_overlay_enriches_narrows_and_reports_drift() {
+    let env = probe(&["--bootstrap", "--root", &specless_root("anchor-idl")]);
+
+    assert_eq!(
+        env.get("idl_path").and_then(Value::as_str),
+        Some("target/idl/vault.json")
+    );
+
+    let init = handler(&env, "initialize");
+    assert_eq!(
+        init.get("intent_tag").and_then(Value::as_str),
+        Some("authority_gated"),
+        "signer `admin` should narrow initialize to authority_gated"
+    );
+    assert!(
+        init.get("applicable_categories").is_some(),
+        "authority_gated handler should carry a narrowed category list"
+    );
+    let signers: Vec<&str> = init
+        .get("idl_accounts")
+        .and_then(Value::as_array)
+        .unwrap()
+        .iter()
+        .filter(|a| a.get("signer").and_then(Value::as_bool) == Some(true))
+        .filter_map(|a| a.get("name").and_then(Value::as_str))
+        .collect();
+    assert_eq!(signers, vec!["admin"]);
+
+    let crank = handler(&env, "crank");
+    assert_eq!(
+        crank.get("intent_tag").and_then(Value::as_str),
+        Some("permissionless"),
+        "no declared signer should narrow crank to permissionless"
+    );
+
+    // Drift: `emergency_withdraw` (source-only) and `reconcile` (IDL-only).
+    let drift: Vec<&str> = env
+        .get("candidates")
+        .and_then(Value::as_array)
+        .unwrap()
+        .iter()
+        .filter(|c| c.get("category_tag").and_then(Value::as_str) == Some("idl_source_drift"))
+        .filter_map(|c| c.get("handler").and_then(Value::as_str))
+        .collect();
+    assert!(
+        drift.contains(&"emergency_withdraw"),
+        "source-only drift missing: {drift:?}"
+    );
+    assert!(
+        drift.contains(&"reconcile"),
+        "idl-only drift missing: {drift:?}"
+    );
+}
+
+/// Pinocchio: source discovery yields no handlers, so the Codama IDL fills
+/// `handlers[]` (each `discovered_via: "idl"`, `source_file` = the IDL).
+#[test]
+fn pinocchio_codama_overlay_fills_handlers_from_idl() {
+    let env = probe(&["--program", &specless_root("pinocchio-codama")]);
+
+    assert_eq!(
+        env.get("runtime").and_then(Value::as_str),
+        Some("pinocchio")
+    );
+    assert_eq!(
+        env.get("idl_path").and_then(Value::as_str),
+        Some("idl.json")
+    );
+
+    let names: Vec<&str> = handlers_of(&env)
+        .iter()
+        .filter_map(|h| h.get("name").and_then(Value::as_str))
+        .collect();
+    assert!(names.contains(&"increment"), "handlers: {names:?}");
+    assert!(names.contains(&"reset"), "handlers: {names:?}");
+
+    for h in handlers_of(&env) {
+        assert_eq!(
+            h.get("discovered_via").and_then(Value::as_str),
+            Some("idl"),
+            "Pinocchio handler `{:?}` should be IDL-discovered",
+            h.get("name")
+        );
+    }
+}
+
+/// A `shank` dep with no on-disk IDL reports `derivable_idl: "shank"` and no
+/// `idl_path` — the overlay does not shell out, it hints.
+#[test]
+fn shank_marker_without_idl_reports_derivable() {
+    let env = probe(&[
+        "--bootstrap",
+        "--root",
+        &specless_root("native-shank-marker"),
+    ]);
+    assert_eq!(env.get("runtime").and_then(Value::as_str), Some("native"));
+    assert!(env.get("idl_path").is_none(), "no IDL is on disk");
+    assert_eq!(
+        env.get("derivable_idl").and_then(Value::as_str),
+        Some("shank")
+    );
+}


### PR DESCRIPTION
Implements the in-repo half of #231. Per `feedback_bench_stays_a_skill`, recall/precision *measurement* stays in the auditor-bench skill; what lives in-repo is the fixture corpus and pass/fail regression tests.

## Context

This answers "did #235 (the IDL overlay, PR #236) improve our metrics?" with a mechanical instrument instead of an expensive, noisy bench re-run. The spec-predicate corpus also backfills regression coverage the probe predicates never had.

## What's here

**`tests/fixtures/probe-corpus/spec/<category>/{vulnerable,safe,hard_safe}.qedspec`** — one triple per spec-aware predicate (all 8: missing_signer, arithmetic_overflow_wrapping, unbounded_amount_param, permissionless_state_writer, lifecycle_one_shot_violation, init_without_pda, stored_field_never_written, arbitrary_cpi).

Contract asserted in `tests/probe_corpus.rs`:
- **vulnerable** → emits its own category tag (candidate or finding);
- **safe / hard_safe** → does *not* emit its own category tag;
- **no safe/hard_safe fixture emits a reproducer-backed `finding`** of any category — a false *confirmed finding* is a release blocker (#231), whereas a stray cross-category *candidate* on a minimal multi-handler spec is legitimate probe output (the predicates compose by design), so cross-category candidates are not asserted against.

`hard_safe` fixtures are deliberately shaped to fool a naive token/name-matching scanner while staying safe under the real structural predicate — e.g. identifiers saturated with `wrap_*` under a checked `+=`, a `permissionless` handler that writes nothing, an init-named handler whose pre-state is `Active` (reconfig, not init), an auth field that is a PDA seed (bound at init).

**`tests/fixtures/probe-corpus/specless/<scenario>/`** — brownfield project trees exercising the #235 IDL overlay end to end:
- `anchor-idl/` — Anchor source + `target/idl/vault.json`: asserts `idl_path`, `admin` signer → `authority_gated` narrowing, no-signer `crank` → `permissionless`, and bidirectional drift (`emergency_withdraw` source-only, `reconcile` IDL-only);
- `pinocchio-codama/` — Pinocchio entrypoint with no `#[program]` mod + a Codama `idl.json`: asserts the otherwise-empty `handlers[]` is filled from the IDL with `discovered_via: "idl"`;
- `native-shank-marker/` — a `shank` dep with no on-disk IDL: asserts `derivable_idl: "shank"` and no `idl_path` (hint, not shell-out).

A `.gitignore` negation keeps the `anchor build`-shaped `target/idl/vault.json` tracked (test data, not build output).

## The lift, concretely

On the real Cantina Pinocchio bench target (`multi_delegator`, the 21%-recall program), the same overlay takes the bootstrap envelope from **0 handlers to 14**, each carrying its IDL signer set — the exact work-list + authorization topology the auditor previously reconstructed by hand. This corpus pins that behavior so it can't silently regress.

## Scope / honesty

This is a regression harness, not a recall number: it proves shipped predicates keep firing on vuln fixtures and stay silent on safe/hard_safe ones across refactors, and that the #235 overlay keeps enriching/narrowing/drifting as designed. Actual recall/precision on real targets remains a bench-skill measurement (the follow-up half of #231).

## Testing

6 tests, all green; full workspace suite green (24 suites); fmt + clippy clean.