### PR TITLE
feat(codegen): --force and --merge-accounts rename recovery for user-owned files (#288)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -114,6 +114,8 @@ cargo test --manifest-path programs/Cargo.toml
 
 **No `--fill` flag.** The agent reads the generated files, greps for `todo!()`, looks up the matching handler / accounts / effect in the `.qedspec`, and edits each body in place. The old `qedgen codegen --fill` / `--fill-tests` flags emitted structured prompts to stdout for the agent to consume — useful before agents had file tools, ceremony now. They're soft-deprecated in v2.18 (print a warning, still run) and will be removed in v3.0. Same direct-edit pattern applies to integration tests and Crucible action bodies.
 
+**Spec-level renames.** `lib.rs` and `instructions/*.rs` are user-owned, so after renaming an account, state field, or handler in the spec, a plain `codegen` regenerates their siblings (guards.rs, state.rs, harnesses) but skips them with a stale-revision WARNING. Recover with `codegen --merge-accounts` (Anchor: regenerates only the `#[derive(Accounts)]` structs, handler fills survive) or `codegen --force` (regenerates the user-owned set wholesale — re-apply fills from git history). Both refuse to run unless the affected files are committed and unmodified in git, so commit before renaming.
+
 Step 5. Verify generated backends.
 
 ```bash

--- a/crates/qedgen/src/cli.rs
+++ b/crates/qedgen/src/cli.rs
@@ -1017,6 +1017,26 @@ pub(crate) enum Commands {
         #[arg(long, default_value = "./programs")]
         output_dir: PathBuf,
 
+        /// Regenerate the USER-OWNED files too (`src/lib.rs`,
+        /// `src/instructions/*.rs`) — the rename workflow where regen +
+        /// re-fill beats hand-merging (#288). Destructive: handler fills
+        /// are overwritten, so every affected file must have a committed,
+        /// unmodified git baseline (the recovery path); dirty or untracked
+        /// files abort before anything is written.
+        #[arg(long, conflicts_with = "merge_accounts")]
+        force: bool,
+
+        /// Surgical alternative to --force for spec-level renames (#288):
+        /// regenerate only the `#[derive(Accounts)]` structs inside the
+        /// user-owned `lib.rs`, preserving handler fills and everything
+        /// else (the Cargo.toml section-merge doctrine applied to Rust
+        /// items). Hand-tuned constraints inside replaced structs are
+        /// overwritten, so the same git-baseline guard applies. Structs
+        /// with no matching handler (e.g. pre-rename leftovers) are left
+        /// in place and reported. Anchor target only.
+        #[arg(long)]
+        merge_accounts: bool,
+
         /// Generate Kani proof harnesses
         #[arg(long)]
         kani: bool,

--- a/crates/qedgen/src/codegen/codegen_mir.rs
+++ b/crates/qedgen/src/codegen/codegen_mir.rs
@@ -14,12 +14,26 @@ use crate::fingerprint::SpecFingerprint;
 use crate::mir::Mir;
 use crate::Target;
 
+/// #288: opt-in regeneration of the user-owned file set. `force`
+/// overwrites `src/lib.rs` + `src/instructions/*.rs` wholesale (the
+/// regen + re-fill rename workflow); `merge_accounts` rewrites only the
+/// `#[derive(Accounts)]` structs inside a user-owned `lib.rs` (Anchor).
+/// Both destroy user content, so [`assert_git_recoverable`] gates them:
+/// every file they would touch needs a committed, unmodified git
+/// baseline first.
+#[derive(Clone, Copy, Default)]
+pub struct RegenOptions {
+    pub force: bool,
+    pub merge_accounts: bool,
+}
+
 struct CodegenCtx<'a> {
     mir: &'a Mir,
     parsed: &'a ParsedSpec,
     fp: &'a SpecFingerprint,
     spec_path: &'a Path,
     output_dir: &'a Path,
+    opts: RegenOptions,
 }
 
 /// Per-framework codegen. Every `emit_*` method defaults to the shared
@@ -39,6 +53,7 @@ trait FrameworkCodegen {
             ctx.output_dir,
             self.target(),
             ctx.spec_path,
+            ctx.opts,
         )
     }
 
@@ -62,6 +77,7 @@ trait FrameworkCodegen {
             ctx.spec_path,
             ctx.output_dir,
             self.target(),
+            ctx.opts.force,
         )
     }
 
@@ -130,6 +146,7 @@ pub fn generate(
     spec_path: &Path,
     output_dir: &Path,
     target: Target,
+    opts: RegenOptions,
 ) -> Result<()> {
     if parsed.handlers.is_empty() {
         anyhow::bail!("No handlers found in the spec — is this a valid qedspec file?");
@@ -144,6 +161,34 @@ pub fn generate(
         );
     }
 
+    if opts.merge_accounts && !matches!(target, Target::Anchor) {
+        anyhow::bail!(
+            "--merge-accounts is Anchor-only: on {:?} the accounts structs live in the \
+             user-owned instructions/<name>.rs files, not lib.rs. Use --force to \
+             regenerate the user-owned set wholesale.",
+            target
+        );
+    }
+
+    // #288: both destructive modes need git as the recovery path — refuse
+    // to overwrite any user-owned file that has no committed, unmodified
+    // baseline, BEFORE any sibling artifact is written.
+    if opts.force || opts.merge_accounts {
+        let mut targets = vec![output_dir.join("src").join("lib.rs")];
+        if opts.force {
+            for handler in &parsed.handlers {
+                targets.push(
+                    output_dir
+                        .join("src")
+                        .join("instructions")
+                        .join(format!("{}.rs", handler.name)),
+                );
+            }
+        }
+        targets.retain(|p| p.exists());
+        assert_git_recoverable(output_dir, &targets)?;
+    }
+
     std::fs::create_dir_all(output_dir)?;
 
     let fp = crate::fingerprint::compute_fingerprint(parsed);
@@ -153,6 +198,7 @@ pub fn generate(
         fp: &fp,
         spec_path,
         output_dir,
+        opts,
     };
 
     match target {
@@ -310,11 +356,55 @@ fn warn_stale_skip(what: &str, drift_root: &Path) {
         "WARNING: {what} was generated from a DIFFERENT spec revision — its #[qed] \
          spec_hash stamps don't match the current spec. After a spec-level rename \
          the regenerated files (state.rs, guards.rs, harnesses) disagree with it \
-         and the crate may not compile. Update it by hand, or delete it and re-run \
-         `qedgen codegen` to regenerate (then re-apply your handler fills); \
+         and the crate may not compile. Recover with `qedgen codegen --merge-accounts` \
+         (Anchor: regenerates only the #[derive(Accounts)] structs, keeping handler \
+         fills) or `qedgen codegen --force` (regenerates the user-owned set wholesale; \
+         re-apply fills from git history), or update it by hand; \
          `qedgen check --drift {} ` lists per-handler drift.",
         drift_root.display()
     );
+}
+
+/// #288: gate for the destructive regen modes. Every file they would
+/// overwrite must be recoverable from git — tracked AND unmodified —
+/// otherwise the overwrite silently destroys handler fills with no way
+/// back. `git status --porcelain` reports exactly the unrecoverable set
+/// (untracked `??`, or any staged/unstaged modification).
+fn assert_git_recoverable(output_dir: &Path, files: &[std::path::PathBuf]) -> Result<()> {
+    if files.is_empty() {
+        return Ok(());
+    }
+    let out = std::process::Command::new("git")
+        .arg("status")
+        .arg("--porcelain")
+        .arg("--untracked-files=all")
+        .arg("--")
+        .args(files)
+        .current_dir(output_dir)
+        .output();
+    let out = match out {
+        Ok(out) if out.status.success() => out,
+        _ => anyhow::bail!(
+            "--force/--merge-accounts need git history as the recovery path, but \
+             `git status` failed under {} — is this a git repository? \
+             (qedgen is git-native; run `git init` + commit first.)",
+            output_dir.display()
+        ),
+    };
+    let dirty: Vec<String> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|l| l.trim_end().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+    if !dirty.is_empty() {
+        anyhow::bail!(
+            "refusing to overwrite user-owned files that have no committed, unmodified \
+             git baseline — the overwrite would be unrecoverable:\n  {}\n\
+             Commit or stash them first (`git add -A && git commit`), then re-run.",
+            dirty.join("\n  ")
+        );
+    }
+    Ok(())
 }
 
 fn emit_lib(
@@ -324,13 +414,16 @@ fn emit_lib(
     output_dir: &Path,
     target: Target,
     spec_path: &Path,
+    opts: RegenOptions,
 ) -> Result<()> {
     use crate::codegen_shared::{to_pascal_case, FrameworkSurface};
 
     // Pinocchio: dedicated helper emits the no_std entrypoint +
     // byte-dispatch from ParsedSpec.
     if matches!(target, Target::Pinocchio) {
-        return crate::codegen_shared::emit_pinocchio_program_lib(parsed, fp, output_dir);
+        return crate::codegen_shared::emit_pinocchio_program_lib(
+            parsed, fp, output_dir, opts.force,
+        );
     }
 
     let surface = FrameworkSurface::for_target(target);
@@ -338,7 +431,19 @@ fn emit_lib(
     std::fs::create_dir_all(&src_dir)?;
 
     let lib_path = src_dir.join("lib.rs");
-    if lib_path.exists() {
+    if lib_path.exists() && opts.force {
+        // #288: recoverability was asserted up front in `generate`.
+        eprintln!(
+            "regenerating user-owned {} (--force) — previous version is in git history; \
+             re-apply handler fills from there.",
+            lib_path.display()
+        );
+    } else if lib_path.exists() {
+        // #288: surgical rename recovery — regenerate only the
+        // `#[derive(Accounts)]` structs, keep everything else.
+        if opts.merge_accounts && matches!(target, Target::Anchor) {
+            return merge_accounts_into_lib(mir, parsed, &lib_path);
+        }
         eprintln!(
             "programs/{}/src/lib.rs already exists — skipping (user-owned). guards.rs regenerated.",
             output_dir
@@ -590,6 +695,186 @@ fn emit_lib(
     Ok(())
 }
 
+/// Where a handler's `#[derive(Accounts)]` struct sits inside a
+/// user-owned `lib.rs` — or why it can't be merged.
+enum StructLocation {
+    /// Byte range covering the struct's leading attribute/doc lines
+    /// through its closing `}` (inclusive end).
+    Found(std::ops::Range<usize>),
+    /// A same-named struct exists but doesn't derive `Accounts` —
+    /// replacing it would clobber an unrelated user type, and appending
+    /// a duplicate name wouldn't compile. Left untouched.
+    Foreign,
+    Missing,
+}
+
+/// Locate `pub struct <name>` in `text` together with its contiguous
+/// leading attribute/doc-comment lines. Only a block whose leading
+/// attributes contain `#[derive(Accounts…` qualifies as replaceable.
+fn locate_accounts_struct(text: &str, name: &str) -> StructLocation {
+    let bytes = text.as_bytes();
+    let needle = format!("pub struct {name}");
+    let mut search_from = 0usize;
+    let mut saw_foreign = false;
+    while let Some(rel) = text[search_from..].find(&needle) {
+        let at = search_from + rel;
+        search_from = at + needle.len();
+        // Name boundary: reject prefix matches (`Pause` inside `Pause2`).
+        match bytes.get(at + needle.len()) {
+            Some(b) if b.is_ascii_alphanumeric() || *b == b'_' => continue,
+            _ => {}
+        }
+        // The declaration must start its line (filters `// pub struct …`
+        // comment mentions).
+        let line_start = text[..at].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        if text[line_start..at].trim() != "" {
+            continue;
+        }
+        let Some(open_rel) = text[at..].find('{') else {
+            continue;
+        };
+        let Some(close) = qedgen_hash_core::scan_balanced_block(bytes, at + open_rel) else {
+            continue;
+        };
+        // Walk back over contiguous attribute / doc-comment lines to
+        // include `#[derive(Accounts)]` (generated struct-level attrs are
+        // single-line; a hand-introduced multi-line attr above the struct
+        // is not walked — the git-baseline guard makes any mis-merge
+        // recoverable).
+        let mut region_start = line_start;
+        // `prev_end` is the index of the '\n' terminating the previous line.
+        while let Some(prev_end) = region_start.checked_sub(1) {
+            let prev_start = text[..prev_end].rfind('\n').map(|i| i + 1).unwrap_or(0);
+            let prev = text[prev_start..prev_end].trim();
+            if prev.starts_with("#[") || prev.starts_with("//") {
+                region_start = prev_start;
+            } else {
+                break;
+            }
+        }
+        if text[region_start..line_start].contains("#[derive(Accounts") {
+            return StructLocation::Found(region_start..close + 1);
+        }
+        saw_foreign = true;
+    }
+    if saw_foreign {
+        StructLocation::Foreign
+    } else {
+        StructLocation::Missing
+    }
+}
+
+/// #288 option 3 — surgical rename recovery for a user-owned Anchor
+/// `lib.rs`: regenerate every current handler's `#[derive(Accounts)]`
+/// struct in place (the Cargo.toml section-merge doctrine applied to
+/// Rust items), preserving the `#[program]` mod, handler fills, imports,
+/// and anything else the user wrote. Structs with no matching handler
+/// (pre-rename leftovers, hand-added instructions) are left in place and
+/// reported. The caller has already asserted a clean git baseline.
+fn merge_accounts_into_lib(mir: &Mir, parsed: &ParsedSpec, lib_path: &Path) -> Result<()> {
+    use crate::codegen_shared::{to_pascal_case, FrameworkSurface};
+
+    let existing = std::fs::read_to_string(lib_path)?;
+    let surface = FrameworkSurface::for_target(Target::Anchor);
+    let is_multi = parsed.account_types.len() > 1;
+    let default_state_name = format!("{}Account", to_pascal_case(&mir.name));
+
+    let fresh: Vec<(String, String)> = parsed
+        .handlers
+        .iter()
+        .map(|h| {
+            (
+                to_pascal_case(&h.name),
+                crate::codegen_shared::render_handler_accounts_struct(
+                    h,
+                    parsed,
+                    is_multi,
+                    &default_state_name,
+                    &surface,
+                    Target::Anchor,
+                ),
+            )
+        })
+        .collect();
+
+    let mut merged = existing.clone();
+    let mut replaced: Vec<&str> = Vec::new();
+    let mut added: Vec<&str> = Vec::new();
+    let mut foreign: Vec<&str> = Vec::new();
+    for (name, render) in &fresh {
+        match locate_accounts_struct(&merged, name) {
+            StructLocation::Found(range) => {
+                merged.replace_range(range, render.trim_end());
+                replaced.push(name);
+            }
+            StructLocation::Foreign => foreign.push(name),
+            StructLocation::Missing => {
+                // New (or renamed-to) handler: append before the trailing
+                // END marker when present, else at EOF.
+                let insertion = format!("\n{}", render);
+                match merged.rfind("// ---- END GENERATED ----") {
+                    Some(marker) => merged.insert_str(marker, &insertion),
+                    None => {
+                        if !merged.ends_with('\n') {
+                            merged.push('\n');
+                        }
+                        merged.push_str(&insertion);
+                    }
+                }
+                added.push(name);
+            }
+        }
+    }
+
+    // Orphans: derive(Accounts) structs with no current handler — a
+    // renamed handler's old struct, or a hand-added instruction's. Never
+    // deleted (the latter is legitimate user code); reported so rename
+    // leftovers get cleaned up by hand.
+    let current: std::collections::HashSet<&str> = fresh.iter().map(|(n, _)| n.as_str()).collect();
+    let mut orphans: Vec<String> = Vec::new();
+    let mut from = 0usize;
+    while let Some(rel) = merged[from..].find("#[derive(Accounts") {
+        let at = from + rel;
+        from = at + 1;
+        let window_end = (at + 400).min(merged.len());
+        if let Some(srel) = merged[at..window_end].find("pub struct ") {
+            let name_start = at + srel + "pub struct ".len();
+            let name: String = merged[name_start..]
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() && !current.contains(name.as_str()) {
+                orphans.push(name);
+            }
+        }
+    }
+
+    if merged != existing {
+        crate::codegen_shared::write_generated_file(lib_path, &merged)?;
+    }
+    eprintln!(
+        "merged #[derive(Accounts)] structs into user-owned {} (--merge-accounts): \
+         {} replaced, {} added; handler fills untouched.",
+        lib_path.display(),
+        replaced.len(),
+        added.len()
+    );
+    if !foreign.is_empty() {
+        eprintln!(
+            "warning: not merged (same-named struct without #[derive(Accounts)]): {}",
+            foreign.join(", ")
+        );
+    }
+    if !orphans.is_empty() {
+        eprintln!(
+            "note: structs with no matching spec handler were left in place \
+             (delete by hand if they belonged to a renamed handler): {}",
+            orphans.join(", ")
+        );
+    }
+    Ok(())
+}
+
 /// Emit `src/instructions/mod.rs` + per-handler `<name>.rs` scaffolds.
 /// Per-handler files are USER-OWNED — emitted only when missing; mod.rs
 /// is always regenerated. Scaffold bodies render from the matching
@@ -601,6 +886,7 @@ fn emit_instructions(
     spec_path: &Path,
     output_dir: &Path,
     target: Target,
+    force: bool,
 ) -> Result<()> {
     use crate::codegen_shared::to_pascal_case;
 
@@ -652,7 +938,14 @@ fn emit_instructions(
             })?;
 
         let handler_path = instr_dir.join(format!("{}.rs", handler.name));
-        if handler_path.exists() {
+        if handler_path.exists() && force {
+            // #288: recoverability was asserted up front in `generate`.
+            eprintln!(
+                "regenerating user-owned {} (--force) — previous version is in git history; \
+                 re-apply the handler fill from there.",
+                handler_path.display()
+            );
+        } else if handler_path.exists() {
             eprintln!(
                 "programs/{}/src/instructions/{}.rs already exists — skipping (user-owned). guards.rs regenerated.",
                 output_dir
@@ -1425,6 +1718,166 @@ mod tests {
         );
     }
 
+    fn parse_spec(src: &str) -> (Mir, ParsedSpec) {
+        let parsed = crate::chumsky_adapter::parse_str(src).expect("parse");
+        let mir = crate::mir::lower(&parsed);
+        (mir, parsed)
+    }
+
+    fn spec_with_account(account: &str) -> String {
+        format!(
+            r#"spec Renamer
+program_id "11111111111111111111111111111111"
+type State | Active of {{ total : U64 }}
+handler poke : State.Active -> State.Active {{
+  accounts {{ {account} : writable }}
+  effect {{ Active.total += 1 }}
+}}
+"#
+        )
+    }
+
+    /// #288 --merge-accounts: an account rename regenerates the struct's
+    /// fields in place while user content elsewhere in lib.rs survives.
+    #[test]
+    fn merge_accounts_updates_renamed_fields_preserving_user_content() {
+        let (mir_a, parsed_a) = parse_spec(&spec_with_account("vault"));
+        let fp = crate::fingerprint::compute_fingerprint(&parsed_a);
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let temp = tmp.path();
+        std::fs::create_dir_all(temp.join("src")).expect("mk src");
+        emit_lib(
+            &mir_a,
+            &parsed_a,
+            &fp,
+            temp,
+            Target::Anchor,
+            Path::new("unused.qedspec"),
+            RegenOptions::default(),
+        )
+        .expect("emit lib");
+
+        // Simulate user ownership: an edit outside the Accounts structs.
+        let lib_path = temp.join("src/lib.rs");
+        let lib = std::fs::read_to_string(&lib_path).expect("lib.rs");
+        assert!(lib.contains("pub vault:"), "baseline has vault field");
+        std::fs::write(
+            &lib_path,
+            lib.replace("use super::*;", "use super::*; // USER-KEPT"),
+        )
+        .expect("user edit");
+
+        // Spec-level rename vault → treasury, then merge.
+        let (mir_b, parsed_b) = parse_spec(&spec_with_account("treasury"));
+        merge_accounts_into_lib(&mir_b, &parsed_b, &lib_path).expect("merge");
+
+        let merged = std::fs::read_to_string(&lib_path).expect("merged lib.rs");
+        assert!(
+            merged.contains("pub treasury:") && !merged.contains("pub vault:"),
+            "struct fields must pick up the rename; got:\n{merged}"
+        );
+        assert!(
+            merged.contains("// USER-KEPT"),
+            "user content outside the structs must survive the merge; got:\n{merged}"
+        );
+    }
+
+    /// #288 --merge-accounts: a handler rename appends the new struct and
+    /// leaves the old one in place (reported, never deleted — it may be a
+    /// hand-added instruction's).
+    #[test]
+    fn merge_accounts_appends_new_struct_keeps_orphan() {
+        let (mir_a, parsed_a) = parse_spec(&spec_with_account("vault"));
+        let fp = crate::fingerprint::compute_fingerprint(&parsed_a);
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let temp = tmp.path();
+        std::fs::create_dir_all(temp.join("src")).expect("mk src");
+        emit_lib(
+            &mir_a,
+            &parsed_a,
+            &fp,
+            temp,
+            Target::Anchor,
+            Path::new("unused.qedspec"),
+            RegenOptions::default(),
+        )
+        .expect("emit lib");
+        let lib_path = temp.join("src/lib.rs");
+
+        // Handler rename poke → jab.
+        let renamed = spec_with_account("vault").replace("poke", "jab");
+        let (mir_b, parsed_b) = parse_spec(&renamed);
+        merge_accounts_into_lib(&mir_b, &parsed_b, &lib_path).expect("merge");
+
+        let merged = std::fs::read_to_string(&lib_path).expect("merged lib.rs");
+        assert!(
+            merged.contains("pub struct Jab"),
+            "renamed handler's struct must be appended; got:\n{merged}"
+        );
+        assert!(
+            merged.contains("pub struct Poke"),
+            "orphan struct is left in place for the user to delete; got:\n{merged}"
+        );
+    }
+
+    /// A same-named struct WITHOUT #[derive(Accounts)] is user territory:
+    /// never replaced, never duplicated.
+    #[test]
+    fn locate_accounts_struct_shapes() {
+        let text = "#[derive(Accounts)]\npub struct Pause<'info> {\n    pub a: u8,\n}\n\npub struct Pause2 {\n    pub b: u8,\n}\n";
+        assert!(matches!(
+            locate_accounts_struct(text, "Pause"),
+            StructLocation::Found(_)
+        ));
+        assert!(matches!(
+            locate_accounts_struct(text, "Pause2"),
+            StructLocation::Foreign
+        ));
+        assert!(matches!(
+            locate_accounts_struct(text, "Missing"),
+            StructLocation::Missing
+        ));
+        // Comment mentions don't count as declarations.
+        let commented = "// pub struct Ghost { }\n";
+        assert!(matches!(
+            locate_accounts_struct(commented, "Ghost"),
+            StructLocation::Missing
+        ));
+    }
+
+    /// #288 --force: an existing user-owned lib.rs is regenerated instead
+    /// of skipped (the git-recoverability guard lives in `generate`, not
+    /// here).
+    #[test]
+    fn force_regenerates_existing_lib() {
+        let (mir, parsed) = parse_spec(&spec_with_account("vault"));
+        let fp = crate::fingerprint::compute_fingerprint(&parsed);
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let temp = tmp.path();
+        std::fs::create_dir_all(temp.join("src")).expect("mk src");
+        let lib_path = temp.join("src/lib.rs");
+        std::fs::write(&lib_path, "// stale user-owned content\n").expect("seed lib");
+
+        emit_lib(
+            &mir,
+            &parsed,
+            &fp,
+            temp,
+            Target::Anchor,
+            Path::new("unused.qedspec"),
+            RegenOptions {
+                force: true,
+                merge_accounts: false,
+            },
+        )
+        .expect("emit lib");
+        let lib = std::fs::read_to_string(&lib_path).expect("lib.rs");
+        assert!(
+            lib.contains("#[program]") && !lib.contains("stale user-owned content"),
+            "--force must regenerate over the existing file; got:\n{lib}"
+        );
+    }
+
     fn lower_fixture(rel_path: &str) -> (Mir, ParsedSpec) {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -1496,6 +1949,7 @@ handler poke : State.Active -> State.Active {
             temp,
             Target::Anchor,
             Path::new("unused.qedspec"),
+            RegenOptions::default(),
         )
         .expect("emit lib");
         let lib = std::fs::read_to_string(temp.join("src/lib.rs")).expect("lib.rs");
@@ -1534,6 +1988,7 @@ handler poke : State.Active -> State.Active {
             temp,
             Target::Anchor,
             Path::new("unused.qedspec"),
+            RegenOptions::default(),
         )
         .expect("emit lib");
         let lib = std::fs::read_to_string(temp.join("src/lib.rs")).expect("lib.rs");

--- a/crates/qedgen/src/codegen/codegen_shared/generators.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/generators.rs
@@ -6,17 +6,25 @@ use super::*;
 
 /// Pinocchio `src/lib.rs` emitter: no_std crate root + module decls +
 /// `declare_id!` + `entrypoint!` + the byte-dispatch `process_instruction`.
-/// Idempotent: a pre-existing `src/lib.rs` is left untouched (user-owned).
+/// Idempotent: a pre-existing `src/lib.rs` is left untouched (user-owned)
+/// unless `force` regenerates it (#288 — recoverability is asserted by
+/// the caller before any artifact is written).
 pub(crate) fn emit_pinocchio_program_lib(
     spec: &ParsedSpec,
     fp: &SpecFingerprint,
     output_dir: &Path,
+    force: bool,
 ) -> Result<()> {
     let surface = FrameworkSurface::for_target(Target::Pinocchio);
     let src_dir = output_dir.join("src");
     std::fs::create_dir_all(&src_dir)?;
     let lib_path = src_dir.join("lib.rs");
-    if lib_path.exists() {
+    if lib_path.exists() && force {
+        eprintln!(
+            "regenerating user-owned {} (--force) — previous version is in git history.",
+            lib_path.display()
+        );
+    } else if lib_path.exists() {
         eprintln!(
             "programs/{}/src/lib.rs already exists — skipping (user-owned). guards.rs regenerated.",
             output_dir

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -1062,7 +1062,14 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 // `codegen` command.
                 let parsed = check::parse_spec_file(qedspec_path)?;
                 let mir = mir::lower(&parsed);
-                codegen_mir::generate(&mir, &parsed, qedspec_path, &program_dir, target)?;
+                codegen_mir::generate(
+                    &mir,
+                    &parsed,
+                    qedspec_path,
+                    &program_dir,
+                    target,
+                    codegen_mir::RegenOptions::default(),
+                )?;
 
                 // Kani harnesses are framework-neutral (pure spec-derived
                 // state model).
@@ -1735,6 +1742,8 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             spec,
             target,
             output_dir,
+            force,
+            merge_accounts,
             kani,
             kani_output,
             kani_impl,
@@ -1849,7 +1858,17 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                      — skipping greenfield Rust scaffold; the program already exists."
                 );
             } else {
-                codegen_mir::generate(&mir, &parsed, &spec, &output_dir, target)?;
+                codegen_mir::generate(
+                    &mir,
+                    &parsed,
+                    &spec,
+                    &output_dir,
+                    target,
+                    codegen_mir::RegenOptions {
+                        force,
+                        merge_accounts,
+                    },
+                )?;
             }
 
             if kani || all {

--- a/crates/qedgen/src/verify/regen_drift.rs
+++ b/crates/qedgen/src/verify/regen_drift.rs
@@ -166,8 +166,15 @@ fn check_example(example: &Example, report: &mut RegenDriftReport, mode: WriteMo
     for (rel, target) in program_outputs(&example.root)? {
         let parsed = crate::check::parse_spec_file(&spec_path)?;
         let mir = crate::mir::lower(&parsed);
-        crate::codegen_mir::generate(&mir, &parsed, &spec_path, &temp_root.join(&rel), target)
-            .with_context(|| format!("regenerating {} for {}", rel.display(), example.name))?;
+        crate::codegen_mir::generate(
+            &mir,
+            &parsed,
+            &spec_path,
+            &temp_root.join(&rel),
+            target,
+            crate::codegen_mir::RegenOptions::default(),
+        )
+        .with_context(|| format!("regenerating {} for {}", rel.display(), example.name))?;
     }
 
     generate_existing_artifacts(&example.root, &temp_root, &spec_path)

--- a/crates/qedgen/tests/documented_lane_journeys.rs
+++ b/crates/qedgen/tests/documented_lane_journeys.rs
@@ -74,6 +74,134 @@ fn quickstart_init_check_codegen_journey() {
     }
 }
 
+/// #288 rename→recover lane (the #253 dogfooding session, mechanized):
+/// scaffold → fill → commit → spec-level account rename → `codegen`
+/// warns on the stale user-owned skip → `--merge-accounts` surgically
+/// updates the `#[derive(Accounts)]` structs (fills preserved) →
+/// `--force` refuses while user-owned files are dirty and regenerates
+/// wholesale once committed.
+#[test]
+fn rename_recover_journey() {
+    common::ensure_qedgen_built();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    let spec = |account: &str| {
+        format!(
+            r#"spec Renamer
+program_id "11111111111111111111111111111111"
+type State | Active of {{ total : U64 }}
+handler poke : State.Active -> State.Active {{
+  accounts {{ {account} : writable }}
+  effect {{ Active.total += 1 }}
+}}
+"#
+        )
+    };
+    std::fs::write(root.join("renamer.qedspec"), spec("vault")).expect("write spec");
+    common::git_init(root);
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(["-c", "user.email=j@t", "-c", "user.name=journey"])
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    assert_ok(
+        "qedgen init",
+        &qedgen(
+            root,
+            &["init", "--name", "renamer", "--spec", "renamer.qedspec"],
+        ),
+    );
+    assert_ok("qedgen codegen", &qedgen(root, &["codegen"]));
+
+    // Simulate the agent fill, then commit — the recovery baseline.
+    let instr_path = root.join("programs/src/instructions/poke.rs");
+    let instr = std::fs::read_to_string(&instr_path).expect("poke.rs");
+    std::fs::write(&instr_path, format!("{instr}// FILL-MARKER\n")).expect("fill");
+    git(&["add", "-A"]);
+    git(&["commit", "-qm", "scaffold + fill"]);
+
+    // Spec-level rename: account vault → treasury.
+    std::fs::write(root.join("renamer.qedspec"), spec("treasury")).expect("rename spec");
+
+    // Plain codegen: skips the user-owned set but must WARN it's stale
+    // and name the recovery flags (#253 option 1 + #288).
+    let out = qedgen(root, &["codegen"]);
+    assert_ok("qedgen codegen (post-rename)", &out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("DIFFERENT spec revision") && stderr.contains("--merge-accounts"),
+        "post-rename codegen must warn stale and name the recovery flags; stderr:\n{stderr}"
+    );
+    let lib_path = root.join("programs/src/lib.rs");
+    let lib = std::fs::read_to_string(&lib_path).expect("lib.rs");
+    assert!(
+        lib.contains("pub vault:"),
+        "plain codegen must not touch the user-owned lib.rs"
+    );
+
+    // Surgical recovery: structs update, fills survive.
+    assert_ok(
+        "qedgen codegen --merge-accounts",
+        &qedgen(root, &["codegen", "--merge-accounts"]),
+    );
+    let lib = std::fs::read_to_string(&lib_path).expect("lib.rs");
+    assert!(
+        lib.contains("pub treasury:") && !lib.contains("pub vault:"),
+        "--merge-accounts must regenerate the Accounts struct fields; got:\n{lib}"
+    );
+    assert!(
+        std::fs::read_to_string(&instr_path)
+            .expect("poke.rs")
+            .contains("// FILL-MARKER"),
+        "--merge-accounts must not touch instruction fills"
+    );
+
+    // --force refuses while user-owned files have uncommitted changes
+    // (the merged lib.rs is dirty; dirty the fill too).
+    let instr = std::fs::read_to_string(&instr_path).expect("poke.rs");
+    std::fs::write(&instr_path, format!("{instr}// UNCOMMITTED\n")).expect("dirty fill");
+    let out = qedgen(root, &["codegen", "--force"]);
+    assert!(
+        !out.status.success(),
+        "--force must refuse dirty user-owned files; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Commit or stash"),
+        "refusal must point at the git recovery path; stderr:\n{stderr}"
+    );
+
+    // Committed baseline → --force regenerates the user-owned set.
+    git(&["add", "-A"]);
+    git(&["commit", "-qm", "pre-force baseline"]);
+    assert_ok(
+        "qedgen codegen --force",
+        &qedgen(root, &["codegen", "--force"]),
+    );
+    assert!(
+        !std::fs::read_to_string(&instr_path)
+            .expect("poke.rs")
+            .contains("FILL-MARKER"),
+        "--force must regenerate the instruction scaffold wholesale"
+    );
+    let lib = std::fs::read_to_string(&lib_path).expect("lib.rs");
+    assert!(
+        lib.contains("pub treasury:"),
+        "--force regen must carry the renamed account; got:\n{lib}"
+    );
+}
+
 /// Scaffold-to-spec lane: `probe --program <anchor-root>
 /// --emit-spec-candidates --audit-dir` → author `answers.json` →
 /// `ratify --audit-dir`, per the auditor guidance — the Anchor-extractor

--- a/references/cli.md
+++ b/references/cli.md
@@ -685,6 +685,11 @@ $QEDGEN codegen --test
 $QEDGEN codegen --proptest
 $QEDGEN codegen --integration
 $QEDGEN codegen --ci
+
+# Rename recovery (#288) — after a spec-level rename left the user-owned
+# files stale (codegen warns). Both need a committed git baseline.
+$QEDGEN codegen --merge-accounts   # Anchor: regen #[derive(Accounts)] structs only, fills survive
+$QEDGEN codegen --force            # regen user-owned set wholesale; re-apply fills from git
 ```
 
 | Flag | Type | Default | Description |
@@ -692,6 +697,8 @@ $QEDGEN codegen --ci
 | `--spec` | Path | optional | Spec file or directory. Defaults to `.qed/config.json spec` |
 | `--target` | enum | `anchor` | Framework target for the Rust program crate. Values: `anchor` (Anchor-compatible, default); `quasar` (Blueshift `quasar_lang`); `pinocchio` (Pinocchio `#![no_std]` — `entrypoint!` + byte-discriminant dispatch, zeropod zero-copy state, `&AccountInfo` account structs with `.handler()` methods, checked effects, SPL Token CPIs). All three targets emit the full program scaffold. The verification backends (`--kani` / `--proptest` / `--lean` / `--ci`) are spec-driven and target-agnostic — they run for any target (see the comment at the top of any generated `tests/kani.rs`). Exception: `--integration` is Quasar-only — the in-process SVM scaffold imports `quasar_svm` and the generated `<name>-client` crate, which don't compile for other targets; non-Quasar targets skip it with a note. |
 | `--output-dir` | Path | `./programs` | Output directory for Rust skeleton |
+| `--force` | bool | false | **Destructive opt-in (#288):** regenerate the USER-OWNED files too (`src/lib.rs`, `src/instructions/*.rs`) — the rename workflow where regen + re-fill beats hand-merging. Every affected file must have a committed, unmodified git baseline (the recovery path); dirty or untracked files abort before anything is written. Conflicts with `--merge-accounts`. |
+| `--merge-accounts` | bool | false | **Surgical rename recovery (#288, Anchor only):** regenerate only the `#[derive(Accounts)]` structs inside the user-owned `lib.rs`, preserving handler fills and everything else (the Cargo.toml section-merge doctrine applied to Rust items). Hand-tuned constraints inside replaced structs are overwritten, so the same git-baseline guard applies. Structs with no matching spec handler (pre-rename leftovers, hand-added instructions) are left in place and reported. |
 | `--all` | bool | false | Generate all artifacts |
 | `--lean` | bool | false | Generate Lean 4 proofs |
 | `--lean-output` | Path | `./formal_verification/Spec.lean` | Lean output path |


### PR DESCRIPTION
Fixes #288 — ships both remaining options from #253 (option 1, the stale-skip warning, landed in #287), plus the deferred #269 rename→recover journey test.

## `codegen --force` (all targets)

Regenerates the user-owned set too (`src/lib.rs`, `src/instructions/*.rs`) — the rename workflow where regen + re-fill beats hand-merging. Gated by a **git-recoverability guard** that runs in `generate` before any artifact is written: every file the flag would overwrite must be tracked AND unmodified (`git status --porcelain`), otherwise codegen aborts listing the dirty files with commit/stash guidance. A `--force` can never destroy fills that git can't recover. Threaded via a new `RegenOptions` through all three skip sites (Anchor/Quasar `emit_lib`, `emit_instructions`, the Pinocchio lib emitter).

## `codegen --merge-accounts` (Anchor only, conflicts with `--force`)

Surgical rename recovery — the Cargo.toml section-merge doctrine applied to Rust items. Regenerates each current handler's `#[derive(Accounts)]` struct inside the user-owned `lib.rs` in place (struct located by name + attribute-line walk-back, block-bounded by `qedgen-hash-core::scan_balanced_block`), preserving the `#[program]` mod, handler fills, imports, and everything else. New/renamed handlers get their struct appended before the END marker. Structs with no matching spec handler are **reported, never deleted** (they may belong to hand-added instructions); a same-named struct without `derive(Accounts)` is user territory and left alone. Replacing a struct overwrites hand-tuned constraints, so the same git-baseline guard applies.

## Supporting changes

- The #253 stale-skip WARNING now names both flags as the recovery path.
- `references/cli.md`: flag table entries + rename-recovery examples; `SKILL.md`: a "Spec-level renames" note in the fill step.
- Non-Anchor targets error early on `--merge-accounts` with a pointer to `--force`.

## Gates

- Unit: `merge_accounts_updates_renamed_fields_preserving_user_content`, `merge_accounts_appends_new_struct_keeps_orphan`, `locate_accounts_struct_shapes` (name-boundary `Pause`/`Pause2`, comment mentions, foreign structs), `force_regenerates_existing_lib`.
- Journey (`documented_lane_journeys.rs::rename_recover_journey`, #269's deferred candidate): scaffold → fill → commit → rename `vault`→`treasury` → plain `codegen` warns naming the flags → `--merge-accounts` updates the struct, fill survives → `--force` refuses on a dirty tree → after commit, regenerates wholesale.
- `cargo fmt --check` clean, clippy zero warnings, full workspace `cargo test` green, `release-gate.sh` clean (7 baselines + zero-sorry sweep), `check --regen-drift` clean over all 7 examples.