### PR TITLE
fix(diagnostics): absolute import-search paths + construct-named parse errors (#254)

### DIFF
--- a/crates/qedgen/src/spec/chumsky_parser/mod.rs
+++ b/crates/qedgen/src/spec/chumsky_parser/mod.rs
@@ -196,13 +196,66 @@ fn byte_offset_to_line_col(src: &str, offset: usize) -> (usize, usize) {
     (line, col)
 }
 
+/// Coarse construct context for a parse error (#254): the nearest
+/// preceding line whose first token is a known construct keyword names
+/// what was being parsed. The raw `Rich` expected-set is token-level
+/// (char classes) and not actionable alone for spec authors.
+fn construct_context(src: &str, offset: usize) -> Option<&'static str> {
+    const CONSTRUCTS: &[&str] = &[
+        "spec",
+        "pragma",
+        "import",
+        "type",
+        "const",
+        "pda",
+        "event",
+        "errors",
+        "interface",
+        "handler",
+        "operation",
+        "instruction",
+        "accounts",
+        "requires",
+        "ensures",
+        "modifies",
+        "effect",
+        "transfers",
+        "emits",
+        "guards",
+        "match",
+        "let",
+        "abstract",
+        "ref_impl",
+        "property",
+        "invariant",
+        "cover",
+        "liveness",
+        "environment",
+        "auth",
+        "call",
+        "upstream",
+        "state_binders",
+    ];
+    let clamped = offset.min(src.len());
+    src[..clamped].lines().rev().find_map(|line| {
+        let first = line.split_whitespace().next()?;
+        CONSTRUCTS.iter().find(|k| **k == first).copied()
+    })
+}
+
 /// Render a chumsky parse error with a `line:col` prefix instead of raw
-/// byte offsets. Keeps the full `Rich` detail (expected set, reason) so
-/// users can still see which tokens were expected.
+/// byte offsets, plus the nearest construct keyword as context. Keeps
+/// the full `Rich` detail (expected set, reason) so users can still see
+/// which tokens were expected.
 pub fn format_parse_error(err: &Rich<'_, char>, src: &str) -> String {
     let span = err.span();
     let (line, col) = byte_offset_to_line_col(src, span.start);
-    format!("line {line}, col {col}: {err:?}")
+    match construct_context(src, span.start) {
+        Some(kw) => {
+            format!("line {line}, col {col} (while parsing the `{kw}` construct): {err:?}")
+        }
+        None => format!("line {line}, col {col}: {err:?}"),
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/qedgen/src/spec/chumsky_parser/tests.rs
+++ b/crates/qedgen/src/spec/chumsky_parser/tests.rs
@@ -131,6 +131,24 @@ fn byte_offset_clamps_past_end() {
 }
 
 #[test]
+fn parse_error_names_the_enclosing_construct() {
+    // #254: a broken handler signature (comma-separated tuple form is
+    // invalid — params are curried `(name : Type)` groups) must name the
+    // construct being parsed, not just dump char-class expectations.
+    let src = "spec Demo\n\nhandler deposit(amount, to) : State.A -> State.B {\n  auth user\n}\n";
+    match parse(src) {
+        Ok(_) => panic!("expected parse to fail"),
+        Err(errs) => {
+            let msg = format_parse_error(&errs[0], src);
+            assert!(
+                msg.contains("`handler` construct"),
+                "parse error should name the enclosing construct — got: {msg}"
+            );
+        }
+    }
+}
+
+#[test]
 fn format_parse_error_prefixes_line_col() {
     // Trigger a parse error and verify the formatter attaches `line X, col Y:`.
     // Use a one-line invalid spec; the error span points into it.

--- a/crates/qedgen/src/spec/import_resolver.rs
+++ b/crates/qedgen/src/spec/import_resolver.rs
@@ -118,11 +118,24 @@ fn resolve_recursive(
             resolve_builtin_dep(&imp.from, builtin)?
         } else {
             let dep = manifest.dependencies.get(&imp.from).ok_or_else(|| {
+                // Name the manifest actually searched, absolutely — a
+                // relative manifest_dir can be empty (spec at cwd), which
+                // rendered as "(looking in )" (#254).
+                let searched = manifest_dir
+                    .canonicalize()
+                    .ok()
+                    .or_else(|| {
+                        std::env::current_dir()
+                            .ok()
+                            .map(|cwd| cwd.join(manifest_dir))
+                    })
+                    .unwrap_or_else(|| manifest_dir.to_path_buf())
+                    .join("qed.toml");
                 anyhow!(
                     "import `{}` references manifest dep `{}`, but no such entry in qed.toml under [dependencies] (looking in {})",
                     imp.name,
                     imp.from,
-                    manifest_dir.display(),
+                    searched.display(),
                 )
             })?;
             match dep {
@@ -974,6 +987,12 @@ mod tests {
         assert!(
             err.contains("no such entry in qed.toml"),
             "unexpected error: {err}"
+        );
+        // #254: the searched path renders absolutely — never the empty
+        // "(looking in )" that a bare relative manifest dir produced.
+        assert!(
+            !err.contains("(looking in )") && err.contains("qed.toml)"),
+            "search path must name the manifest absolutely: {err}"
         );
     }
 


### PR DESCRIPTION
Both papercuts from the issue:

1. **Empty `(looking in )`** — the unknown-manifest-dep error interpolated a possibly-empty relative manifest dir. It now names the searched `qed.toml` absolutely (canonicalized, cwd-joined fallback), asserted by the existing unknown-dep-key test extended to reject the empty parenthetical.

2. **Raw char-class parse errors** — the issue's proposed coarse mapping from parser context → construct name, at the error-rendering layer: `format_parse_error` scans back from the error offset to the nearest line whose first token is a known construct keyword (`handler`, `property`, `accounts`, `requires`, …, 33 keywords) and prefixes `(while parsing the \`<kw>\` construct)`. The full `Rich` expected-set detail is preserved for readers who want it. Nested clauses resolve to the most specific keyword since the scan finds the nearest. Gate: a broken handler signature (comma-separated tuple params) must name `handler`.

Full suite, fmt, clippy green.

Closes #254