### PR TITLE
fix(auditor): type-wrong domain-artifact fields fail cleanly instead of crashing jq (#250)

### DIFF
--- a/skills/qedgen-auditor/scripts/check-domain-artifacts.sh
+++ b/skills/qedgen-auditor/scripts/check-domain-artifacts.sh
@@ -30,6 +30,7 @@ done
 validate_dossier() {
   jq -e '
     def enum($values): . as $value | ($values | index($value)) != null;
+    def obj: type == "object";
     def stable_id: type == "string" and test("^[a-z][a-z0-9_-]*$");
     def structural_id: type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_.:-]*$");
     def anchor:
@@ -52,14 +53,14 @@ validate_dossier() {
     (.target.program_root | type == "string" and length > 0) and
     (.target.runtime | enum(["anchor", "pinocchio", "native-rust", "quasar", "qedgen-codegen", "sbpf", "unknown"])) and
     (.target.mode | enum(["spec-aware", "spec-less"])) and
-    (.handlers | type == "array" and all(.[];
+    (.handlers | type == "array" and all(.[]; obj and
       (.name | type == "string" and length > 0) and
       ((.source_path == null) or (.source_path | type == "string" and length > 0)) and
       ((.accounts_type == null) or (.accounts_type | type == "string" and length > 0)) and
-      (.args | type == "array" and all(.[];
+      (.args | type == "array" and all(.[]; obj and
         (.name | type == "string" and length > 0) and
         ((.qedspec_type == null) or (.qedspec_type | type == "string" and length > 0)))))) and
-    (.structural_candidates | type == "array" and all(.[];
+    (.structural_candidates | type == "array" and all(.[]; obj and
       (.id | structural_id) and
       (.kind | type == "string" and length > 0) and
       (.scope | type == "string" and length > 0) and
@@ -68,7 +69,7 @@ validate_dossier() {
       (.probe_confidence | enum(["high", "medium", "low"])) and
       (.ratification | enum(["pending", "user", "rejected", "bug"])) and
       (if (.ratification == "rejected" or .ratification == "bug") then (.rationale | type == "string" and length > 0) else true end))) and
-    (.asset_flows | type == "array" and all(.[];
+    (.asset_flows | type == "array" and all(.[]; obj and
       (.id | stable_id) and
       (.handler | type == "string" and length > 0) and
       (.asset | type == "string" and length > 0) and
@@ -76,41 +77,41 @@ validate_dossier() {
       (.destination | type == "string" and length > 0) and
       (.nominal_amount | type == "string" and length > 0) and
       (.metadata | metadata))) and
-    (.quantities | type == "array" and all(.[];
+    (.quantities | type == "array" and all(.[]; obj and
       (.id | stable_id) and
       (.symbol | type == "string" and length > 0) and
       (.unit | type == "string" and length > 0) and
       (.scale | type == "string" and length > 0) and
       (.rounding | enum(["exact", "floor", "ceil", "nearest", "unknown"])) and
       (.metadata | metadata))) and
-    (.paired_operations | type == "array" and all(.[];
+    (.paired_operations | type == "array" and all(.[]; obj and
       (.id | stable_id) and
       (.left_operation | type == "string" and length > 0) and
       (.right_operation | type == "string" and length > 0) and
       (.relationship | type == "string" and length > 0) and
       (.metadata | metadata))) and
-    (.lifecycle_edges | type == "array" and all(.[];
+    (.lifecycle_edges | type == "array" and all(.[]; obj and
       (.id | stable_id) and
       (.account | type == "string" and length > 0) and
       (.handler | type == "string" and length > 0) and
       (.from | type == "string" and length > 0) and
       (.to | type == "string" and length > 0) and
       (.metadata | metadata))) and
-    (.authority_capabilities | type == "array" and all(.[];
+    (.authority_capabilities | type == "array" and all(.[]; obj and
       (.id | stable_id) and
       (.role | type == "string" and length > 0) and
       (.identity_anchor | type == "string" and length > 0) and
       (.handler | type == "string" and length > 0) and
       (.effects | type == "array" and length > 0) and
       (.metadata | metadata))) and
-    (.economic_equations | type == "array" and all(.[];
+    (.economic_equations | type == "array" and all(.[]; obj and
       (.id | stable_id) and
       (.name | type == "string" and length > 0) and
       (.expression | type == "string" and length > 0) and
       (.scope | type == "array" and length > 0) and
       (.tolerance | type == "string" and length > 0) and
       (.metadata | metadata))) and
-    (.external_assumptions | type == "array" and all(.[];
+    (.external_assumptions | type == "array" and all(.[]; obj and
       (.id | stable_id) and
       (.kind | enum(["oracle", "token", "cpi", "clock", "keeper", "governance", "dependency", "other"])) and
       (.claim | type == "string" and length > 0) and
@@ -126,6 +127,7 @@ validate_dossier() {
 validate_manifest() {
   jq -e '
     def enum($values): . as $value | ($values | index($value)) != null;
+    def obj: type == "object";
     def stable_id: type == "string" and test("^[a-z][a-z0-9_-]*$");
     .schema_version == 1 and
     .schema_uri == "https://qedgen.dev/schemas/auditor/audit-run-manifest-v1.schema.json" and
@@ -134,7 +136,7 @@ validate_manifest() {
     (.target | type == "object") and
     (.target.program_root | type == "string" and length > 0) and
     (.target.mode | enum(["spec-aware", "spec-less"])) and
-    (.lanes | type == "array" and length > 0 and all(.[];
+    (.lanes | type == "array" and length > 0 and all(.[]; obj and
       (.name | enum(["source-review", "ordinary-probe", "compile", "mollusk", "miri", "crucible-protocol", "crucible-skeleton", "crucible-domain"])) and
       (.status | enum(["not-run", "queued", "running", "passed", "failed", "blocked", "not-applicable"])) and
       (if .status == "blocked" then
@@ -151,6 +153,7 @@ validate_manifest() {
 validate_handoff() {
   jq -e '
     def enum($values): . as $value | ($values | index($value)) != null;
+    def obj: type == "object";
     def clause:
       type == "object" and
       (.candidate_id | type == "string" and length > 0) and
@@ -170,7 +173,7 @@ validate_handoff() {
     (.layers.structural | type == "array" and all(.[]; clause)) and
     (.layers.domain | type == "array" and all(.[]; clause)) and
     (.layers.regression | type == "array" and all(.[]; clause)) and
-    (.language_gaps | type == "array" and all(.[];
+    (.language_gaps | type == "array" and all(.[]; obj and
       (.candidate_id | type == "string" and length > 0) and
       (.reason | type == "string" and length > 0) and
       (.current_language_support | type == "string" and length > 0) and
@@ -181,6 +184,7 @@ validate_handoff() {
 validate_sequences() {
   jq -e '
     def enum($values): . as $value | ($values | index($value)) != null;
+    def obj: type == "object";
     def unresolved:
       type == "object" and
       (.name | type == "string" and length > 0) and
@@ -194,7 +198,7 @@ validate_sequences() {
       (.unresolved_parameters | type == "array" and all(.[]; unresolved));
     .schema_version == 1 and
     .schema_uri == "https://qedgen.dev/schemas/auditor/domain-sequences-v1.schema.json" and
-    (.plans | type == "array" and all(.[];
+    (.plans | type == "array" and all(.[]; obj and
       (.id | type == "string" and length > 0) and
       (.kind | enum(["paired_round_trip", "lifecycle_transition"])) and
       (.title | type == "string" and length > 0) and
@@ -204,7 +208,7 @@ validate_sequences() {
       (.teardown | type == "array" and all(.[]; action)) and
       (.provenance_candidate_ids | type == "array" and length > 0) and
       (.unresolved_parameters | type == "array" and all(.[]; unresolved)))) and
-    (.exclusions | type == "array" and all(.[];
+    (.exclusions | type == "array" and all(.[]; obj and
       (.candidate_id | type == "string" and length > 0) and
       (.collection | enum(["paired_operations", "lifecycle_edges"])) and
       (.ratification | enum(["auto", "user", "pending", "rejected", "bug"])) and
@@ -219,11 +223,13 @@ validate_sequence_bindings() {
     .schema_uri == "https://qedgen.dev/schemas/auditor/domain-sequence-bindings-v1.schema.json" and
     .source_sequence_schema_uri == "https://qedgen.dev/schemas/auditor/domain-sequences-v1.schema.json" and
     ((.source_audit_id == null) or (.source_audit_id | type == "string" and length > 0)) and
-    (.bindings | type == "array" and all(.[];
+    (.bindings | type == "array" and all(.[]; (type == "object") and
       (.plan_id | type == "string" and length > 0) and
       ((.action == null) or
-       ((.action.phase | IN("setup", "forward", "reverse", "teardown")) and
+       ((.action | type == "object") and
+        (.action.phase | IN("setup", "forward", "reverse", "teardown")) and
         (.action.index | type == "number" and . >= 0))) and
+      (.parameter | type == "object") and
       (.parameter.name | type == "string" and length > 0) and
       (.parameter.kind | kind)))
   ' "$1" >/dev/null
@@ -233,24 +239,27 @@ validate_resolved_sequences() {
   jq -e '
     def resolved_binding:
       type == "object" and
+      (.parameter | type == "object") and
       (.parameter.name | type == "string" and length > 0) and
+      (.provenance | type == "object") and
       .provenance.source == "user" and
       (.provenance.plan_id | type == "string" and length > 0);
     def action:
       type == "object" and
       (.handler | type == "string" and length > 0) and
       (.resolved_bindings | type == "array" and all(.[]; resolved_binding));
+    def actions: type == "array" and all(.[]; action);
     .schema_version == 1 and
     .schema_uri == "https://qedgen.dev/schemas/auditor/resolved-domain-sequences-v1.schema.json" and
     .source_sequence_schema_uri == "https://qedgen.dev/schemas/auditor/domain-sequences-v1.schema.json" and
     .source_bindings_schema_uri == "https://qedgen.dev/schemas/auditor/domain-sequence-bindings-v1.schema.json" and
-    (.plans | type == "array" and all(.[];
+    (.plans | type == "array" and all(.[]; (type == "object") and
       (.id | type == "string" and length > 0) and
-      (.setup | all(.[]; action)) and
-      (.forward | all(.[]; action)) and
-      (.reverse | all(.[]; action)) and
-      (.teardown | all(.[]; action)) and
-      (.resolved_plan_bindings | all(.[]; resolved_binding))))
+      (.setup | actions) and
+      (.forward | actions) and
+      (.reverse | actions) and
+      (.teardown | actions) and
+      (.resolved_plan_bindings | type == "array" and all(.[]; resolved_binding))))
   ' "$1" >/dev/null
 }
 
@@ -261,9 +270,10 @@ validate_account_overlay() {
     .source_resolved_sequence_schema_uri == "https://qedgen.dev/schemas/auditor/resolved-domain-sequences-v1.schema.json" and
     (.handlers | type == "object" and all(to_entries[];
       (.key | length > 0) and
+      (.value | type == "object") and
       (.value.accounts | type == "object" and all(to_entries[];
         (.key | length > 0) and
-        (.value | test("^fixture:[A-Za-z0-9_][A-Za-z0-9_.-]*$")))) and
+        (.value | type == "string" and test("^fixture:[A-Za-z0-9_][A-Za-z0-9_.-]*$")))) and
       (.value.provenance | type == "object")))
   ' "$1" >/dev/null
 }
@@ -276,7 +286,7 @@ validate_replay_report() {
     (.resolved_document_sha256 | sha256) and
     (.account_binding_overlay_sha256 | sha256) and
     (.harness_sha256 | sha256) and
-    (.records | type == "array" and length > 0 and all(.[];
+    (.records | type == "array" and length > 0 and all(.[]; (type == "object") and
       (.plan_id | type == "string" and length > 0) and
       (.seed_path | type == "string" and length > 0) and
       (.seed_sha256 | sha256) and
@@ -346,6 +356,16 @@ fi
 validate_dossier "$fixtures/valid-domain-dossier.json"
 if validate_dossier "$fixtures/invalid-domain-dossier.json"; then
   echo "invalid domain dossier fixture unexpectedly passed" >&2
+  exit 1
+fi
+
+# A type-wrong field (string args instead of objects) must be a CLEAN
+# validation failure (jq -e false → exit 1), not a jq runtime crash
+# (exit 5) — the crash was GH #250.
+rc=0
+validate_dossier "$fixtures/invalid-args-domain-dossier.json" || rc=$?
+if [[ $rc -ne 1 ]]; then
+  echo "string-typed handlers[].args fixture: expected clean invalid (exit 1), got exit $rc" >&2
   exit 1
 fi
 

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-args-domain-dossier.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-args-domain-dossier.json
@@ -1,0 +1,223 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/domain-dossier-v1.schema.json",
+  "audit_id": "fee_vault_20260714",
+  "target": {
+    "program_root": "programs/fee-vault",
+    "runtime": "anchor",
+    "mode": "spec-less",
+    "spec": null,
+    "source_commit": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "handlers": [
+    {
+      "name": "update_fee",
+      "source_path": "programs/fee-vault/src/update_fee.rs",
+      "accounts_type": "UpdateFee",
+      "args": [
+        "fee_bps",
+        "recipient"
+      ]
+    }
+  ],
+  "structural_candidates": [
+    {
+      "id": "c-fee-authority",
+      "kind": "account_signer_check",
+      "scope": "handler:update_fee",
+      "summary": "Fee updates authenticate the stored administrator.",
+      "suggested_syntax": "auth admin",
+      "probe_confidence": "high",
+      "ratification": "pending",
+      "rationale": null,
+      "finding_ids": [
+        "finding_fee_signer"
+      ],
+      "evidence_count": 1
+    }
+  ],
+  "asset_flows": [
+    {
+      "id": "flow_deposit",
+      "handler": "deposit",
+      "asset": "underlying_mint",
+      "source": "user_token_account",
+      "destination": "vault_token_account",
+      "nominal_amount": "amount",
+      "delivered_amount": "post_balance - pre_balance",
+      "fee_expression": null,
+      "authority": "user",
+      "state_mutations": [
+        "vault.total_assets += delivered_amount"
+      ],
+      "metadata": {
+        "confidence": "literal",
+        "ratification": "auto",
+        "rationale": "Transfer and measured balance delta are explicit.",
+        "source_anchors": [
+          {
+            "path": "programs/fee-vault/src/deposit.rs",
+            "line_start": 18,
+            "line_end": 29,
+            "symbol": "deposit",
+            "excerpt": "let delivered = post.checked_sub(pre)?;"
+          }
+        ],
+        "verification_lanes": [
+          "manual",
+          "mollusk",
+          "crucible"
+        ]
+      }
+    }
+  ],
+  "quantities": [
+    {
+      "id": "qty_total_assets",
+      "symbol": "vault.total_assets",
+      "unit": "underlying atoms",
+      "scale": "mint.decimals",
+      "rounding": "exact",
+      "valid_range": "0..=u64::MAX",
+      "conversions": [],
+      "metadata": {
+        "confidence": "derived",
+        "ratification": "pending",
+        "rationale": "Field name and transfer site imply underlying atoms.",
+        "source_anchors": [
+          {
+            "path": "programs/fee-vault/src/state.rs",
+            "line_start": 9,
+            "symbol": "Vault::total_assets",
+            "excerpt": "pub total_assets: u64"
+          }
+        ],
+        "verification_lanes": [
+          "manual",
+          "mollusk"
+        ]
+      }
+    }
+  ],
+  "paired_operations": [],
+  "lifecycle_edges": [
+    {
+      "id": "edge_initialize",
+      "account": "vault",
+      "handler": "initialize",
+      "from": "Uninitialized",
+      "to": "Active",
+      "guards": [
+        "vault.is_initialized == false"
+      ],
+      "terminal": false,
+      "metadata": {
+        "confidence": "literal",
+        "ratification": "auto",
+        "rationale": "The handler reads and sets is_initialized.",
+        "source_anchors": [
+          {
+            "path": "programs/fee-vault/src/initialize.rs",
+            "line_start": 14,
+            "line_end": 18,
+            "symbol": "initialize",
+            "excerpt": "require!(!vault.is_initialized);"
+          }
+        ],
+        "verification_lanes": [
+          "manual",
+          "crucible"
+        ]
+      }
+    }
+  ],
+  "authority_capabilities": [
+    {
+      "id": "cap_admin_fee",
+      "role": "admin",
+      "identity_anchor": "vault.admin == admin.key() && admin.is_signer",
+      "handler": "update_fee",
+      "effects": [
+        "vault.fee_bps"
+      ],
+      "limits": [
+        "fee_bps <= 10000"
+      ],
+      "revocation_path": null,
+      "metadata": {
+        "confidence": "literal",
+        "ratification": "auto",
+        "rationale": "Signer and has_one constraints are explicit.",
+        "source_anchors": [
+          {
+            "path": "programs/fee-vault/src/update_fee.rs",
+            "line_start": 7,
+            "line_end": 12,
+            "symbol": "UpdateFee",
+            "excerpt": "#[account(has_one = admin)]"
+          }
+        ],
+        "verification_lanes": [
+          "manual",
+          "mollusk",
+          "crucible"
+        ]
+      }
+    }
+  ],
+  "economic_equations": [
+    {
+      "id": "eq_asset_conservation",
+      "name": "vault asset conservation",
+      "expression": "vault.total_assets == deposits - withdrawals",
+      "scope": [
+        "deposit",
+        "withdraw"
+      ],
+      "tolerance": "0 underlying atoms",
+      "unit_check": "compatible",
+      "metadata": {
+        "confidence": "semantic",
+        "ratification": "pending",
+        "rationale": "Cross-handler sum requires protocol intent.",
+        "source_anchors": [
+          {
+            "path": "programs/fee-vault/src/state.rs",
+            "line_start": 9,
+            "symbol": "Vault::total_assets",
+            "excerpt": "pub total_assets: u64"
+          }
+        ],
+        "verification_lanes": [
+          "manual",
+          "crucible"
+        ]
+      }
+    }
+  ],
+  "external_assumptions": [
+    {
+      "id": "assume_token_delivery",
+      "kind": "token",
+      "claim": "Accounting uses measured delivery for fee-bearing mints.",
+      "failure_effect": "Recorded assets can exceed the vault token balance.",
+      "metadata": {
+        "confidence": "derived",
+        "ratification": "pending",
+        "rationale": "Token interface accepts Token-2022.",
+        "source_anchors": [
+          {
+            "path": "programs/fee-vault/src/deposit.rs",
+            "line_start": 18,
+            "symbol": "deposit",
+            "excerpt": "token_interface::transfer_checked"
+          }
+        ],
+        "verification_lanes": [
+          "manual",
+          "mollusk"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
`scripts/check-domain-artifacts.sh` aborted with a low-level jq internal error (`Cannot index string with string "name"`, exit 5) when a `domain-dossier.json` carried `handlers[].args` as an array of strings — or any other type-wrong field feeding an unguarded object-field access. The message named neither the offending field nor the required shape.

This makes every validator type-defensive:

- shared `def obj: type == "object"` guard on every array-element predicate across all eight validators (dossier, manifest, handoff, sequences, bindings, resolved-sequences, account overlay, replay report);
- nested-object accesses guarded too (`.parameter`, `.action`, `.provenance`, overlay `.value`), and two latent unchecked-array holes in `validate_resolved_sequences` (`.setup`/`.forward`/… and `.resolved_plan_bindings` had no `type == "array"` check) closed along the way;
- new fixture `invalid-args-domain-dossier.json` (string-typed args) + a self-test asserting it produces a **clean invalid** — exit 1, not jq's crash exit 5.

Verified: the fixture reproduced exit 5 before the change, exits 1 after; script self-test and `scripts/check-auditor-skill.sh` pass; installed copy synced via `scripts/sync-auditor-skill.sh`.

The issue's option 2 (delegating structural validation to a real JSON-Schema validator for instance-path error reporting) is deliberately not taken here — it would add a runtime dependency to a script that ships into end-user harnesses.

Closes #250