### PR TITLE
fix(cli): canonicalize --program root; drop /./ from resolved codegen output paths (#289, #290)

### DIFF
--- a/crates/qedgen/src/probe/ratify.rs
+++ b/crates/qedgen/src/probe/ratify.rs
@@ -1235,7 +1235,21 @@ fn manifest_program_root(audit_dir: &Path) -> Option<PathBuf> {
         serde_json::from_str(&std::fs::read_to_string(audit_dir.join("run-manifest.json")).ok()?)
             .ok()?;
     let root = manifest.get("target")?.get("program_root")?.as_str()?;
-    (!root.is_empty()).then(|| PathBuf::from(root))
+    if root.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(root);
+    // #289: manifests written by pre-canonicalization binaries can carry
+    // a relative root (e.g. `"."`), whose `file_name()` is `None` and
+    // degrades every derived name to the `"program"` placeholder.
+    // Best-effort canonicalize against the ratify cwd; keep the raw
+    // path when resolution fails.
+    if path.is_relative() {
+        if let Ok(canonical) = path.canonicalize() {
+            return Some(canonical);
+        }
+    }
+    Some(path)
 }
 
 fn default_spec_path(audit_dir: &Path) -> PathBuf {
@@ -1936,6 +1950,36 @@ mod tests {
         assert_eq!(
             default_findings_dir(&audit),
             prog_root.join(".qed/findings")
+        );
+        Ok(())
+    }
+
+    /// #289: a relative `program_root` recorded by a pre-canonicalization
+    /// binary (`--program .`) resolves against the ratify cwd — derived
+    /// names use the real directory name, never the `program.qedspec`
+    /// placeholder that `file_name() == None` produces.
+    #[test]
+    fn default_paths_canonicalize_relative_manifest_program_root() -> Result<()> {
+        let dir = tempdir()?;
+        let audit = dir.path().join("audit");
+        std::fs::create_dir_all(&audit)?;
+        std::fs::write(
+            audit.join("run-manifest.json"),
+            r#"{ "target": { "program_root": "." } }"#,
+        )?;
+        let cwd = std::env::current_dir()?.canonicalize()?;
+        let name = cwd
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("test cwd has a name")
+            .to_string();
+        assert_eq!(
+            default_spec_path(&audit),
+            cwd.join(format!("{name}.qedspec"))
+        );
+        assert_eq!(
+            default_scoping_path(&audit),
+            cwd.join(".qed/plan/scoping.md")
         );
         Ok(())
     }

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -374,7 +374,11 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             // --program routes through the Pinocchio site enumerator; the
             // envelope's `findings` are the site catalogue mapped 1:1. The
             // audit subagent writes the reproducers.
-            if let Some(prog_root) = &program {
+            if let Some(raw_root) = &program {
+                // #289: resolve `--program .` (and any relative root) to
+                // its real directory before anything derives a name from
+                // it — see canonicalize_program_root.
+                let prog_root = &run_helpers::canonicalize_program_root(raw_root);
                 let detected = probe::detect_runtime_public(prog_root);
                 let runtime_final = runtime
                     .map(probe::Runtime::from)
@@ -1775,13 +1779,8 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     .unwrap_or_else(|| std::path::Path::new("."))
                     .to_path_buf()
             };
-            let against_spec = |p: PathBuf| -> PathBuf {
-                if p.is_absolute() {
-                    p
-                } else {
-                    spec_dir.join(p)
-                }
-            };
+            let against_spec =
+                |p: PathBuf| -> PathBuf { run_helpers::resolve_output_against_spec(&spec_dir, p) };
             let output_dir = against_spec(output_dir);
             let kani_output = against_spec(kani_output);
             let kani_impl_output = against_spec(kani_impl_output);

--- a/crates/qedgen/src/run_helpers.rs
+++ b/crates/qedgen/src/run_helpers.rs
@@ -48,6 +48,36 @@ pub(crate) fn note_sbpf_skip(artifact: &str) {
     );
 }
 
+/// Resolve a codegen output path against the spec's directory (#279).
+/// Relative paths — including every clap literal default like
+/// `./programs` — join onto `spec_dir`; the `Components` re-collect
+/// drops the interior `CurDir` so the resolved path never renders a
+/// literal `/./` (#290). Absolute paths pass through untouched.
+pub(crate) fn resolve_output_against_spec(spec_dir: &Path, p: PathBuf) -> PathBuf {
+    if p.is_absolute() {
+        p
+    } else {
+        spec_dir.join(p).components().collect()
+    }
+}
+
+/// Canonicalize the `--program` root once at the probe entry (#289).
+/// `--program .` is the natural invocation from inside a program root,
+/// but every downstream name — the skeleton `spec` name, the
+/// `target.program_root` recorded in the run manifest and dossier, and
+/// ratify's default `<name>.qedspec` — derives from
+/// `Path::file_name()`, which is `None` for `"."` and falls back to a
+/// `"program"` placeholder. Nonexistent paths fall back to a lexical
+/// cwd-join so downstream "not found" errors still fire on a concrete
+/// path.
+pub(crate) fn canonicalize_program_root(raw: &Path) -> PathBuf {
+    raw.canonicalize().unwrap_or_else(|_| {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(raw).components().collect())
+            .unwrap_or_else(|_| raw.to_path_buf())
+    })
+}
+
 /// Materialize the audit working set (`interview.md`, `clusters.json`,
 /// `skeleton.qedspec`, domain dossier seed, and run manifest) under `dir` —
 /// shared by the Pinocchio (run.rs),
@@ -1052,6 +1082,51 @@ mod tests {
     use crate::cluster::{cluster_protos, ClusterKind, ProtoClause};
     use crate::program_model::ProgramFramework;
     use std::path::PathBuf;
+
+    /// #290: resolved codegen output paths must never render a literal
+    /// `/./` — clap defaults are `./x` and `PathBuf::join` preserves
+    /// the `CurDir` component.
+    #[test]
+    fn resolved_output_paths_have_no_curdir_segment() {
+        let resolved = super::resolve_output_against_spec(
+            std::path::Path::new("/abs/path/to/project"),
+            PathBuf::from("./programs"),
+        );
+        assert_eq!(resolved, PathBuf::from("/abs/path/to/project/programs"));
+        assert!(
+            !resolved.display().to_string().contains("/./"),
+            "resolved path renders a literal /./: {}",
+            resolved.display()
+        );
+        // Absolute paths pass through untouched.
+        assert_eq!(
+            super::resolve_output_against_spec(
+                std::path::Path::new("/spec/dir"),
+                PathBuf::from("/elsewhere/out")
+            ),
+            PathBuf::from("/elsewhere/out")
+        );
+    }
+
+    /// #289: `--program .` resolves to a directory with a real name
+    /// (`file_name()` is no longer `None`); nonexistent roots fall back
+    /// to a lexical cwd-join that keeps the typed name.
+    #[test]
+    fn canonicalize_program_root_gives_dot_a_real_name() {
+        let root = super::canonicalize_program_root(std::path::Path::new("."));
+        assert!(root.is_absolute());
+        assert!(
+            root.file_name().is_some(),
+            "`.` must resolve to a named directory, got {}",
+            root.display()
+        );
+        let missing = super::canonicalize_program_root(std::path::Path::new("./no-such-dir-289"));
+        assert!(missing.is_absolute());
+        assert_eq!(
+            missing.file_name().and_then(|n| n.to_str()),
+            Some("no-such-dir-289")
+        );
+    }
 
     /// #196: the runtime-agnostic scanners fire on an ANCHOR-shaped crate —
     /// they used to be wired only into the Pinocchio probe branch, leaving

--- a/crates/qedgen/tests/bootstrap_ratify_journey.rs
+++ b/crates/qedgen/tests/bootstrap_ratify_journey.rs
@@ -82,3 +82,88 @@ fn bootstrap_probe_to_ratify_journey() {
         "doubled .qed/.qed.qedspec path must not reappear (#249)"
     );
 }
+
+/// #289: `probe --program .` from inside the program root — the natural
+/// invocation — must canonicalize before anything derives a name. The
+/// skeleton spec name, the manifest's recorded `target.program_root`,
+/// and ratify's default spec path all carry the directory's real name,
+/// never the `program`/`Program` placeholder.
+#[test]
+fn probe_program_dot_uses_real_directory_name() {
+    common::ensure_qedgen_built();
+
+    let (_tmp, root) = common::stage_fixture_named(
+        "crates/qedgen/tests/fixtures/probe-corpus/specless/pinocchio-codama",
+        "myvault",
+    );
+    let audit_rel = ".qed/audit/dot-journey";
+
+    let out = Command::new(common::qedgen_bin())
+        .args([
+            "probe",
+            "--program",
+            ".",
+            "--emit-spec-candidates",
+            "--audit-dir",
+            audit_rel,
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("run qedgen probe --program .");
+    assert!(
+        out.status.success(),
+        "probe --program . failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let audit = root.join(audit_rel);
+    let skeleton =
+        std::fs::read_to_string(audit.join("skeleton.qedspec")).expect("read skeleton.qedspec");
+    let spec_line = skeleton
+        .lines()
+        .find(|l| l.starts_with("spec "))
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        spec_line.to_lowercase().contains("myvault"),
+        "skeleton spec name must derive from the real directory name, got: {spec_line}"
+    );
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(audit.join("run-manifest.json")).expect("read run-manifest.json"),
+    )
+    .expect("parse run-manifest.json");
+    let recorded = manifest["target"]["program_root"]
+        .as_str()
+        .expect("target.program_root");
+    assert!(
+        std::path::Path::new(recorded).is_absolute() && recorded.ends_with("myvault"),
+        "manifest must record the canonicalized program root, got: {recorded}"
+    );
+
+    // Ratify's default output derives from the recorded root.
+    std::fs::write(audit.join("answers.json"), "{\"answers\":[]}\n").expect("write answers");
+    let out = Command::new(common::qedgen_bin())
+        .args(["ratify", "--audit-dir", audit_rel])
+        .current_dir(&root)
+        .output()
+        .expect("run qedgen ratify");
+    assert!(
+        out.status.success(),
+        "ratify failed on the --program . working set: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        root.join("myvault.qedspec").exists(),
+        "ratified spec must land at myvault.qedspec, not program.qedspec; dir: {:?}",
+        std::fs::read_dir(&root)
+            .map(|d| d
+                .filter_map(|e| e.ok().map(|e| e.file_name()))
+                .collect::<Vec<_>>())
+            .unwrap_or_default()
+    );
+    assert!(
+        !root.join("program.qedspec").exists(),
+        "placeholder program.qedspec must not be written (#289)"
+    );
+}

--- a/crates/qedgen/tests/common/mod.rs
+++ b/crates/qedgen/tests/common/mod.rs
@@ -102,6 +102,34 @@ pub fn stage_fixture(fixture_dir: &str) -> tempfile::TempDir {
     tmp
 }
 
+/// Like [`stage_fixture`], but copies into a *named* subdirectory of
+/// the tempdir — for tests whose assertions depend on the program
+/// root's directory name (#289; a bare tempdir's name is random).
+/// Returns the tempdir guard plus the staged program root.
+pub fn stage_fixture_named(fixture_dir: &str, name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dest = tmp.path().join(name);
+    fs::create_dir_all(&dest).expect("create named fixture dir");
+    let src = repo_root().join(fixture_dir);
+
+    let rsync = Command::new("rsync")
+        .args([
+            "-aq",
+            "--exclude=.anchor",
+            "--exclude=target",
+            "--exclude=.lake",
+            "--exclude=node_modules",
+        ])
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dest.display()))
+        .status()
+        .expect("spawn rsync");
+    assert!(rsync.success(), "rsync failed for fixture {}", fixture_dir);
+
+    git_init(&dest);
+    (tmp, dest)
+}
+
 /// Produce a unified-diff string between two multiline texts. Avoids
 /// pulling in an extra crate; the output isn't IDE-grade but suffices
 /// for test failure messages.


