### PR TITLE
fix(cli): accept --json on qedgen probe (#251)

### DIFF
--- a/crates/qedgen/src/cli.rs
+++ b/crates/qedgen/src/cli.rs
@@ -408,6 +408,12 @@ pub(crate) enum Commands {
         /// `rustc` on PATH (soft dependency).
         #[arg(long)]
         execute_repros: bool,
+
+        /// Accepted for CLI consistency with sibling subcommands
+        /// (`verify --json`, `readiness --json`); probe output is
+        /// always the JSON envelope, so this flag is a no-op (#251).
+        #[arg(long)]
+        json: bool,
     },
 
     /// Ratify a scaffold-to-spec interview into a `.qedspec` + side-files.
@@ -1299,6 +1305,24 @@ pub(crate) enum AristotleCommands {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn probe_bootstrap_accepts_json_flag() {
+        // #251: probe output is always JSON, but the flag learned on
+        // sibling subcommands must parse instead of hard-erroring.
+        let cli = Cli::try_parse_from([
+            "qedgen", "probe", "--bootstrap", "--root", "p", "--json",
+        ])
+        .expect("--json must parse on probe");
+        let Commands::Probe {
+            bootstrap, json, ..
+        } = cli.command
+        else {
+            panic!("expected probe command");
+        };
+        assert!(bootstrap);
+        assert!(json);
+    }
 
     #[test]
     fn parses_explicit_domain_crucible_mode() {

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -367,6 +367,9 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             emit_spec_candidates,
             audit_dir,
             execute_repros,
+            // Output is unconditionally JSON; the flag exists only so the
+            // `--json` habit learned on sibling subcommands parses (#251).
+            json: _,
         } => {
             // --program routes through the Pinocchio site enumerator; the
             // envelope's `findings` are the site catalogue mapped 1:1. The


### PR DESCRIPTION
`qedgen probe --bootstrap --root <p> --json` failed with `error: unexpected argument '--json' found` even though probe's output is already unconditionally JSON, and `--json` is an accepted flag on sibling subcommands (`verify --probe-repros --json`, `readiness --json`).

This adds an accept-and-ignore `--json` flag to the `Probe` variant (documented as a no-op for CLI consistency) plus a CLI parse test asserting `probe --bootstrap --root <p> --json` parses and carries the flag.

Closes #251