### PR TITLE
feat(probe): mechanize the dead-guard / unwired-error-variant sweep (#240)

### DIFF
--- a/crates/qedgen/src/probe/dead_guard_probe.rs
+++ b/crates/qedgen/src/probe/dead_guard_probe.rs
@@ -1,0 +1,426 @@
+//! Dead-guard / unwired-error-variant sweep (#240).
+//!
+//! An error-enum variant that is *defined* but wired into no guard is a
+//! named intention the code never enforces: the maintainer named the check
+//! (the variant name often spells out the invariant) but no call site ever
+//! fires it, so the path it was meant to protect proceeds unchecked. This
+//! class is invisible to the per-category catalog and to the comparison-
+//! direction / store-without-validate passes — there IS no guard to find a
+//! coverage gap against; the guard exists in name only.
+//!
+//! The sweep was a prose manual-review pass in the auditor skill (§3f),
+//! which a strong model under-executes (a benchmark run missed the class
+//! entirely in one worker and mis-rated it in another). It is fully
+//! deterministic, so it belongs in the tool: enumerate the program's
+//! `#[error_code]` enum variants, grep each for an enforcement call-site in
+//! the crate's `src/`, and emit one [`Candidate`] per zero-call-site
+//! variant for the model to triage and severity-rate. "qedgen greps; the
+//! model judges."
+//!
+//! Emitted as a [`Candidate`], never a [`Finding`]: a guard that is never
+//! called is an *absence*, and an absence has no runnable reproducer
+//! (`probes = reproducible only`). The candidate carries the severity rule
+//! in its `investigation_hint` — a dead guard inherits the impact ceiling
+//! of the path it fails to protect, not a dead-variant floor.
+//!
+//! Scope: `#[error_code]` enums (Anchor / Quasar), the runtimes that carry
+//! a first-class error enum with named variants. Native `thiserror` enums
+//! are a future extension; absent an `#[error_code]` enum the sweep is a
+//! clean no-op (empty vec), never a false positive.
+
+use anyhow::Result;
+use regex::Regex;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::probe::scan_util::{byte_offset_to_line, line_is_commented};
+use crate::probe::{Candidate, Category};
+
+/// A variant declaration site: the enum it belongs to and where it is
+/// defined, so a candidate can name the exact `file:line` of the dead guard.
+struct VariantDecl {
+    name: String,
+    enum_name: String,
+    rel_file: String,
+    line: u32,
+}
+
+/// The byte span of an enum body in a specific file, so occurrences of a
+/// variant name inside its own declaration are excluded from the call-site
+/// grep (the declaration is not enforcement).
+struct EnumBodySpan {
+    file: std::path::PathBuf,
+    start: usize,
+    end: usize,
+}
+
+/// Entry point: enumerate `#[error_code]` variants under `<root>/src`, then
+/// flag every variant with no enforcement call-site. No `src/`, no error
+/// enum, or no dead variant each yield an empty vec (never an error).
+pub fn scan_program(project_root: &Path) -> Result<Vec<Candidate>> {
+    let src_dir = project_root.join("src");
+    if !src_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let rs_files = crate::fs_walk::collect_rs_files(&src_dir, crate::fs_walk::DEFAULT_SKIP_DIRS);
+
+    // Pass 1: enumerate error-enum variants + record each enum body span.
+    let mut decls: Vec<VariantDecl> = Vec::new();
+    let mut enum_spans: Vec<EnumBodySpan> = Vec::new();
+    let mut sources: BTreeMap<std::path::PathBuf, String> = BTreeMap::new();
+    for file in &rs_files {
+        let Ok(source) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        let rel = file
+            .strip_prefix(project_root)
+            .unwrap_or(file)
+            .display()
+            .to_string();
+        for e in find_error_enums(&source) {
+            enum_spans.push(EnumBodySpan {
+                file: file.clone(),
+                start: e.body_start,
+                end: e.body_end,
+            });
+            for (variant, offset) in e.variants {
+                decls.push(VariantDecl {
+                    name: variant,
+                    enum_name: e.enum_name.clone(),
+                    rel_file: rel.clone(),
+                    line: byte_offset_to_line(&source, offset),
+                });
+            }
+        }
+        sources.insert(file.clone(), source);
+    }
+    if decls.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Pass 2: for each variant, does any non-comment occurrence exist in
+    // `src/` OUTSIDE its own enum declaration? Any such occurrence is
+    // treated as wired (conservative — a bare-name match biases toward
+    // not-flagging, so we only surface variants that are provably dead).
+    let mut out: Vec<Candidate> = Vec::new();
+    for decl in &decls {
+        if !has_enforcement_call_site(&decl.name, &sources, &enum_spans) {
+            out.push(unwired_candidate(decl));
+        }
+    }
+    Ok(out)
+}
+
+/// A parsed `#[error_code]` enum: its name, its body byte-span, and each
+/// variant with the byte offset of its declaration.
+struct ErrorEnum {
+    enum_name: String,
+    body_start: usize,
+    body_end: usize,
+    variants: Vec<(String, usize)>,
+}
+
+/// Locate every `#[error_code]`-attributed `enum <Name> { ... }` in a file
+/// and extract its variants. Brace-matched from the `{` after the enum
+/// name, so nested braces (variant discriminants, doc-comment braces) don't
+/// truncate the body early.
+fn find_error_enums(source: &str) -> Vec<ErrorEnum> {
+    // `#[error_code]` (optionally `#[error_code(offset = N)]`) followed,
+    // possibly across other derives/attrs, by `... enum <Name> {`.
+    let attr_re = Regex::new(r"#\[\s*error_code").expect("static regex compiles");
+    let enum_re =
+        Regex::new(r"enum\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\{").expect("static regex compiles");
+    let mut out = Vec::new();
+    for attr in attr_re.find_iter(source) {
+        // Find the first `enum <Name> {` at or after the attribute.
+        let Some(caps) = enum_re.captures_at(source, attr.end()) else {
+            continue;
+        };
+        let name = caps.name("name").unwrap().as_str().to_string();
+        let brace_open = caps.get(0).unwrap().end() - 1; // index of `{`
+        let Some(body_end) = match_brace(source, brace_open) else {
+            continue;
+        };
+        let body = &source[brace_open + 1..body_end];
+        let variants = extract_variants(body, brace_open + 1);
+        out.push(ErrorEnum {
+            enum_name: name,
+            body_start: brace_open,
+            body_end,
+            variants,
+        });
+    }
+    out
+}
+
+/// Return the byte index of the `}` matching the `{` at `open`, or `None`
+/// if unbalanced. Skips braces inside `//` line comments and string
+/// literals so a `{` in a `#[msg("...")]` string or comment can't unbalance
+/// the count.
+fn match_brace(source: &str, open: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut depth = 0i32;
+    let mut i = open;
+    let mut in_str = false;
+    let mut in_line_comment = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_line_comment {
+            if c == b'\n' {
+                in_line_comment = false;
+            }
+        } else if in_str {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_str = false;
+            }
+        } else if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            in_line_comment = true;
+        } else if c == b'"' {
+            in_str = true;
+        } else if c == b'{' {
+            depth += 1;
+        } else if c == b'}' {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Extract variant identifiers from an enum body. A variant is an
+/// identifier at the start of a statement (after skipping attributes like
+/// `#[msg("...")]` and doc comments). `body_offset` is the byte offset of
+/// the body start in the original source, so returned offsets are absolute.
+fn extract_variants(body: &str, body_offset: usize) -> Vec<(String, usize)> {
+    // A variant declaration line: leading whitespace, a CamelCase ident,
+    // then `,`, `{`, `(`, `=`, or end-of-line — never `::` (a path) or `(`
+    // preceded by lowercase (a fn call). Attributes (`#[...]`) and doc
+    // comments (`///`, `//`) are skipped by requiring the ident to be the
+    // first token on the line.
+    let re = Regex::new(r"(?m)^[ \t]*(?P<name>[A-Z][A-Za-z0-9_]*)\s*(?:,|\{|\(|=|$)")
+        .expect("static regex compiles");
+    let mut out = Vec::new();
+    for caps in re.captures_iter(body) {
+        let m = caps.name("name").unwrap();
+        out.push((m.as_str().to_string(), body_offset + m.start()));
+    }
+    out
+}
+
+/// Does `variant` appear as an enforcement reference anywhere in `src/`
+/// outside its own enum declaration and outside comments? Bare word-
+/// boundary match: a reference to the variant name in Rust code is almost
+/// always error construction (`err!` / `require_*!` / `return Err(..)` / a
+/// match arm). Matching bare (not `Enum::Variant`) biases toward
+/// not-flagging on name collisions — the safe direction, since a false
+/// "unwired" claim is noise.
+fn has_enforcement_call_site(
+    variant: &str,
+    sources: &BTreeMap<std::path::PathBuf, String>,
+    enum_spans: &[EnumBodySpan],
+) -> bool {
+    let re =
+        Regex::new(&format!(r"\b{}\b", regex::escape(variant))).expect("escaped regex compiles");
+    for (file, source) in sources {
+        for m in re.find_iter(source) {
+            // Skip the occurrence inside the variant's own enum body.
+            let in_own_decl = enum_spans
+                .iter()
+                .any(|span| &span.file == file && m.start() >= span.start && m.start() < span.end);
+            if in_own_decl {
+                continue;
+            }
+            if line_is_commented(source, m.start()) {
+                continue;
+            }
+            return true;
+        }
+    }
+    false
+}
+
+fn unwired_candidate(decl: &VariantDecl) -> Candidate {
+    Candidate {
+        category: Category::UnwiredErrorVariant,
+        category_tag: Category::UnwiredErrorVariant.tag().to_string(),
+        handler: decl.name.clone(),
+        spec_silent_on: format!(
+            "error variant `{}::{}` is defined at {}:{} but has no enforcement \
+             call-site anywhere in `src/` — the named check is wired into no guard",
+            decl.enum_name, decl.name, decl.rel_file, decl.line
+        ),
+        suppression_hint: "wire the variant into the guard it names (a \
+                           `require!`/`require_*!`/`err!`/`return Err(..)` on the path it \
+                           should protect), or delete the dead variant if the invariant is \
+                           genuinely covered elsewhere"
+            .to_string(),
+        investigation_hint: "read the variant name and the path/handler it evidently guards, \
+                             then ask whether the missing enforcement is exploitable. If its \
+                             invariant is load-bearing (a signer / authority / limit the path \
+                             assumes), the absent guard is a REAL finding — grade it at the \
+                             impact ceiling of the path it fails to protect, NOT at a \
+                             dead-variant floor (an unwired global-authority guard is HIGH, not \
+                             LOW/INFO). If a different guard already covers the invariant \
+                             redundantly, or the variant is deprecated/placeholder, it is INFO."
+            .to_string(),
+        reason: "deterministic dead-guard sweep — the error enum was enumerated and each \
+                 variant grepped for an enforcement call-site in `src/`; an unwired guard is an \
+                 absence, which has no runnable reproducer"
+            .to_string(),
+        repro_harness: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_root(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("qedgen-dead-guard-{tag}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        dir
+    }
+
+    /// One enforced variant (`Unauthorized`, fired via `require!`) and one
+    /// unenforced variant (`AdminGuardMissing`, defined only) → exactly the
+    /// latter is emitted.
+    #[test]
+    fn flags_only_the_unenforced_variant() {
+        let root = tmp_root("basic");
+        std::fs::write(
+            root.join("src/errors.rs"),
+            r#"
+use anchor_lang::prelude::*;
+
+#[error_code]
+pub enum MyError {
+    #[msg("caller is not authorized")]
+    Unauthorized,
+    #[msg("admin guard was never wired")]
+    AdminGuardMissing,
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            r#"
+use crate::errors::MyError;
+pub fn handler(is_admin: bool) -> Result<()> {
+    require!(is_admin, MyError::Unauthorized);
+    Ok(())
+}
+"#,
+        )
+        .unwrap();
+
+        let cands = scan_program(&root).unwrap();
+        let names: Vec<&str> = cands.iter().map(|c| c.handler.as_str()).collect();
+        assert_eq!(names, vec!["AdminGuardMissing"], "got {names:?}");
+        let c = &cands[0];
+        assert_eq!(c.category_tag, "unwired_error_variant");
+        assert!(c.spec_silent_on.contains("MyError::AdminGuardMissing"));
+        assert!(c.spec_silent_on.contains("src/errors.rs:"));
+        assert!(c.repro_harness.is_none());
+        // Severity rule must ride along so the model does not mis-rate it low.
+        assert!(c.investigation_hint.contains("impact ceiling"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A variant referenced only inside a `//` comment is still unwired.
+    #[test]
+    fn commented_reference_does_not_count_as_enforcement() {
+        let root = tmp_root("commented");
+        std::fs::write(
+            root.join("src/errors.rs"),
+            "#[error_code]\npub enum E {\n    NeverFired,\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "// TODO: return Err(E::NeverFired) when the guard is added\npub fn f() {}\n",
+        )
+        .unwrap();
+        let cands = scan_program(&root).unwrap();
+        assert_eq!(
+            cands.iter().map(|c| c.handler.as_str()).collect::<Vec<_>>(),
+            vec!["NeverFired"]
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// `return Err(E::X.into())` and a bare match-arm reference both count
+    /// as enforcement.
+    #[test]
+    fn return_err_and_match_arm_count_as_enforcement() {
+        let root = tmp_root("wired-forms");
+        std::fs::write(
+            root.join("src/errors.rs"),
+            "#[error_code]\npub enum E {\n    ViaReturn,\n    ViaMatch,\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            r#"
+fn a() -> Result<()> { return Err(E::ViaReturn.into()); }
+fn b(x: u8) -> Result<()> {
+    match x {
+        0 => Err(E::ViaMatch.into()),
+        _ => Ok(()),
+    }
+}
+"#,
+        )
+        .unwrap();
+        let cands = scan_program(&root).unwrap();
+        assert!(
+            cands.is_empty(),
+            "both wired; got {:?}",
+            cands.iter().map(|c| &c.handler).collect::<Vec<_>>()
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// No `#[error_code]` enum → clean no-op, not a false positive.
+    #[test]
+    fn no_error_enum_is_a_silent_noop() {
+        let root = tmp_root("no-enum");
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub enum Plain { A, B }\npub fn f() {}\n",
+        )
+        .unwrap();
+        assert!(scan_program(&root).unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A `{` inside a `#[msg("...")]` string must not truncate the enum body.
+    #[test]
+    fn brace_in_msg_string_does_not_truncate_body() {
+        let root = tmp_root("brace-in-msg");
+        std::fs::write(
+            root.join("src/errors.rs"),
+            "#[error_code]\npub enum E {\n    #[msg(\"unbalanced { brace in message\")]\n    FirstVariant,\n    SecondVariant,\n}\n",
+        )
+        .unwrap();
+        // Neither is referenced → both should be flagged; the point is that
+        // SecondVariant is still SEEN (the body didn't end at the `{`).
+        let cands = scan_program(&root).unwrap();
+        let mut names: Vec<&str> = cands.iter().map(|c| c.handler.as_str()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["FirstVariant", "SecondVariant"],
+            "got {names:?}"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/qedgen/src/probe/mod.rs
+++ b/crates/qedgen/src/probe/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod cluster;
 pub(crate) mod crucible_brownfield;
 pub(crate) mod crucible_probe;
 pub(crate) mod crucible_replay;
+pub(crate) mod dead_guard_probe;
 pub(crate) mod domain_account_overlay;
 pub(crate) mod domain_extract;
 pub(crate) mod domain_interview;
@@ -169,6 +170,15 @@ pub enum Category {
     /// interface). Deterministic cross-check; emitted as a candidate, not
     /// a finding — there is no runnable reproducer for drift by nature.
     IdlSourceDrift,
+    /// Dead-guard sweep (#240): an error-enum variant that is *defined* but
+    /// has no enforcement call-site anywhere in the crate's `src/` — the
+    /// maintainer named a check (the variant often spells out the invariant)
+    /// that no `require!` / `err!` / `return Err` ever fires, so the path it
+    /// was meant to protect proceeds unchecked. Deterministic (enumerate the
+    /// enum, grep each variant); emitted as a candidate, not a finding — an
+    /// absence has no runnable reproducer. The model triages and grades it at
+    /// the impact ceiling of the unguarded path, not a dead-variant floor.
+    UnwiredErrorVariant,
 }
 
 impl Category {
@@ -207,6 +217,7 @@ impl Category {
                 "external_authority_not_revoked_on_close"
             }
             Category::IdlSourceDrift => "idl_source_drift",
+            Category::UnwiredErrorVariant => "unwired_error_variant",
         }
     }
 }
@@ -1061,12 +1072,20 @@ pub fn run_bootstrap(project_root: &Path) -> Result<ProbeOutput> {
     // surface source/IDL handler-set drift as candidates.
     let overlay = idl_overlay::apply(project_root, &runtime, &mut handlers, &applicable);
 
+    // #240: deterministic dead-guard sweep — every `#[error_code]` variant
+    // defined but wired into no enforcement call-site in `src/` becomes an
+    // `unwired_error_variant` candidate for the model to triage. Runs on the
+    // spec-less envelope (source-scanner lens the bootstrap previously
+    // lacked); a no-op where there is no error enum.
+    let mut candidates = overlay.drift_candidates;
+    candidates.extend(dead_guard_probe::scan_program(project_root).unwrap_or_default());
+
     Ok(ProbeOutput {
         project_root: Some(project_root.display().to_string()),
         runtime: Some(runtime),
         handlers: Some(handlers),
         applicable_categories: Some(applicable),
-        candidates: overlay.drift_candidates,
+        candidates,
         idl_path: overlay.idl_path,
         derivable_idl: overlay.derivable_idl,
         dispatcher_kind,

--- a/crates/qedgen/src/probe/probe_repro.rs
+++ b/crates/qedgen/src/probe/probe_repro.rs
@@ -163,6 +163,9 @@ pub fn construct_reproducer(
         // deterministic cross-check has no runnable reproducer, so it never
         // flows through this dispatcher.
         Category::IdlSourceDrift => Err(ConstructFailure::NotImplemented),
+        // #240: an unwired error variant is an *absence* (a guard never
+        // called) — born as a candidate in `dead_guard_probe`, no reproducer.
+        Category::UnwiredErrorVariant => Err(ConstructFailure::NotImplemented),
     }
 }
 

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/Anchor.toml
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/Anchor.toml
@@ -1,0 +1,2 @@
+[programs.localnet]
+unwired = "Unwired11111111111111111111111111111111111"

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/Cargo.toml
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "unwired"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anchor-lang = "0.30"

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/src/errors.rs
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/src/errors.rs
@@ -1,0 +1,18 @@
+use anchor_lang::prelude::*;
+
+// Two variants are wired into guards below; one is defined but never
+// enforced anywhere in src/ — the #240 dead-guard sweep must flag ONLY the
+// last one as `unwired_error_variant`.
+#[error_code]
+pub enum VaultError {
+    #[msg("caller is not the vault authority")]
+    Unauthorized,
+    #[msg("amount exceeds the configured cap")]
+    AmountTooLarge,
+    // Defined but wired into no guard — the named check never fires, so the
+    // path it was meant to protect (a hook authority that must not be one of
+    // the hook accounts) proceeds unchecked. This is the load-bearing dead
+    // guard the sweep exists to surface.
+    #[msg("hook authority must not be part of the hook accounts")]
+    HookAuthorityCannotBePartOfHookAccounts,
+}

--- a/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/src/lib.rs
+++ b/crates/qedgen/tests/fixtures/probe-corpus/specless/anchor-unwired-guard/src/lib.rs
@@ -1,0 +1,25 @@
+use anchor_lang::prelude::*;
+
+pub mod errors;
+use crate::errors::VaultError;
+
+declare_id!("Unwired11111111111111111111111111111111111");
+
+#[program]
+pub mod unwired {
+    use super::*;
+
+    // `Unauthorized` is wired via require!, `AmountTooLarge` via a
+    // return Err — both must stay silent. `HookAuthorityCannotBePartOfHookAccounts`
+    // is defined in errors.rs but referenced nowhere → the sole candidate.
+    pub fn withdraw(ctx: Context<Withdraw>, amount: u64, is_authority: bool) -> Result<()> {
+        require!(is_authority, VaultError::Unauthorized);
+        if amount > 1_000 {
+            return Err(VaultError::AmountTooLarge.into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Withdraw {}

--- a/crates/qedgen/tests/probe_corpus.rs
+++ b/crates/qedgen/tests/probe_corpus.rs
@@ -20,7 +20,8 @@
 //! - `specless/<scenario>/` — brownfield project trees exercising the #235
 //!   IDL-enrichment overlay end to end (enrich, framework-enforced
 //!   narrowing, source/IDL drift, Pinocchio handler fill, derivable-IDL
-//!   hint on a marker-without-IDL and on an unbuilt framework checkout).
+//!   hint on a marker-without-IDL and on an unbuilt framework checkout, and
+//!   the #240 dead-guard / unwired-error-variant sweep).
 //!
 //! These are pass/fail *regression* tests, not a metric: they pin that a
 //! shipped predicate keeps firing on its vuln fixture and stays silent on
@@ -280,5 +281,42 @@ fn unbuilt_anchor_without_idl_reports_derivable_anchor() {
     assert_eq!(
         env.get("derivable_idl").and_then(Value::as_str),
         Some("anchor")
+    );
+}
+
+/// #240 dead-guard sweep: an `#[error_code]` variant defined but wired into
+/// no enforcement call-site surfaces as an `unwired_error_variant` candidate;
+/// variants that ARE enforced (require! / return Err) stay silent. The sweep
+/// runs on the spec-less envelope (a source lens the bootstrap previously
+/// lacked) and emits candidates, never reproducer-backed findings.
+#[test]
+fn unwired_error_variant_surfaces_as_candidate() {
+    let env = probe(&[
+        "--bootstrap",
+        "--root",
+        &specless_root("anchor-unwired-guard"),
+    ]);
+
+    let unwired: Vec<&str> = env
+        .get("candidates")
+        .and_then(Value::as_array)
+        .unwrap()
+        .iter()
+        .filter(|c| c.get("category_tag").and_then(Value::as_str) == Some("unwired_error_variant"))
+        .filter_map(|c| c.get("handler").and_then(Value::as_str))
+        .collect();
+
+    // Exactly the defined-but-unenforced variant; the two wired ones are silent.
+    assert_eq!(
+        unwired,
+        vec!["HookAuthorityCannotBePartOfHookAccounts"],
+        "got {unwired:?}"
+    );
+
+    // A dead guard is an absence — it must be a candidate, never a finding.
+    let findings = tags_of(&env, "findings");
+    assert!(
+        !findings.contains(&"unwired_error_variant"),
+        "unwired variant must not be a reproducer-backed finding: {findings:?}"
     );
 }

--- a/references/cli.md
+++ b/references/cli.md
@@ -405,6 +405,19 @@ the built IDL), a `shank`/`codama` dep or codama config file is one
 `shank idl` / `codama run` away. A hint for the agent, the CLI does not
 shell out.
 
+v2.44 (#240) also runs a **dead-guard / unwired-error-variant sweep** on
+every spec-less envelope: each `#[error_code]` enum variant that is defined
+but has no enforcement call-site (`require!` / `require_*!` / `err!` /
+`return Err(.. Variant ..)` / a match arm) anywhere in `src/` surfaces as an
+`unwired_error_variant` entry in `candidates[]` (`handler` = the variant,
+`spec_silent_on` = its definition `file:line`). A named-but-never-fired
+error is a guard that exists in name only — the path it was meant to protect
+proceeds unchecked. Deterministic (enumerate the enum, grep each variant),
+so it is a candidate, never a reproducer-backed finding; the
+`investigation_hint` carries the severity rule (grade at the impact ceiling
+of the unguarded path, not a dead-variant floor). No `#[error_code]` enum →
+no candidates (clean no-op, not a false positive).
+
 ```bash
 # Spec-aware
 $QEDGEN probe --spec my_program.qedspec

--- a/skills/qedgen-auditor/references/manual-review-passes.md
+++ b/skills/qedgen-auditor/references/manual-review-passes.md
@@ -234,22 +234,33 @@ output format in [report-and-grading.md](report-and-grading.md).
    the invariant) but no call site ever fires it, so the path it was meant
    to protect proceeds unchecked. This class is invisible to the per-category
    catalog and to 3a–3e: there IS no guard to find a coverage gap against;
-   the guard exists in name only. Run it on every audit — it is mechanical
-   and high signal.
+   the guard exists in name only.
 
-   1. **Enumerate the program's error enum.** List every variant of the
-      `errors.rs` (or equivalent) error type.
-   2. **Grep each variant for an enforcement call-site** in the program
-      tree: `require!` / `require_*!` / `err!` / `return Err(.. Variant ..)`
-      / a `match` arm that returns it. Auto-generated SDK / IDL / TypeScript
-      / doc references do NOT count — they mirror the enum, they don't
-      enforce it. Restrict the grep to the program crate's `src/`.
-   3. **Any variant with zero enforcement call-sites is a candidate.** Read
-      the variant name and the handler/path it was evidently meant to guard,
-      then ask: is the missing enforcement exploitable? A dead variant whose
-      invariant is load-bearing (a signer/authority/limit the path assumes)
-      is a real finding; a dead variant that a *different* guard already
-      covers redundantly is INFO.
+   **Mechanized (#240): qedgen runs the enumeration + grep for you.** The
+   probe envelope now carries the candidate list — every `#[error_code]`
+   variant with zero enforcement call-sites in `src/` appears as an
+   `unwired_error_variant` candidate (`handler` = the variant, `spec_silent_on`
+   = its definition `file:line`). Read them off `candidates[]`; do NOT
+   re-derive the sweep by hand — an earlier benchmark run showed free-form
+   manual review under-executes it (one run missed the class, another mis-rated
+   it). Your job is step 3 below: triage each candidate and grade it.
+
+   1. **Enumerate + grep — done by the probe.** (Historically manual:
+      enumerate the `errors.rs` error enum, grep each variant for a
+      `require!` / `require_*!` / `err!` / `return Err(.. Variant ..)` /
+      match-arm call-site in `src/`, excluding SDK/IDL/TS/doc mirrors. The
+      probe's `unwired_error_variant` candidates ARE this result.) On a tree
+      the probe cannot parse, fall back to running the grep by hand.
+   2. **Confirm the grep** for any candidate you intend to file — one bare-name
+      reference the sweep counts as enforcement can still be a non-enforcing
+      use (a log line, a display arm), so a variant the sweep left *un*flagged
+      is occasionally still dead; spot-check the load-bearing ones.
+   3. **Triage each candidate.** Read the variant name and the handler/path it
+      was evidently meant to guard, then ask: is the missing enforcement
+      exploitable? A dead variant whose invariant is load-bearing (a
+      signer/authority/limit the path assumes) is a real finding; a dead
+      variant that a *different* guard already covers redundantly, or a
+      deprecated/placeholder variant, is INFO.
 
    High signal-to-noise: a named-but-unused error is a strong signal that an
    intended check was dropped or never wired. Corpus: a defined-but-never-


### PR DESCRIPTION
Closes #240.

## Why

The auditor skill's §3f dead-guard pass is documented as *mandatory* — "run it on every audit — it is mechanical and high signal" — yet an N=2 benchmark run showed a strong model under-executes the prose pass: one run concluded "no unwired guards found," the other found the mechanism but graded it LOW (the exact mis-rating §3f's severity rule warns against). The sweep is fully deterministic, so it belongs in the tool. "qedgen greps; the model judges."

## What

- **`probe/dead_guard_probe.rs`** — enumerate every `#[error_code]` variant (brace-matched enum body, so a `{` inside a `#[msg("…")]` string can't truncate it), grep each for an enforcement call-site in `src/` (excluding comments and its own declaration), emit one `Candidate` per zero-call-site variant.
- It's a **`Candidate`, never a `Finding`** — a guard never called is an *absence*, which has no runnable reproducer. The `investigation_hint` carries the severity-ceiling rule so the model grades it at the impact ceiling of the unguarded path, not a dead-variant floor.
- **Wired into `run_bootstrap`**, so every path (spec-less `--bootstrap` and `--program`) surfaces it. Conservative: a bare-name reference counts as wired (biases toward *not* flagging), so only provably-dead variants surface; no `#[error_code]` enum → clean no-op.

On the benchmark target this reduced 127 error variants to 8 zero-call-site candidates — including the load-bearing authority-guard variant the manual runs missed.

## Tests / docs

- 5 unit tests (enforced-vs-unenforced, commented reference, `return Err`/match-arm forms, no-enum no-op, brace-in-msg body span).
- Corpus fixture `anchor-unwired-guard` + `probe_corpus.rs` regression test (asserts exactly the dead variant, and never as a finding).
- §3f prose now reads candidates off the envelope instead of re-deriving by hand; `references/cli.md` envelope doc updated.
- Full suite green (24 ok-suites), fmt + clippy clean.