### PR TITLE
fix(install): refuse to keep a version-skewed bin/qedgen silently (#252)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,10 +120,23 @@ build_from_source() {
 }
 
 # ── Install qedgen binary ───────────────────────────────────────────────
-if [ -f "$QEDGEN_BIN" ] && [ -x "$QEDGEN_BIN" ] && "$QEDGEN_BIN" --version &> /dev/null; then
-    echo "✓ Pre-built qedgen binary is compatible"
+# The checkout's Cargo.toml is the source of truth for the expected
+# version. A pre-existing bin/qedgen is kept ONLY if it matches $VERSION:
+# a stale binary from an earlier install still runs, but fails on newer
+# specs with errors that look like spec bugs, not version skew.
+existing_version=""
+if [ -f "$QEDGEN_BIN" ] && [ -x "$QEDGEN_BIN" ]; then
+    existing_version="$("$QEDGEN_BIN" --version 2>/dev/null | awk '{print $2}')"
+fi
+
+if [ -n "$existing_version" ] && [ "v$existing_version" = "$VERSION" ]; then
+    echo "✓ Pre-built qedgen binary is current (${VERSION})"
 else
-    echo "Pre-built binary missing or incompatible."
+    if [ -n "$existing_version" ]; then
+        echo "Pre-built binary is v${existing_version}; this checkout expects ${VERSION} — refreshing."
+    else
+        echo "Pre-built binary missing or not runnable."
+    fi
 
     asset_name=$(detect_asset_name 2>/dev/null || true)
     installed=false
@@ -137,9 +150,24 @@ else
     fi
 
     if [ "$installed" = false ]; then
-        echo "  Release binary unavailable, falling back to source compilation..."
-        build_from_source
-        echo "✓ qedgen binary built from source"
+        if command -v cargo &> /dev/null; then
+            echo "  Release binary unavailable, falling back to source compilation..."
+            build_from_source
+            echo "✓ qedgen binary built from source"
+        elif [ -n "$existing_version" ]; then
+            # No download, no toolchain: keep the stale binary rather than
+            # leave nothing, but say so loudly (never "✓ compatible").
+            STALE_KEPT=true
+            echo ""
+            echo "  WARNING: could not refresh qedgen — keeping STALE binary v${existing_version},"
+            echo "           but this skill checkout is ${VERSION}. Newer specs may fail with"
+            echo "           confusing parse/validation errors. Install Rust (https://rustup.rs)"
+            echo "           or restore network access, then re-run install.sh."
+            echo ""
+        else
+            # No binary at all — surfaces the rustup instructions and exits.
+            build_from_source
+        fi
     fi
 fi
 
@@ -166,7 +194,11 @@ fi
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  qedgen ${VERSION} installed successfully!"
+if [ "${STALE_KEPT:-false}" = true ]; then
+    echo "  qedgen ${VERSION} NOT installed — stale v${existing_version} kept (see warning above)."
+else
+    echo "  qedgen ${VERSION} installed successfully!"
+fi
 echo ""
 if [ "${PATH_LINKED:-false}" = true ] && [ "${ON_PATH:-false}" = true ]; then
     echo "  qedgen is on your PATH — run \`qedgen --help\` to confirm."


### PR DESCRIPTION
install.sh kept any *working* `bin/qedgen` forever — the gate was `--version &> /dev/null`, so a v2.15.1 leftover under a v2.43+ checkout was declared "✓ compatible" and every post-2.27 spec feature then failed with parse/validation errors that look like spec bugs, not version skew.

The gate now compares the binary's `--version` output against the Cargo.toml-derived `$VERSION`:

- **match** → kept, message names the version;
- **mismatch** → re-download the pinned release asset (existing checksum-verified path), falling back to source build;
- **mismatch + no download + no cargo** → keep the stale binary rather than leave nothing, but print a loud warning naming both versions, and the closing banner says `NOT installed — stale vX kept` instead of "installed successfully".

Validated in a sandboxed skill tree: match kept; stale v2.15.1 stub refreshed to the real v2.45.0 release asset (checksum verified); 404 + cargo-less PATH produced the warning + honest banner with exit 0.

The reporter's suggested runtime-side skew warning in `qedgen check` is intentionally not included here — tracked as a follow-up if wanted.

Closes #252