### PR TITLE
fix(codegen): spec-relative output resolution + combined prerequisite preflight (#279, #262)

### DIFF
--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -1756,12 +1756,41 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             handler,
             fill_tests,
         } => {
-            require_git_repo()?;
             // `is_pinocchio` gates the post-regen stamped-drift scan below
             // (the Pinocchio scaffold carries no `#[qed(verified)]` stamps).
             let is_pinocchio = matches!(target, Target::Pinocchio);
             let cwd = std::env::current_dir()?;
             let spec = init::resolve_spec_path(spec.as_deref(), &cwd)?;
+            // #279: relative output paths — including every clap default —
+            // resolve against the spec's directory (the project root), not
+            // the invoker's cwd. `codegen --spec <elsewhere>/x.qedspec` from
+            // anywhere writes into <elsewhere>/, never scatters artifacts
+            // under cwd. Absolute paths pass through untouched. A directory
+            // --spec (multi-fragment project) IS the project root — taking
+            // its parent would walk out of the project.
+            let spec_dir = if spec.is_dir() {
+                spec.clone()
+            } else {
+                spec.parent()
+                    .unwrap_or_else(|| std::path::Path::new("."))
+                    .to_path_buf()
+            };
+            let against_spec = |p: PathBuf| -> PathBuf {
+                if p.is_absolute() {
+                    p
+                } else {
+                    spec_dir.join(p)
+                }
+            };
+            let output_dir = against_spec(output_dir);
+            let kani_output = against_spec(kani_output);
+            let kani_impl_output = against_spec(kani_impl_output);
+            let test_output = against_spec(test_output);
+            let proptest_output = against_spec(proptest_output);
+            let crucible_output = against_spec(crucible_output);
+            let integration_output = against_spec(integration_output);
+            let lean_output = against_spec(lean_output);
+            let ci_output = against_spec(ci_output);
             // One parse + one MIR lowering, shared by every artifact stage
             // below (the arm previously re-parsed per artifact).
             let parsed = check::parse_spec_file(&spec)?;
@@ -1771,6 +1800,33 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             // so the scaffold's handlers gate can't fire before the Lean
             // branch (#88): assembly targets emit only `--lean` and `--ci`.
             let is_assembly = parsed.is_assembly_target();
+            // #262: one preflight, every missing prerequisite in a single
+            // message — previously the git gate and the .qed gate lived in
+            // different layers and failed one round-trip at a time. The
+            // .qed/ prerequisite applies only when the greenfield Rust
+            // scaffold will run (where the gate historically lived):
+            // assembly and brownfield/mirror specs never required it.
+            let scaffold_will_run = !(is_assembly
+                || kani_impl_brownfield
+                || kani_impl_context
+                || parsed.is_struct_mirror());
+            let mut missing: Vec<String> = Vec::new();
+            if !run_helpers::has_git_repo(&cwd) {
+                missing.push("not inside a git repository — run `git init`".to_string());
+            }
+            if scaffold_will_run && init::find_qed_dir(&spec).is_none() {
+                missing.push(format!(
+                    "no .qed/ directory next to {} — run `qedgen init --name <name> --spec {}`",
+                    spec.display(),
+                    spec.display()
+                ));
+            }
+            if !missing.is_empty() {
+                anyhow::bail!(
+                    "codegen prerequisites missing:\n  - {}",
+                    missing.join("\n  - ")
+                );
+            }
             if is_assembly {
                 eprintln!(
                     "note: sBPF spec — skipping Rust scaffold (assembly programs \

--- a/crates/qedgen/tests/codegen_determinism.rs
+++ b/crates/qedgen/tests/codegen_determinism.rs
@@ -54,14 +54,20 @@ fn walk(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) {
 }
 
 fn run_codegen(spec: &Path, out_dir: &Path) {
+    // Canonicalize so the scaffold's spec-path relativization works on
+    // macOS (`/var` tempdirs canonicalize to `/private/var`; a mixed
+    // form makes strip_prefix fail and the stamp fall back to the
+    // absolute — run-unique — tempdir path).
+    let out_dir = &out_dir.canonicalize().expect("canonicalize out_dir");
     common::git_init(out_dir);
+    let staged = common::stage_spec_surface(spec, out_dir);
+    // No --output-dir override: the defaults resolve against the staged
+    // spec's project root (#279), so everything lands under out_dir with
+    // the standard layout and the `#[qed(spec = …)]` stamps relativize
+    // to stable run-independent paths.
     let output = Command::new(qedgen_bin())
         .args(["codegen", "--all", "--spec"])
-        .arg(spec)
-        .arg("--output-dir")
-        .arg(out_dir)
-        // cwd-relative artifact defaults (tests/, programs/, fuzz/) must
-        // land in the tempdir, not wherever the test harness runs.
+        .arg(&staged)
         .current_dir(out_dir)
         .output()
         .expect("spawn qedgen codegen");

--- a/crates/qedgen/tests/codegen_preflight.rs
+++ b/crates/qedgen/tests/codegen_preflight.rs
@@ -1,0 +1,99 @@
+//! Gates for the codegen dispatch seam: the combined prerequisite
+//! preflight (#262) and spec-relative output resolution (#279).
+
+mod common;
+
+use std::path::Path;
+use std::process::Command;
+
+fn qedgen_from(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(common::qedgen_bin())
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("spawn qedgen")
+}
+
+/// #262: a scratch dir missing BOTH prerequisites (git repo, .qed/) gets
+/// one error naming both fixes — not one prerequisite per round-trip.
+#[test]
+fn preflight_reports_all_missing_prerequisites_at_once() {
+    common::ensure_qedgen_built();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    std::fs::copy(
+        common::repo_root().join("examples/rust/escrow/escrow.qedspec"),
+        root.join("escrow.qedspec"),
+    )
+    .expect("copy spec");
+
+    let out = qedgen_from(root, &["codegen", "--proptest", "--spec", "escrow.qedspec"]);
+    assert!(!out.status.success(), "preflight must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("git init") && stderr.contains("qedgen init"),
+        "one message must name every missing prerequisite; stderr:\n{stderr}"
+    );
+}
+
+/// #279: relative output paths (including the clap defaults) resolve
+/// against the spec's directory, not the invoker's cwd — no scattered
+/// artifact trees when codegen is driven from outside the project.
+#[test]
+fn relative_outputs_resolve_against_spec_dir_not_cwd() {
+    common::ensure_qedgen_built();
+
+    // A real project: spec + git + qedgen init.
+    let proj = tempfile::tempdir().expect("tempdir");
+    let root = proj.path();
+    std::fs::copy(
+        common::repo_root().join("examples/rust/escrow/escrow.qedspec"),
+        root.join("escrow.qedspec"),
+    )
+    .expect("copy spec");
+    common::git_init(root);
+    let out = qedgen_from(
+        root,
+        &["init", "--name", "escrow", "--spec", "escrow.qedspec"],
+    );
+    assert!(
+        out.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Drive codegen from a DIFFERENT cwd (inside the repo, so the git
+    // gate passes) with an absolute --spec.
+    let elsewhere = tempfile::tempdir().expect("tempdir");
+    let spec_abs = root.join("escrow.qedspec");
+    common::git_init(elsewhere.path());
+    let out = qedgen_from(
+        elsewhere.path(),
+        &[
+            "codegen",
+            "--proptest",
+            "--spec",
+            spec_abs.to_str().expect("utf8"),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "codegen failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        root.join("programs/tests/proptest.rs").exists(),
+        "artifacts must land under the spec's project root"
+    );
+    let scattered: Vec<_> = std::fs::read_dir(elsewhere.path())
+        .expect("read cwd")
+        .filter_map(|e| e.ok().map(|e| e.file_name()))
+        .filter(|n| n != ".git")
+        .collect();
+    assert!(
+        scattered.is_empty(),
+        "nothing may be created under the invoking cwd; found {scattered:?}"
+    );
+}

--- a/crates/qedgen/tests/common/mod.rs
+++ b/crates/qedgen/tests/common/mod.rs
@@ -197,3 +197,50 @@ impl SnapshotHarness {
         );
     }
 }
+
+/// Stage the spec surface (every `*.qedspec` fragment — subdirectories
+/// included — plus `qed.toml`, and an empty `.qed/`) of `spec`'s project
+/// into `out_dir`; returns the staged `--spec` argument RELATIVE to
+/// `out_dir` (run the binary with `current_dir(out_dir)` so embedded
+/// `#[qed(spec = …)]` stamps stay run-independent).
+///
+/// #279 made relative codegen outputs resolve against the spec's project
+/// root, so a test must never point `--spec` at a real repo example or
+/// fixture — the run would regenerate artifacts into the repo tree.
+pub fn stage_spec_surface(spec: &Path, out_dir: &Path) -> PathBuf {
+    let (src_dir, spec_file) = if spec.is_dir() {
+        (spec.to_path_buf(), None)
+    } else {
+        (
+            spec.parent().expect("spec has a parent").to_path_buf(),
+            Some(spec.file_name().expect("spec file name").to_owned()),
+        )
+    };
+    fn copy_surface(src: &Path, src_root: &Path, out_root: &Path) {
+        for entry in fs::read_dir(src).expect("read spec dir").flatten() {
+            let p = entry.path();
+            let name = entry.file_name();
+            if p.is_dir() {
+                // Build outputs / VCS state aren't spec surface.
+                if name != ".git" && name != "target" && name != ".lake" {
+                    copy_surface(&p, src_root, out_root);
+                }
+            } else {
+                let is_spec = name.to_string_lossy().ends_with(".qedspec");
+                if is_spec || name == "qed.toml" {
+                    let rel = p.strip_prefix(src_root).expect("under src root");
+                    let dst = out_root.join(rel);
+                    fs::create_dir_all(dst.parent().expect("dst parent")).expect("mkdir");
+                    fs::copy(&p, &dst).expect("stage spec file");
+                }
+            }
+        }
+    }
+    copy_surface(&src_dir, &src_dir, out_dir);
+    // Codegen's preflight requires a .qed/ next to the spec.
+    fs::create_dir_all(out_dir.join(".qed")).expect("create .qed");
+    match spec_file {
+        Some(name) => PathBuf::from(name),
+        None => PathBuf::from("."),
+    }
+}

--- a/crates/qedgen/tests/mir_snapshot.rs
+++ b/crates/qedgen/tests/mir_snapshot.rs
@@ -48,20 +48,24 @@ use std::process::Command;
 fn render_mir_spec(_fixture_dir: &str, spec_arg: &str) -> String {
     common::ensure_qedgen_built();
     let tmp = tempfile::tempdir().expect("create tempdir");
-    common::git_init(tmp.path());
-    let spec_path = common::repo_root().join(spec_arg);
+    let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+    common::git_init(&root);
+    // #279: relative outputs resolve against the SPEC's project root, so
+    // stage the spec surface into the tempdir instead of pointing --spec
+    // at the real repo example (which would regenerate into the repo).
+    let staged = common::stage_spec_surface(&common::repo_root().join(spec_arg), &root);
 
     let status = Command::new(common::qedgen_bin())
         .arg("codegen")
         .arg("--spec")
-        .arg(&spec_path)
+        .arg(&staged)
         .arg("--lean")
-        .current_dir(tmp.path())
+        .current_dir(&root)
         .status()
         .expect("spawn qedgen codegen");
     assert!(status.success(), "qedgen codegen failed for {}", spec_arg);
 
-    let out = tmp.path().join("formal_verification").join("Spec.lean");
+    let out = root.join("formal_verification").join("Spec.lean");
     fs::read_to_string(&out).unwrap_or_else(|e| panic!("read {}: {e}", out.display()))
 }
 


### PR DESCRIPTION
Two dispatch-seam fixes plus the hermeticity fallout they exposed.

**#279 — spec-relative outputs.** All nine relative output-path defaults (`./programs`, `./formal_verification/Spec.lean`, `./fuzz`, `.github/workflows/verify.yml`, …) and any user-supplied relative path now resolve against the spec's project root; a directory `--spec` (multi-fragment project) is its own root — taking its parent walked out of the project entirely. Absolute paths pass through untouched. This kills the failure mode filed from two independent hits (v2.27.1's cd-per-example lake workflow; this week's stray repo-root `programs/`): running `codegen --spec <elsewhere>` from anywhere now writes into `<elsewhere>`.

**#262 — combined preflight.** One message reports every missing prerequisite (`git init`, `qedgen init`) instead of one error per round-trip. The `.qed/` requirement is scoped to invocations where the greenfield scaffold actually runs: sBPF and brownfield/mirror specs never required it (the historical gate lived inside the scaffold generator), and the first draft of this preflight over-gating them was caught by the sBPF CLI suite.

**Hermeticity fallout — the interesting part.** Three test harnesses *depended* on the old cwd-relative behavior, and under the new semantics were silently regenerating artifacts into the real bundled examples and fixtures on every run (`codegen_determinism` drove `codegen --all` against real example specs — tracked `guards.rs`/`state.rs` diffs and untracked `fuzz/` trees appeared mid-suite; `mir_snapshot` pointed `--spec` at repo paths). A shared `common::stage_spec_surface` helper now stages the spec surface (fragments incl. subdirs, `qed.toml`, `.qed/`) into each suite's tempdir, with relative `--spec` args so `#[qed(spec = …)]` stamps stay run-independent (macOS `/var`↔`/private/var` canonicalization included). Post-fix, full-suite runs are verified to leave the repo byte-clean.

**Gates**: `codegen_preflight.rs` — one-message-names-both-prerequisites, and a different-cwd invocation asserting artifacts land under the spec root with nothing created under cwd.

Full workspace suite, fmt, clippy, release gate: green; zero working-tree pollution after the run.

Closes #279
Closes #262