### PR TITLE
refactor(check): exhaustive-match SeverityCounts tally — no more open-coded severity filters (#270)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ The UX is **agent-first**: the user interacts with the SKILL (`SKILL.md`) and ag
 - When a template can't close a case, emit `sorry` with a comment — never bury it in tactics that might spuriously close.
 - Don't pre-shell to Leanstral/Aristotle for what a local LLM can do. Escalation is for *after* you've tried, not when you expect to need to.
 - The typed MIR (`mir.rs`) exists for bug-class elimination, not LoC: matches over the closed `Stmt` enum are exhaustive by discipline (no `_` arms — see the enum doc in `mir.rs`), so a new statement kind is a compile error at every `Stmt` consumer (Lean codegen, Rust scaffold, and the Kani/proptest effect lowering via `rust_codegen_util::stmt_effect_triple`), not silent drift. Conditional `effect { match … }` bodies lower to `Stmt::Branch` (Phase 5): Rust renders a `match`, the flat-state Lean transition applies exactly one arm (per-arm bound guards); the ADT Lean path still flattens arms to their union (`stmts_with_branch_union`). Measure intrinsics by bugs eliminated, not lines saved.
+- The closed-enum discipline applies to small enums too: never tally or gate on an enum with open-coded `.filter(|x| x.variant == …)` chains — count through an exhaustive `match` (e.g. `SeverityCounts::of`) so a new variant is a compile error at every accounting site, not a silently dropped case (#260/#270: `Severity::Error` vanished from the check summary and exit code for ten releases this way).
 
 ## Build and test
 

--- a/crates/qedgen/src/check/code_drift.rs
+++ b/crates/qedgen/src/check/code_drift.rs
@@ -410,17 +410,9 @@ pub fn check_unified(
 
 /// Print the unified drift report.
 pub fn print_unified_report(spec_name: &str, report: &UnifiedReport) {
-    // Spec completeness
-    let warns = report
-        .completeness
-        .iter()
-        .filter(|w| w.severity == Severity::Warning)
-        .count();
-    let infos = report
-        .completeness
-        .iter()
-        .filter(|w| w.severity == Severity::Info)
-        .count();
+    // Spec completeness — tally through the exhaustive-match counter so
+    // Error entries can't drop out of the summary (#260/#270).
+    let counts = SeverityCounts::of(&report.completeness);
 
     eprintln!("──── Spec Completeness ──────────────────────────────────");
     if report.completeness.is_empty() {
@@ -436,7 +428,10 @@ pub fn print_unified_report(spec_name: &str, report: &UnifiedReport) {
             eprintln!("    Fix: {}", w.fix);
         }
     }
-    eprintln!("  {} warning(s), {} info\n", warns, infos);
+    eprintln!(
+        "  {} error(s), {} warning(s), {} info\n",
+        counts.errors, counts.warnings, counts.infos
+    );
 
     // Code drift
     if let Some(ref drift) = report.code_drift {

--- a/crates/qedgen/src/check/model.rs
+++ b/crates/qedgen/src/check/model.rs
@@ -1069,6 +1069,40 @@ pub enum Severity {
     Info,
 }
 
+/// Per-severity tallies for a lint set.
+///
+/// Construct via [`SeverityCounts::of`], whose match is exhaustive by
+/// discipline (no `_` arm — see the `Stmt` enum doc in `mir.rs`): adding
+/// a `Severity` variant is a compile error here, not a silently
+/// uncounted lint. Open-coded `.filter(|w| w.severity == …)` tallies are
+/// how Error-severity lints vanished from the check summary and exit
+/// code for ten releases (#260); count through this instead (#270).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SeverityCounts {
+    pub errors: usize,
+    pub warnings: usize,
+    pub infos: usize,
+}
+
+impl SeverityCounts {
+    pub fn of(warnings: &[CompletenessWarning]) -> Self {
+        let mut counts = Self::default();
+        for w in warnings {
+            match w.severity {
+                Severity::Error => counts.errors += 1,
+                Severity::Warning => counts.warnings += 1,
+                Severity::Info => counts.infos += 1,
+            }
+        }
+        counts
+    }
+
+    /// The check exit policy: Error ≥ Warning fail; Info never does (#260).
+    pub fn fails_check(&self) -> bool {
+        self.errors > 0 || self.warnings > 0
+    }
+}
+
 /// A concrete counterexample showing how an operation breaks a property.
 /// Structured as data so the agent can reason about it and present it clearly.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1207,11 +1241,11 @@ pub struct UnifiedReport {
 
 impl UnifiedReport {
     pub fn issue_count(&self) -> usize {
-        let comp = self
-            .completeness
-            .iter()
-            .filter(|w| w.severity == Severity::Warning)
-            .count();
+        // #270: Error-severity completeness findings count as issues too —
+        // the old Warning-only filter let E-class lints through the
+        // `check --code/--kani` exit gate (#260's bug class).
+        let counts = SeverityCounts::of(&self.completeness);
+        let comp = counts.errors + counts.warnings;
         let code = self.code_drift.as_ref().map_or(0, |v| {
             v.iter().filter(|d| d.status != DriftStatus::InSync).count()
         });
@@ -1226,5 +1260,58 @@ impl UnifiedReport {
             .filter(|r| r.status != Status::Proven)
             .count();
         comp + code + kani + lean
+    }
+}
+
+#[cfg(test)]
+mod severity_counts_tests {
+    use super::*;
+
+    fn lint(severity: Severity) -> CompletenessWarning {
+        CompletenessWarning {
+            rule: "test_rule".into(),
+            severity,
+            priority: 1,
+            message: String::new(),
+            subject: None,
+            fix: String::new(),
+            example: None,
+            counterexample: None,
+            fix_options: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn tally_counts_every_severity_and_errors_fail() {
+        let counts = SeverityCounts::of(&[
+            lint(Severity::Error),
+            lint(Severity::Warning),
+            lint(Severity::Info),
+            lint(Severity::Info),
+        ]);
+        assert_eq!(
+            (counts.errors, counts.warnings, counts.infos),
+            (1, 1, 2),
+            "every variant must land in exactly one bucket"
+        );
+        assert!(counts.fails_check(), "errors must fail");
+        assert!(
+            !SeverityCounts::of(&[lint(Severity::Info)]).fails_check(),
+            "info alone must not fail"
+        );
+    }
+
+    #[test]
+    fn issue_count_includes_error_severity_completeness() {
+        // #270: an Error-only report must register as an issue — the old
+        // Warning-only filter waved E-class lints through the unified
+        // check exit gate.
+        let report = UnifiedReport {
+            completeness: vec![lint(Severity::Error)],
+            code_drift: None,
+            kani_drift: None,
+            lean_coverage: Vec::new(),
+        };
+        assert_eq!(report.issue_count(), 1);
     }
 }

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -1357,26 +1357,15 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 } else if warnings.is_empty() {
                     eprintln!("Spec is complete — no issues found.");
                 } else {
-                    let errors = warnings
-                        .iter()
-                        .filter(|w| w.severity == check::Severity::Error)
-                        .count();
-                    let warns = warnings
-                        .iter()
-                        .filter(|w| w.severity == check::Severity::Warning)
-                        .count();
-                    let infos = warnings
-                        .iter()
-                        .filter(|w| w.severity == check::Severity::Info)
-                        .count();
+                    let counts = check::SeverityCounts::of(&warnings);
                     for w in &warnings {
                         eprintln!("{}\n", format_lint_warning(w));
                     }
-                    eprintln!("{} error(s), {} warning(s), {} info", errors, warns, infos);
-                    // Error ≥ Warning in the exit decision (#260): before
-                    // this, E-class lints printed but were invisible to both
-                    // the tally and the exit code.
-                    if errors > 0 || warns > 0 {
+                    eprintln!(
+                        "{} error(s), {} warning(s), {} info",
+                        counts.errors, counts.warnings, counts.infos
+                    );
+                    if counts.fails_check() {
                         has_issues = true;
                     }
                 }


### PR DESCRIPTION
Implements the #270 prevention item. #260's mechanism was an open-coded `.filter(|w| w.severity == X)` tally written when `Severity` had two variants — adding `Error` in v2.10 compiled cleanly while the new variant silently dropped out of the accounting for ten releases.

The consumer audit found the same live pattern in **two more exit-relevant sites**, both fixed here:

- `UnifiedReport::issue_count` counted only Warning-severity completeness findings — `check --code`/`--kani` waved E-class lints through its exit gate (`has_issues` at `run.rs:1250`);
- `print_unified_report`'s completeness tally dropped Error entries from its summary line (they printed with an `E` icon, then vanished — the exact #260 shape).

All three sites now count through `SeverityCounts::of`, whose `match` has no wildcard arm by discipline (same doctrine as the closed `Stmt` enum in `mir.rs`): a new `Severity` variant is a **compile error at every accounting site**, not a silently uncounted lint. `fails_check()` centralizes the Error ≥ Warning exit policy.

Deliberately unchanged: the ratify/elicit blocking predicates (`matches!(w.severity, Severity::Error)`) — those are intentional single-variant gates, not tallies, and stay explicit.

CLAUDE.md design principles gain the corresponding line. Unit tests cover the tally buckets, the fail policy, and the `issue_count` Error inclusion; the #260 integration gate (`check_exit_code.rs`) still passes.

Closes #270