### PR DESCRIPTION
Fixes #289, fixes #290 — the two bug residuals from the 0719 triage wave.

## #289 — `probe --program .` yields placeholder names

The raw clap `--program` path was never canonicalized, so `Path::file_name()` (`None` for `"."`) degraded every derived name to the `program` / `spec Program` placeholder: the skeleton spec name, the `target.program_root` recorded in `run-manifest.json` / `domain-dossier.json`, and ratify's default `<name>.qedspec`.

- The probe entry (`run.rs`) canonicalizes once via new `run_helpers::canonicalize_program_root` before any branch (Anchor / Native / Pinocchio / fallback) derives a name; nonexistent roots fall back to a lexical cwd-join so downstream errors still fire on a concrete path.
- `ratify::manifest_program_root` defensively canonicalizes relative roots recorded in manifests written by pre-fix binaries.

## #290 — resolved codegen output paths render a literal `/./`

Relative output paths — including every clap literal default like `./programs` — resolved via `spec_dir.join(p)`, which preserves the `CurDir` component (residual of #279/#285). The `against_spec` seam now re-collects through `Components` (new `run_helpers::resolve_output_against_spec`), dropping the interior `.` for all nine `--*-output` flags at once. Verified end-to-end: `Generated 6 files in /abs/.../programs`, no `/./`.

## Gates

- `resolved_output_paths_have_no_curdir_segment` — resolved path contains no `/./`; absolute paths pass through untouched.
- `canonicalize_program_root_gives_dot_a_real_name` — `.` resolves to a named absolute dir; missing roots keep the typed name.
- `default_paths_canonicalize_relative_manifest_program_root` — ratify derives real names from a manifest recording `"."`.
- Journey test `probe_program_dot_uses_real_directory_name` — stages the pinocchio-codama fixture as `myvault/`, runs `probe --program . --emit-spec-candidates` + `ratify` from inside it; pins `spec Myvault`, an absolute manifest root ending in `myvault`, and `myvault.qedspec` (never `program.qedspec`). Adds a `stage_fixture_named` harness helper (a bare tempdir's random name can't anchor name assertions).

Full workspace `cargo test` green; `cargo clippy --all-targets` clean.