### PR TITLE
feat(ci): cold-start smoke — install.sh scenario matrix + installed-binary quickstart (#274)

### DIFF
--- a/.github/workflows/cold-start.yml
+++ b/.github/workflows/cold-start.yml
@@ -1,0 +1,36 @@
+# Cold-start smoke (#274): simulate the outside user — install.sh scenario
+# matrix (fresh / match / stale-refresh / stranded) plus the quickstart
+# driven with the INSTALLED binary. The #252-254 bug batch came from the
+# first external dogfooder because no in-repo flow ever ran this path.
+#
+# Path-filtered on PRs (install plumbing changes), weekly otherwise — the
+# scheduled run also catches release-asset breakage (deleted/renamed
+# assets) that no code change would surface.
+name: Cold-start smoke
+
+on:
+  pull_request:
+    paths:
+      - install.sh
+      - scripts/cold-start-smoke.sh
+      - .github/workflows/cold-start.yml
+      - crates/qedgen/Cargo.toml
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cold-start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Source-build fallback: right after a version bump the pinned
+      # release asset doesn't exist yet, and install.sh falls back to
+      # cargo. Scenario D strips PATH itself to exercise the no-toolchain
+      # branch regardless.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cold-start smoke
+        run: bash scripts/cold-start-smoke.sh

--- a/scripts/cold-start-smoke.sh
+++ b/scripts/cold-start-smoke.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Cold-start smoke (#274): simulate the outside user on a fresh checkout.
+#
+# The #252-254 bug batch all came from the first external dogfooder — the
+# in-repo flow never exercises install.sh or the installed-binary
+# quickstart. This script does, hermetically: every scenario runs in a
+# scratch copy of the tree with HOME sandboxed, so the symlink step can
+# never touch the invoking user's real ~/.local/bin or ~/.cargo/bin.
+#
+# Scenarios:
+#   A fresh        — no bin/qedgen: install resolves the pinned release
+#                    asset (or source-builds) and lands the right version
+#   B match        — matching binary is kept, not re-downloaded
+#   C stale        — version-skewed binary is refreshed (#252 regression)
+#   D stranded     — stale binary + no download + no cargo: loud warning,
+#                    honest "NOT installed" banner, exit 0
+#   E quickstart   — the SKILL.md core loop driven with the INSTALLED
+#                    binary (journey tests cover the workspace build; this
+#                    covers what a user actually runs)
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+VERSION="v$(grep '^version' "$repo_root/crates/qedgen/Cargo.toml" | head -1 | sed 's/.*"\(.*\)"/\1/')"
+
+failures=0
+fail() {
+  echo "✗ $*" >&2
+  failures=$((failures + 1))
+}
+pass() { echo "✓ $*"; }
+
+# A pristine copy of the checkout (sans build products), one per scenario.
+base="$scratch/base"
+mkdir -p "$base"
+rsync -aq \
+  --exclude=.git --exclude=target --exclude='.lake' \
+  --exclude=node_modules --exclude='.anchor' \
+  "$repo_root/" "$base/"
+
+make_tree() { # <name> -> path on stdout
+  local tree="$scratch/$1"
+  cp -R "$base" "$tree"
+  echo "$tree"
+}
+
+run_install() { # <tree> [extra env as K=V...]
+  local tree="$1"
+  shift
+  mkdir -p "$scratch/home"
+  env HOME="$scratch/home" "$@" "$tree/install.sh" 2>&1
+}
+
+installed_version() { # <tree>
+  "$1/bin/qedgen" --version 2>/dev/null | awk '{print $2}'
+}
+
+write_stale_stub() { # <tree>
+  mkdir -p "$1/bin"
+  printf '#!/bin/sh\necho "qedgen 2.15.1"\n' > "$1/bin/qedgen"
+  chmod +x "$1/bin/qedgen"
+}
+
+# ── A: fresh install ────────────────────────────────────────────────────
+tree="$(make_tree fresh)"
+rm -f "$tree/bin/qedgen"
+out="$(run_install "$tree")" && rc=0 || rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail "A fresh: install.sh exited $rc"
+  tail -5 <<<"$out" | sed 's/^/    /' >&2
+elif [[ "v$(installed_version "$tree")" != "$VERSION" ]]; then
+  fail "A fresh: installed '$(installed_version "$tree")', expected ${VERSION#v}"
+else
+  pass "A fresh install lands $VERSION"
+fi
+fresh_tree="$tree"
+
+# ── B: matching binary kept ─────────────────────────────────────────────
+out="$(run_install "$fresh_tree")" && rc=0 || rc=$?
+if [[ $rc -ne 0 ]] || ! grep -q "is current" <<<"$out"; then
+  fail "B match: expected 'is current' keep-path (exit $rc)"
+  tail -5 <<<"$out" | sed 's/^/    /' >&2
+else
+  pass "B matching binary kept"
+fi
+
+# ── C: stale binary refreshed ───────────────────────────────────────────
+tree="$(make_tree stale)"
+write_stale_stub "$tree"
+out="$(run_install "$tree")" && rc=0 || rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail "C stale: install.sh exited $rc"
+  tail -5 <<<"$out" | sed 's/^/    /' >&2
+elif [[ "v$(installed_version "$tree")" != "$VERSION" ]]; then
+  fail "C stale: still '$(installed_version "$tree")' after install, expected refresh to ${VERSION#v}"
+else
+  pass "C stale binary refreshed to $VERSION"
+fi
+
+# ── D: stranded (stale + no download + no cargo) ────────────────────────
+tree="$(make_tree stranded)"
+write_stale_stub "$tree"
+sed -i.bak 's/^version = .*/version = "99.99.99"/' "$tree/crates/qedgen/Cargo.toml"
+out="$(run_install "$tree" PATH=/usr/bin:/bin)" && rc=0 || rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail "D stranded: expected exit 0 with warning, got exit $rc"
+elif ! grep -q "WARNING: could not refresh qedgen" <<<"$out"; then
+  fail "D stranded: loud stale warning missing"
+elif ! grep -q "NOT installed" <<<"$out"; then
+  fail "D stranded: banner still claims success"
+else
+  pass "D stranded keeps stale binary with loud warning + honest banner"
+fi
+
+# ── E: quickstart with the installed binary ─────────────────────────────
+qedgen="$fresh_tree/bin/qedgen"
+proj="$scratch/proj"
+mkdir -p "$proj"
+cp "$repo_root/examples/rust/escrow/escrow.qedspec" "$proj/"
+step() { # <label> <cmd...>
+  local label="$1"
+  shift
+  local out rc=0
+  out="$(cd "$proj" && "$@" 2>&1)" || rc=$?
+  if [[ $rc -ne 0 ]]; then
+    fail "E quickstart / $label: exit $rc"
+    tail -5 <<<"$out" | sed 's/^/    /' >&2
+    return 1
+  fi
+}
+# NOTE on `check`: the installed binary is the pinned RELEASE, while the
+# spec comes from HEAD — lint baselines legitimately skew between the two
+# (the strict baseline is owned by the workspace journey tests and the
+# release gate). Here `check` must run and produce its summary; exit 1
+# from lint findings is acceptable, a crash / parse failure is not.
+check_lenient() {
+  local out rc=0
+  out="$(cd "$proj" && "$qedgen" check 2>&1)" || rc=$?
+  if [[ $rc -gt 1 ]] || ! grep -Eq "(error\(s\)|warning\(s\))," <<<"$out"; then
+    fail "E quickstart / check: exit $rc without a lint summary"
+    tail -5 <<<"$out" | sed 's/^/    /' >&2
+    return 1
+  fi
+}
+git -C "$proj" init -q . &&
+  step "init" "$qedgen" init --name escrow --spec escrow.qedspec &&
+  check_lenient &&
+  step "codegen" "$qedgen" codegen --all &&
+  {
+    quickstart_ok=1
+    for artifact in programs/src/lib.rs programs/tests/proptest.rs \
+      formal_verification/Spec.lean; do
+      if [[ ! -f "$proj/$artifact" ]]; then
+        fail "E quickstart: missing $artifact"
+        quickstart_ok=0
+      fi
+    done
+    [[ $quickstart_ok -eq 1 ]] && pass "E quickstart clean with the installed binary"
+  }
+
+# ── Verdict ─────────────────────────────────────────────────────────────
+if [[ $failures -gt 0 ]]; then
+  echo "cold-start-smoke: $failures failure(s)" >&2
+  exit 1
+fi
+echo "cold-start-smoke: all scenarios clean"


### PR DESCRIPTION
Implements the #274 prevention item — the #252–254 batch all came from the first external dogfooder, because no in-repo flow ever ran the cold-start path.

**`scripts/cold-start-smoke.sh`** (script-first, workflow just invokes it — same doctrine as the release gate). Every scenario runs in a scratch copy of the checkout with `HOME` sandboxed, so the install symlink step can never touch the invoking user's real `~/.local/bin`:

- **A fresh** — no `bin/qedgen`: install lands exactly the Cargo.toml-pinned version (release asset, checksum-verified; source-build fallback);
- **B match** — matching binary kept via the `is current` path;
- **C stale** — a v2.15.1 stub is refreshed to the pinned version (the #252 regression);
- **D stranded** — stale stub + 404 download + cargo-less PATH: loud both-versions warning, honest `NOT installed` banner, exit 0;
- **E quickstart** — the SKILL.md core loop (`init` → `check` → `codegen --all`) driven with the **installed** binary, artifacts asserted.

Scenario E's `check` is asserted leniently (runs + prints a lint summary; exit 1 acceptable): the installed binary is the *released* version while the spec comes from HEAD, and lint baselines legitimately skew across that boundary — the strict baseline is owned by the workspace journey tests (#282) and the release gate (#276). This skew wasn't hypothetical: the first local run failed exactly there, with v2.45.0 (pre-#267 lints) warning on HEAD's escrow spec.

**`cold-start.yml`**: path-filtered on PRs touching install plumbing, weekly on schedule (also catches release-asset breakage no code change would surface), plus manual dispatch.

All five scenarios validated locally, including real v2.45.0 release-asset downloads; shellcheck clean.

Closes #274