### PR TITLE
fix(probe,ratify): bootstrap→ratify lane works end-to-end (#248, #249)

### DIFF
--- a/crates/qedgen/src/probe/ratify.rs
+++ b/crates/qedgen/src/probe/ratify.rs
@@ -90,7 +90,16 @@ pub fn run(opts: &RatifyOpts) -> Result<RatifyReport> {
         .filter(|p| p.exists());
     let structured = answers_path.is_some();
 
-    let mut required: Vec<&Path> = vec![&clusters_path, &skeleton_path];
+    // skeleton.qedspec is the merge base and always required.
+    // clusters.json is optional for a hypotheses-only working set (#248:
+    // the bootstrap lane materializes hypotheses without proto-clause
+    // clusters) — ratify then proceeds on the hypothesis answers alone.
+    let hypotheses_path = opts.audit_dir.join("hypotheses.json");
+    let hypotheses_only = !clusters_path.exists() && hypotheses_path.exists();
+    let mut required: Vec<&Path> = vec![&skeleton_path];
+    if !hypotheses_only {
+        required.push(&clusters_path);
+    }
     if !structured {
         // Legacy path only — the structured answer set replaces the
         // user-edited interview file (PRD D4: in-harness, no file).
@@ -107,7 +116,6 @@ pub fn run(opts: &RatifyOpts) -> Result<RatifyReport> {
 
     // Hypotheses (present for working sets written after spec elicitation
     // landed; absent dirs stay supported).
-    let hypotheses_path = opts.audit_dir.join("hypotheses.json");
     let hypotheses_doc = hypotheses_path
         .exists()
         .then(|| elicit::read_hypotheses(&hypotheses_path))
@@ -149,8 +157,12 @@ pub fn run(opts: &RatifyOpts) -> Result<RatifyReport> {
         read_interview_file(&interview_path)?
     };
 
-    let clusters: Vec<Cluster> = serde_json::from_str(&std::fs::read_to_string(&clusters_path)?)
-        .with_context(|| format!("parsing clusters.json at {}", clusters_path.display()))?;
+    let clusters: Vec<Cluster> = if hypotheses_only {
+        Vec::new()
+    } else {
+        serde_json::from_str(&std::fs::read_to_string(&clusters_path)?)
+            .with_context(|| format!("parsing clusters.json at {}", clusters_path.display()))?
+    };
     let skeleton = std::fs::read_to_string(&skeleton_path)?;
 
     let cluster_by_id: BTreeMap<&str, &Cluster> =
@@ -1197,13 +1209,37 @@ fn render_bug_finding(cluster: &Cluster, ratification: &Ratification) -> String 
 
 // ── Defaults ──────────────────────────────────────────────────────────
 
+/// Project root for default output paths (#249). Priority:
+/// 1. the working set's recorded `target.program_root`
+///    (`run-manifest.json`) — authoritative, immune to audit-dir nesting;
+/// 2. the `.qed` ancestor convention — `.qed/audit/<ts>/` (or any
+///    nesting depth) resolves to the directory *containing* `.qed`.
+///    The old two-`.parent()` arithmetic landed on `<root>/.qed` itself
+///    and produced `<root>/.qed/.qed.qedspec`;
+/// 3. cwd.
+fn project_root_of(audit_dir: &Path) -> Option<PathBuf> {
+    if let Some(root) = manifest_program_root(audit_dir) {
+        return Some(root);
+    }
+    audit_dir
+        .ancestors()
+        .find(|a| a.file_name().is_some_and(|n| n == ".qed"))
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+}
+
+/// Read the `target.program_root` the probe recorded in
+/// `run-manifest.json`.
+fn manifest_program_root(audit_dir: &Path) -> Option<PathBuf> {
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(audit_dir.join("run-manifest.json")).ok()?)
+            .ok()?;
+    let root = manifest.get("target")?.get("program_root")?.as_str()?;
+    (!root.is_empty()).then(|| PathBuf::from(root))
+}
+
 fn default_spec_path(audit_dir: &Path) -> PathBuf {
-    // <project_root>/<project_name>.qedspec; `.qed/audit/<ts>/` → project
-    // root is two levels up. Fall back to cwd if non-conforming.
-    let project_root = audit_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .map(Path::to_path_buf);
+    let project_root = project_root_of(audit_dir);
     let name = project_root
         .as_ref()
         .and_then(|p| p.file_name())
@@ -1215,17 +1251,13 @@ fn default_spec_path(audit_dir: &Path) -> PathBuf {
 }
 
 fn default_scoping_path(audit_dir: &Path) -> PathBuf {
-    audit_dir
-        .parent()
-        .and_then(|p| p.parent())
+    project_root_of(audit_dir)
         .map(|root| root.join(".qed/plan/scoping.md"))
         .unwrap_or_else(|| PathBuf::from(".qed/plan/scoping.md"))
 }
 
 fn default_findings_dir(audit_dir: &Path) -> PathBuf {
-    audit_dir
-        .parent()
-        .and_then(|p| p.parent())
+    project_root_of(audit_dir)
         .map(|root| root.join(".qed/findings"))
         .unwrap_or_else(|| PathBuf::from(".qed/findings"))
 }
@@ -1810,6 +1842,98 @@ mod tests {
         assert_eq!(outcome["run_id"], "run-vault-123");
         assert_eq!(outcome["outcomes"][0]["outcome"], "lowered");
         assert!(outcome["time_to_ratify_seconds"].is_u64());
+        Ok(())
+    }
+
+    /// #248: a hypotheses-only working set (skeleton + hypotheses.json,
+    /// no clusters.json — the bootstrap lane's shape) must ratify on the
+    /// hypothesis answers alone instead of hard-requiring clusters.json.
+    #[test]
+    fn hypotheses_only_working_set_ratifies_without_clusters() -> Result<()> {
+        let dir = tempdir()?;
+        let audit = dir.path().join(".qed/audit/test");
+        std::fs::create_dir_all(&audit)?;
+        let skeleton = render_skeleton_from_handlers(&["set_fee".into()], "vault");
+        std::fs::write(audit.join("skeleton.qedspec"), &skeleton)?;
+        // NOTE: no clusters.json.
+        let hyp = auth_hypothesis("set_fee", "admin");
+        write_hypotheses(&audit, "run-vault-124", std::slice::from_ref(&hyp))?;
+        std::fs::write(
+            audit.join("answers.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "answers": [{ "id": hyp.id, "decision": "accept", "note": "" }]
+            }))?,
+        )?;
+
+        let report = run(&RatifyOpts {
+            audit_dir: audit,
+            spec_out: Some(dir.path().join("vault.qedspec")),
+            scoping_out: Some(dir.path().join("scoping.md")),
+            findings_dir: Some(dir.path().join("findings")),
+            answers: None,
+            proptest: false,
+        })?;
+        assert_eq!(report.hypotheses_lowered, 1);
+        let spec = std::fs::read_to_string(&report.spec_path)?;
+        assert!(spec.contains("auth admin"), "spec:\n{spec}");
+        Ok(())
+    }
+
+    /// #249: the conventional `.qed/audit/<ts>` audit dir must resolve
+    /// default outputs to `<root>/<name>.qedspec` and
+    /// `<root>/.qed/plan/scoping.md` — the old two-`.parent()` arithmetic
+    /// produced `<root>/.qed/.qed.qedspec`. Both relative and absolute.
+    #[test]
+    fn default_paths_resolve_qed_audit_convention() {
+        for audit in [
+            PathBuf::from("proj/.qed/audit/run-1"),
+            PathBuf::from("/abs/proj/.qed/audit/run-1"),
+        ] {
+            let spec = default_spec_path(&audit);
+            assert!(
+                spec.ends_with("proj/proj.qedspec"),
+                "audit {} -> spec {}",
+                audit.display(),
+                spec.display()
+            );
+            let scoping = default_scoping_path(&audit);
+            assert!(
+                scoping.ends_with("proj/.qed/plan/scoping.md"),
+                "audit {} -> scoping {}",
+                audit.display(),
+                scoping.display()
+            );
+            let findings = default_findings_dir(&audit);
+            assert!(
+                findings.ends_with("proj/.qed/findings"),
+                "audit {} -> findings {}",
+                audit.display(),
+                findings.display()
+            );
+        }
+    }
+
+    /// #249: `run-manifest.json`'s `target.program_root` is authoritative
+    /// over path arithmetic — non-conventional audit-dir nesting still
+    /// resolves to the recorded program root.
+    #[test]
+    fn default_paths_prefer_manifest_program_root() -> Result<()> {
+        let dir = tempdir()?;
+        let audit = dir.path().join("elsewhere/deep/audit-dir");
+        std::fs::create_dir_all(&audit)?;
+        let prog_root = dir.path().join("programs/vault");
+        std::fs::write(
+            audit.join("run-manifest.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "target": { "program_root": prog_root.display().to_string() }
+            }))?,
+        )?;
+        assert_eq!(default_spec_path(&audit), prog_root.join("vault.qedspec"));
+        assert_eq!(
+            default_scoping_path(&audit),
+            prog_root.join(".qed/plan/scoping.md")
+        );
+        assert_eq!(default_findings_dir(&audit), prog_root.join(".qed/findings"));
         Ok(())
     }
 

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -829,8 +829,28 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             let output = if bootstrap {
                 let root = root
                     .ok_or_else(|| anyhow::anyhow!("--bootstrap requires --root <project-path>"))?;
+                // #248: materialize the audit working set so the documented
+                // handoff (probe → answers.json → `qedgen ratify`) works
+                // from the spec-less bootstrap lane too. Previously these
+                // flags were accepted but silently dropped (`None` below),
+                // leaving the audit dir empty and ratify hard-erroring.
+                if let Some(dir) = audit_dir.as_ref().filter(|_| emit_spec_candidates) {
+                    let detected = probe::detect_runtime_public(&root);
+                    write_audit_working_set(
+                        dir,
+                        &root,
+                        &[],
+                        program_model::ProgramFramework::Native,
+                        run_helpers::dossier_runtime_label(&detected),
+                        /*lenient_skeleton=*/ true,
+                    )?;
+                }
                 let mut output = probe::run_bootstrap(&root)?;
-                probe::finalize_specless(&mut output, &root, None);
+                probe::finalize_specless(
+                    &mut output,
+                    &root,
+                    audit_dir.as_deref().filter(|_| emit_spec_candidates),
+                );
                 output
             } else {
                 let spec = spec.ok_or_else(|| {

--- a/crates/qedgen/tests/bootstrap_ratify_journey.rs
+++ b/crates/qedgen/tests/bootstrap_ratify_journey.rs
@@ -1,0 +1,77 @@
+//! Journey test for the documented spec-less elicitation handoff (#248,
+//! #249): `probe --bootstrap --emit-spec-candidates --audit-dir` →
+//! author `answers.json` → `ratify --audit-dir`, exactly as the auditor
+//! guidance prescribes. Before #248 the bootstrap branch silently
+//! dropped the audit dir (empty dir, ratify hard-error); before #249
+//! ratify wrote the spec to `<root>/.qed/.qed.qedspec`.
+
+mod common;
+
+use std::process::Command;
+
+#[test]
+fn bootstrap_probe_to_ratify_journey() {
+    common::ensure_qedgen_built();
+
+    let tmp = common::stage_fixture("crates/qedgen/tests/fixtures/probe-corpus/specless/native-shank-marker");
+    let root = tmp.path();
+    let audit = root.join(".qed/audit/journey-1");
+
+    // Step 1: bootstrap probe with working-set materialization.
+    let out = Command::new(common::qedgen_bin())
+        .args(["probe", "--bootstrap", "--root"])
+        .arg(root)
+        .args(["--emit-spec-candidates", "--audit-dir"])
+        .arg(&audit)
+        .output()
+        .expect("run qedgen probe --bootstrap");
+    assert!(
+        out.status.success(),
+        "bootstrap probe failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    for artifact in [
+        "clusters.json",
+        "skeleton.qedspec",
+        "hypotheses.json",
+        "run-manifest.json",
+    ] {
+        assert!(
+            audit.join(artifact).exists(),
+            "bootstrap --emit-spec-candidates --audit-dir must materialize {artifact} (#248); \
+             audit dir contents: {:?}",
+            std::fs::read_dir(&audit)
+                .map(|d| d.filter_map(|e| e.ok().map(|e| e.file_name())).collect::<Vec<_>>())
+                .unwrap_or_default()
+        );
+    }
+
+    // Step 2: author the (empty) structured answer set — the issue repro.
+    std::fs::write(audit.join("answers.json"), "{\"answers\":[]}\n").expect("write answers");
+
+    // Step 3: ratify consumes the working set with default output paths.
+    let out = Command::new(common::qedgen_bin())
+        .args(["ratify", "--audit-dir"])
+        .arg(&audit)
+        .current_dir(root)
+        .output()
+        .expect("run qedgen ratify");
+    assert!(
+        out.status.success(),
+        "ratify failed on the bootstrap working set: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // #249: default spec path is <root>/<name>.qedspec derived from the
+    // manifest's recorded program root — never <root>/.qed/.qed.qedspec.
+    let name = root.file_name().and_then(|n| n.to_str()).expect("root name");
+    assert!(
+        root.join(format!("{name}.qedspec")).exists(),
+        "ratified spec must land at <root>/{name}.qedspec; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !root.join(".qed/.qed.qedspec").exists(),
+        "doubled .qed/.qed.qedspec path must not reappear (#249)"
+    );
+}


### PR DESCRIPTION
Two bugs that together meant the documented spec-less elicitation handoff — `probe --bootstrap --emit-spec-candidates --audit-dir <dir>` → author `answers.json` → `ratify --audit-dir <dir>` — had never worked end-to-end.

**#248 — bootstrap probe silently dropped the audit dir.** `run.rs`'s `--bootstrap` branch passed `None` to `finalize_specless` and never called `write_audit_working_set`, so the flags parsed but the dir stayed empty and `ratify` hard-errored on the missing `clusters.json`. The branch now mirrors the `--program` generic-runtime fallback: materialize the working set (empty `clusters.json`, lenient `skeleton.qedspec`, `run-manifest.json`, domain seeds) and thread the audit dir through `finalize_specless` so `hypotheses.json` lands. Belt-and-braces, `ratify` also accepts a hypotheses-only working set (skeleton + hypotheses, no `clusters.json`) per the issue's option 2 — the skeleton stays hard-required since it is the merge base.

**#249 — ratify's default paths derived the project root with two `.parent()` calls**, but the documented convention `.qed/audit/<ts>/` is three components deep — the derived root was `<root>/.qed` and the spec was written to `<root>/.qed/.qed.qedspec`. Default paths now resolve the project root from the working set's recorded `run-manifest.json` `target.program_root` (authoritative, immune to non-conventional nesting), falling back to the `.qed`-ancestor convention (any depth), then cwd.

**Gates**: unit tests for manifest-priority and convention-arithmetic derivations (relative and absolute audit dirs) and the hypotheses-only acceptance; plus `bootstrap_ratify_journey.rs` — an end-to-end journey test that drives the real binary through the documented three-step sequence on a staged brownfield fixture and asserts the spec lands at `<root>/<name>.qedspec`, never the doubled path. This is the first of the journey-test pattern from the bug post-mortem: per-phase unit gates existed, but no test had ever executed the documented user sequence.

Full workspace suite green.

Closes #248
Closes #249