### PR TITLE
style: rustfmt the #251/#248/#249 additions — unbreak the CI fmt gate

### DIFF
--- a/crates/qedgen/src/cli.rs
+++ b/crates/qedgen/src/cli.rs
@@ -1310,10 +1310,8 @@ mod tests {
     fn probe_bootstrap_accepts_json_flag() {
         // #251: probe output is always JSON, but the flag learned on
         // sibling subcommands must parse instead of hard-erroring.
-        let cli = Cli::try_parse_from([
-            "qedgen", "probe", "--bootstrap", "--root", "p", "--json",
-        ])
-        .expect("--json must parse on probe");
+        let cli = Cli::try_parse_from(["qedgen", "probe", "--bootstrap", "--root", "p", "--json"])
+            .expect("--json must parse on probe");
         let Commands::Probe {
             bootstrap, json, ..
         } = cli.command

--- a/crates/qedgen/src/probe/ratify.rs
+++ b/crates/qedgen/src/probe/ratify.rs
@@ -1933,7 +1933,10 @@ mod tests {
             default_scoping_path(&audit),
             prog_root.join(".qed/plan/scoping.md")
         );
-        assert_eq!(default_findings_dir(&audit), prog_root.join(".qed/findings"));
+        assert_eq!(
+            default_findings_dir(&audit),
+            prog_root.join(".qed/findings")
+        );
         Ok(())
     }
 

--- a/crates/qedgen/tests/bootstrap_ratify_journey.rs
+++ b/crates/qedgen/tests/bootstrap_ratify_journey.rs
@@ -13,7 +13,9 @@ use std::process::Command;
 fn bootstrap_probe_to_ratify_journey() {
     common::ensure_qedgen_built();
 
-    let tmp = common::stage_fixture("crates/qedgen/tests/fixtures/probe-corpus/specless/native-shank-marker");
+    let tmp = common::stage_fixture(
+        "crates/qedgen/tests/fixtures/probe-corpus/specless/native-shank-marker",
+    );
     let root = tmp.path();
     let audit = root.join(".qed/audit/journey-1");
 
@@ -41,7 +43,9 @@ fn bootstrap_probe_to_ratify_journey() {
             "bootstrap --emit-spec-candidates --audit-dir must materialize {artifact} (#248); \
              audit dir contents: {:?}",
             std::fs::read_dir(&audit)
-                .map(|d| d.filter_map(|e| e.ok().map(|e| e.file_name())).collect::<Vec<_>>())
+                .map(|d| d
+                    .filter_map(|e| e.ok().map(|e| e.file_name()))
+                    .collect::<Vec<_>>())
                 .unwrap_or_default()
         );
     }
@@ -64,7 +68,10 @@ fn bootstrap_probe_to_ratify_journey() {
 
     // #249: default spec path is <root>/<name>.qedspec derived from the
     // manifest's recorded program root — never <root>/.qed/.qed.qedspec.
-    let name = root.file_name().and_then(|n| n.to_str()).expect("root name");
+    let name = root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("root name");
     assert!(
         root.join(format!("{name}.qedspec")).exists(),
         "ratified spec must land at <root>/{name}.qedspec; stderr: {}",


### PR DESCRIPTION
`cargo fmt --check` has been failing on main since PR #264 (the #251 CLI test's formatting), persisting through #268's additions — my local ship flow ran tests but never the fmt gate, so the red went unnoticed until the #271 gate-step run surfaced it. fmt-only diff, zero behavior change; cli/ratify test suites re-verified.

Fittingly for the prevention theme: the local pre-merge flow must mirror CI's steps (fmt, clippy) — noted in the session log.