### PR TITLE
test(auditor): shape-wrong fixture per validator + shellcheck in CI (#273)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
           bash scripts/check-auditor-skill.sh
           bash scripts/test-auditor-preflight.sh
 
+      # #273: static analysis over every shipped shell script. Warning
+      # severity — info-level notes (e.g. intentional single-quoted grep
+      # patterns) don't gate.
+      - name: Shellcheck
+        run: shellcheck --severity=warning install.sh scripts/*.sh skills/qedgen-auditor/scripts/*.sh
+
       - name: Check README drift
         run: bash scripts/check-readme-drift.sh
 

--- a/scripts/check-lake-build.sh
+++ b/scripts/check-lake-build.sh
@@ -16,7 +16,7 @@
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$REPO_ROOT"
+cd "$REPO_ROOT" || exit 1
 
 STRICT=0
 ONLY_PATTERN=""

--- a/skills/qedgen-auditor/scripts/check-domain-artifacts.sh
+++ b/skills/qedgen-auditor/scripts/check-domain-artifacts.sh
@@ -359,15 +359,19 @@ if validate_dossier "$fixtures/invalid-domain-dossier.json"; then
   exit 1
 fi
 
-# A type-wrong field (string args instead of objects) must be a CLEAN
-# validation failure (jq -e false → exit 1), not a jq runtime crash
-# (exit 5) — the crash was GH #250.
-rc=0
-validate_dossier "$fixtures/invalid-args-domain-dossier.json" || rc=$?
-if [[ $rc -ne 1 ]]; then
-  echo "string-typed handlers[].args fixture: expected clean invalid (exit 1), got exit $rc" >&2
-  exit 1
-fi
+# A type-wrong (shape-wrong) field must be a CLEAN validation failure
+# (jq -e false → exit 1), never a jq runtime crash (exit 5) — the crash
+# was GH #250; one shape-wrong fixture per validator is policy (#273).
+expect_clean_invalid() {
+  local validator="$1" fixture="$2" rc=0
+  "$validator" "$fixtures/$fixture" || rc=$?
+  if [[ $rc -ne 1 ]]; then
+    echo "$fixture: expected clean invalid (exit 1) from $validator, got exit $rc" >&2
+    exit 1
+  fi
+}
+
+expect_clean_invalid validate_dossier invalid-args-domain-dossier.json
 
 validate_manifest "$fixtures/valid-audit-run-manifest.json"
 validate_manifest "$fixtures/valid-probe-failure-manifest.json"
@@ -392,5 +396,15 @@ validate_sequence_bindings "$fixtures/valid-domain-sequence-bindings.json"
 validate_resolved_sequences "$fixtures/valid-resolved-domain-sequences.json"
 validate_account_overlay "$fixtures/valid-account-binding-overlay.json"
 validate_replay_report "$fixtures/valid-domain-replay-report.json"
+
+# Shape-wrong sweep (#273): one type-confused fixture per validator, each
+# targeting a field an outside author would plausibly get wrong.
+expect_clean_invalid validate_manifest invalid-shape-audit-run-manifest.json
+expect_clean_invalid validate_handoff invalid-shape-spec-handoff.json
+expect_clean_invalid validate_sequences invalid-shape-domain-sequences.json
+expect_clean_invalid validate_sequence_bindings invalid-shape-domain-sequence-bindings.json
+expect_clean_invalid validate_resolved_sequences invalid-shape-resolved-domain-sequences.json
+expect_clean_invalid validate_account_overlay invalid-shape-account-binding-overlay.json
+expect_clean_invalid validate_replay_report invalid-shape-domain-replay-report.json
 
 echo "auditor domain artifact checks passed"

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-account-binding-overlay.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-account-binding-overlay.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/account-binding-overlay-v1.schema.json",
+  "source_resolved_sequence_schema_uri": "https://qedgen.dev/schemas/auditor/resolved-domain-sequences-v1.schema.json",
+  "audit_id": "audit_vault",
+  "handlers": {
+    "deposit": "fixture:x"
+  }
+}

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-audit-run-manifest.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-audit-run-manifest.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/audit-run-manifest-v1.schema.json",
+  "audit_id": "fee_vault_20260714",
+  "status": "tooling-blocked",
+  "target": {
+    "program_root": "programs/fee-vault",
+    "runtime": "anchor",
+    "mode": "spec-less",
+    "spec": null,
+    "source_commit": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "tool_versions": {
+    "qedgen": "unavailable",
+    "auditor_skill": "2.42.0"
+  },
+  "lanes": [
+    "compile",
+    {
+      "name": "ordinary-probe",
+      "status": "blocked",
+      "reason": "qedgen executable is unavailable",
+      "resume_command": "qedgen probe --bootstrap --root programs/fee-vault",
+      "started_at": null,
+      "finished_at": null,
+      "artifact_paths": []
+    },
+    {
+      "name": "crucible-domain",
+      "status": "blocked",
+      "reason": "ratified spec and qedgen executable are unavailable",
+      "resume_command": "qedgen probe --fuzz 300 --spec .qed/audit/fee_vault_20260714/ratified.qedspec --json",
+      "started_at": null,
+      "finished_at": null,
+      "artifact_paths": []
+    }
+  ],
+  "artifacts": {
+    "domain_dossier_json": ".qed/audit/fee_vault_20260714/domain-dossier.json",
+    "domain_dossier_markdown": ".qed/audit/fee_vault_20260714/domain-dossier.md",
+    "ratified_intent": null,
+    "report": ".qed/findings/audit-fee_vault_20260714.md",
+    "suppressions": null
+  }
+}

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-domain-replay-report.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-domain-replay-report.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/domain-replay-report-v1.schema.json",
+  "resolved_document_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "account_binding_overlay_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+  "harness_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+  "records": [
+    "record"
+  ]
+}

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-domain-sequence-bindings.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-domain-sequence-bindings.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/domain-sequence-bindings-v1.schema.json",
+  "source_sequence_schema_uri": "https://qedgen.dev/schemas/auditor/domain-sequences-v1.schema.json",
+  "source_audit_id": "audit_vault",
+  "bindings": [
+    {
+      "plan_id": "sequence:pair_deposit_withdraw:deposit:withdraw:setup=none:teardown=none",
+      "action": {
+        "phase": "forward",
+        "index": 0
+      },
+      "parameter": "amount",
+      "value": 42
+    }
+  ]
+}

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-domain-sequences.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-domain-sequences.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/domain-sequences-v1.schema.json",
+  "audit_id": "audit_vault",
+  "source_dossier_schema_version": 1,
+  "plans": [
+    "plan"
+  ],
+  "exclusions": []
+}

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-resolved-domain-sequences.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-resolved-domain-sequences.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/resolved-domain-sequences-v1.schema.json",
+  "source_sequence_schema_uri": "https://qedgen.dev/schemas/auditor/domain-sequences-v1.schema.json",
+  "source_bindings_schema_uri": "https://qedgen.dev/schemas/auditor/domain-sequence-bindings-v1.schema.json",
+  "audit_id": "audit_vault",
+  "source_dossier_schema_version": 1,
+  "plans": [
+    {
+      "id": "sequence:pair_deposit_withdraw:deposit:withdraw:setup=none:teardown=none",
+      "kind": "paired_round_trip",
+      "title": "deposit then withdraw",
+      "setup": "not-an-array",
+      "forward": [
+        {
+          "handler": "deposit",
+          "role": "forward",
+          "from_state": null,
+          "to_state": null,
+          "guards": [],
+          "provenance_candidate_ids": [
+            "pair_deposit_withdraw"
+          ],
+          "resolved_bindings": [
+            {
+              "parameter": {
+                "handler": "deposit",
+                "name": "amount",
+                "kind": "handler_argument",
+                "declared_type": "U64",
+                "reason": "explicit value required"
+              },
+              "value": 42,
+              "provenance": {
+                "source": "user",
+                "plan_id": "sequence:pair_deposit_withdraw:deposit:withdraw:setup=none:teardown=none",
+                "action": {
+                  "phase": "forward",
+                  "index": 0
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "reverse": [],
+      "teardown": [],
+      "provenance_candidate_ids": [
+        "pair_deposit_withdraw"
+      ],
+      "resolved_plan_bindings": []
+    }
+  ],
+  "exclusions": []
+}

--- a/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-spec-handoff.json
+++ b/skills/qedgen-auditor/test-fixtures/domain-artifacts/invalid-shape-spec-handoff.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "schema_uri": "https://qedgen.dev/schemas/auditor/spec-handoff-v1.schema.json",
+  "spec_path": "fee-vault.qedspec",
+  "layers": {
+    "structural": [
+      {
+        "candidate_id": "AccountOwnerCheck:program",
+        "disposition": "emitted",
+        "spec_path": "fee-vault.qedspec",
+        "verification_lanes": [
+          "check"
+        ]
+      }
+    ],
+    "domain": [
+      {
+        "candidate_id": "qty_fee_amount",
+        "kind": "quantity",
+        "disposition": "needs_authoring",
+        "verification_lanes": [
+          "manual",
+          "crucible"
+        ],
+        "authoring": {
+          "constructs": [
+            "const",
+            "mul_div_floor"
+          ],
+          "template": "const SCALE = 10000\nlet fee = mul_div_floor(amount, bps, SCALE)",
+          "notes": [
+            "Nominal unit checking is not yet enforced by the type system."
+          ]
+        }
+      }
+    ],
+    "regression": []
+  },
+  "language_gaps": [
+    "gap"
+  ]
+}


### PR DESCRIPTION
Implements the #273 prevention item.

**Shape-wrong fixtures**: #250's lesson was that invalid fixtures tested *value* violations but never *shape* violations, because fixture author and validator author shared a mental model. Each of the seven remaining validators now has a type-confused fixture targeting a field an outside author would plausibly get wrong:

| validator | shape wrong |
|---|---|
| manifest | `lanes[0]` a string |
| handoff | `language_gaps[0]` a string |
| sequences | `plans[0]` a string |
| bindings | `parameter` a string |
| resolved-sequences | `setup` a non-array (pins the array checks added in #266) |
| account-overlay | handler value a string |
| replay-report | `records[0]` a string |

A shared `expect_clean_invalid` helper asserts each yields **exit 1 exactly** — a clean validation failure, never jq's runtime-crash exit 5. All pass against the #266 type guards. Self-test runs in CI via the existing auditor-skill contract step.

**Shellcheck**: `shellcheck --severity=warning` over `install.sh`, `scripts/*.sh`, and the auditor skill scripts as a CI step. Baseline survey found one warning — unchecked `cd` in `check-lake-build.sh` (SC2164) — fixed; the two info-level notes are intentional single-quoted grep patterns, below the gate's severity.

Installed skill copy synced; auditor-skill gate and release gate green.

Closes #273