### PR TITLE
fix(codegen): Anchor init space target and InitSpace derive

### DIFF
--- a/crates/qedgen/src/codegen/codegen_mir.rs
+++ b/crates/qedgen/src/codegen/codegen_mir.rs
@@ -1030,8 +1030,7 @@ fn emit_state(
     target: Target,
 ) -> Result<()> {
     use crate::codegen_shared::{
-        is_multi_variant_adt_state, map_type_for_target, map_type_pod, to_pascal_case,
-        FrameworkSurface,
+        is_multi_variant_adt_state, map_type_for_target, map_type_pod, FrameworkSurface,
     };
 
     // Pinocchio: zeropod zero-copy state via the dedicated helper.
@@ -1137,7 +1136,9 @@ fn emit_state(
         }
     } else if is_multi_variant_adt_state(parsed) && matches!(target, Target::Anchor) {
         // Multi-variant ADT: wrapper struct + inner enum + accessors.
-        let state_name = format!("{}Account", to_pascal_case(&mir.name));
+        // Shared derivation with the `space =` reference — see
+        // `state_struct_name`.
+        let state_name = crate::codegen_shared::state_struct_name(parsed, None);
         let inner_name = format!("{}Inner", state_name);
         let acct = &parsed.account_types[0];
 
@@ -1174,15 +1175,24 @@ fn emit_state(
             /* blank_after_impl */ false,
         )?;
     } else {
-        // Flat single-account fallback.
-        let state_name = format!("{}Account", to_pascal_case(&mir.name));
+        // Flat single-account fallback. Shared derivation with the
+        // `space =` reference — see `state_struct_name`.
+        let state_name = crate::codegen_shared::state_struct_name(parsed, None);
 
         let account_attr = if surface.explicit_account_discriminator {
             "#[account(discriminator = 1)]\n"
         } else {
             "#[account]\n"
         };
-        out.push_str(&format!("{}pub struct {} {{\n", account_attr, state_name));
+        out.push_str(account_attr);
+        // `InitSpace` on every Anchor account struct, matching the
+        // multi-account and ADT branches: an `init` account renders
+        // `space = 8 + <T>::INIT_SPACE`, which does not resolve without
+        // the derive (E0599, scaffold did not compile).
+        if matches!(target, Target::Anchor) {
+            out.push_str("#[derive(InitSpace)]\n");
+        }
+        out.push_str(&format!("pub struct {} {{\n", state_name));
 
         for (fname, ftype) in &parsed.state_fields {
             out.push_str(&format!(
@@ -2273,6 +2283,99 @@ handler poke : State.Active -> State.Active {
         assert!(
             body.contains("PoolInner::balance() called on a variant without `balance`"),
             "expected panic message for missing variant; got:\n{body}"
+        );
+    }
+
+    /// #305 regression: the `space = 8 + <T>::INIT_SPACE` attribute and
+    /// the state-struct emission are rendered at different sites, and
+    /// diverged two ways on a single-account spec whose ADT name differs
+    /// from the program name:
+    /// - the space target read the ADT name (`VaultAccount`) while the
+    ///   struct was named after the program (`RuntimeVaultAccount`) —
+    ///   E0433, undeclared type;
+    /// - the flat branch emitted `#[account]` without
+    ///   `#[derive(InitSpace)]`, so `INIT_SPACE` did not resolve — E0599.
+    ///
+    /// Asserts the invariant rather than either spelling: whatever struct
+    /// `space =` names must be the struct that is emitted, and it must
+    /// carry the derive.
+    #[test]
+    fn init_space_target_matches_the_emitted_state_struct() {
+        const SRC: &str = r#"spec RuntimeVault
+
+type Vault
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+type Error
+  | InvalidAmount
+
+pda vault ["vault", owner]
+
+handler open : Vault.Uninitialized -> Vault.Active {
+  auth owner
+  accounts {
+    owner          : signer, writable
+    vault          : writable, pda ["vault", owner]
+    system_program : program
+  }
+  effect {
+    owner := owner.pubkey
+    total := 0
+  }
+}
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let spec_path = dir.path().join("vault.qedspec");
+        std::fs::write(&spec_path, SRC).unwrap();
+        std::fs::create_dir_all(dir.path().join(".qed")).unwrap();
+
+        let spec = crate::check::parse_spec_file(&spec_path).expect("parse");
+        let mir = crate::mir::lower(&spec);
+        let out_dir = dir.path().join("programs");
+        generate(
+            &mir,
+            &spec,
+            &spec_path,
+            &out_dir,
+            Target::Anchor,
+            RegenOptions::default(),
+        )
+        .expect("anchor codegen should succeed");
+
+        let state = std::fs::read_to_string(out_dir.join("src/state.rs")).expect("state.rs");
+        let lib = std::fs::read_to_string(out_dir.join("src/lib.rs")).expect("lib.rs");
+
+        // Pull the struct named by `space = 8 + <T>::INIT_SPACE`.
+        let marker = "space = 8 + ";
+        let start = lib
+            .find(marker)
+            .map(|i| i + marker.len())
+            .expect("init account renders a space attribute");
+        let space_target = lib[start..]
+            .split("::INIT_SPACE")
+            .next()
+            .expect("space target is an INIT_SPACE reference")
+            .to_string();
+
+        // The named struct must be the one actually emitted...
+        assert!(
+            state.contains(&format!("pub struct {space_target} {{")),
+            "space target `{space_target}` names no emitted struct:\n{state}"
+        );
+        // ...and it must derive InitSpace, or `INIT_SPACE` does not resolve.
+        assert!(
+            state.contains("#[derive(InitSpace)]"),
+            "Anchor state struct must derive InitSpace:\n{state}"
+        );
+        // Guard the specific historical spelling too, so a regression is
+        // reported as a name mismatch rather than a bare missing struct.
+        assert_eq!(
+            space_target, "RuntimeVaultAccount",
+            "single-account spec names the wrapper after the program, not the ADT"
         );
     }
 }

--- a/crates/qedgen/src/codegen/codegen_shared/account_attr.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/account_attr.rs
@@ -107,16 +107,15 @@ pub(crate) fn quasar_account_attr(
         // the canonical form is `space = 8 + <AccountStruct>::INIT_SPACE`
         // (8 = Anchor discriminator). The struct name must match what
         // `generate_state` emits.
-        let space_target = match (target, handler.on_account.as_deref()) {
-            // Multi-state spec: per-handler `on_account` names
-            // the ADT being driven. The wrapper struct is
-            // `<Name>Account`.
-            (_, Some(adt_name)) => format!("{}Account", adt_name),
-            // Single-state spec on Anchor: the wrapper is
-            // `<Program>Account` (matches `generate_state`'s
-            // non-multi branch).
-            (crate::Target::Anchor, None) => {
-                format!("{}Account", to_pascal_case(&spec.program_name))
+        let space_target = match target {
+            // Shared derivation with `generate_state` — see
+            // `state_struct_name`. Keying on `on_account` alone emitted
+            // `<Adt>Account` for single-account specs whose ADT name
+            // differs from the program name, against a struct actually
+            // named `<Program>Account` (E0433, scaffold did not
+            // compile).
+            crate::Target::Anchor => {
+                crate::codegen_shared::state_struct_name(spec, handler.on_account.as_deref())
             }
             // Quasar handles space differently — its `init`
             // analogue takes size from the typed `Account<T>`

--- a/crates/qedgen/src/codegen/codegen_shared/generators.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/generators.rs
@@ -560,6 +560,28 @@ pub fn is_multi_variant_adt_state(spec: &ParsedSpec) -> bool {
             .unwrap_or(false)
 }
 
+/// The generated account-wrapper struct name for the state a handler
+/// drives. Single source for the two sites that must agree: the struct
+/// `generate_state` emits, and the `space = 8 + <T>::INIT_SPACE`
+/// reference `account_attr` renders on an `init` account. When they
+/// disagree the generated scaffold does not compile.
+///
+/// Only a MULTI-account spec names the wrapper after the ADT — there is
+/// one struct per account type. A single-account spec (flat state or
+/// multi-variant ADT alike) names it after the program, so keying on
+/// `on_account` alone is wrong: a lifecycle-typed handler
+/// (`: Vault.Uninitialized -> Vault.Active`) sets `on_account` even
+/// when the spec has exactly one account type.
+pub fn state_struct_name(spec: &ParsedSpec, on_account: Option<&str>) -> String {
+    match on_account {
+        Some(adt) if spec.account_types.len() > 1 => format!("{adt}Account"),
+        _ => format!(
+            "{}Account",
+            crate::codegen_shared::to_pascal_case(&spec.program_name)
+        ),
+    }
+}
+
 /// Index an ADT account's variant fields: field name → every
 /// `(variant_name, declared_type)` occurrence, in name-sorted (BTreeMap)
 /// order. Raw view — includes fields whose type differs across variants;

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -184,6 +184,7 @@ pub struct Deposit {}
 use anchor_lang::prelude::*;
 
 #[account]
+#[derive(InitSpace)]
 pub struct PoolDemoAccount {
     pub pool_balance: u64,
     pub status: u8,

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -379,6 +379,7 @@ pub struct Initialize<'info> {
 use anchor_lang::prelude::*;
 
 #[account]
+#[derive(InitSpace)]
 pub struct EscrowAccount {
     pub initializer: Pubkey,
     pub taker: Pubkey,

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -4278,6 +4278,7 @@ mod escrow {
 use anchor_lang::prelude::*;
 
 #[account]
+#[derive(InitSpace)]
 pub struct EscrowAccount {
     pub initializer: Pubkey,
     pub initializer_token_account: Pubkey,

--- a/crates/qedgen/tests/snapshots/let-bindings-fee-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/let-bindings-fee-split.codegen.txt
@@ -223,6 +223,7 @@ pub struct State {
 }
 
 #[account]
+#[derive(InitSpace)]
 pub struct FeeSplitAccount {
     pub pool: u64,
     pub fees: u64,

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -1178,6 +1178,7 @@ mod multisig {
 use anchor_lang::prelude::*;
 
 #[account]
+#[derive(InitSpace)]
 pub struct MultisigAccount {
     pub creator: Pubkey,
     pub threshold: u8,


### PR DESCRIPTION
Fixes #305. Found while building the #294 P0 runtime-journey fixture.

Two defects, one family: the `space = 8 + <T>::INIT_SPACE` attribute and the state-struct emission are rendered at separate sites that could disagree. Either one makes the generated Anchor scaffold fail to compile.

## 1. Wrong struct name (E0433)

`account_attr` keyed the space target on `handler.on_account` being set, yielding `<Adt>Account`. But only a **multi**-account spec names the wrapper per ADT; a single-account spec names it `<Program>Account`. A lifecycle-typed handler (`: Vault.Uninitialized -> Vault.Active`) sets `on_account` even with one account type, so the derivations diverged whenever the ADT name differed from the program name:

```
error[E0433]: failed to resolve: use of undeclared type `VaultAccount`
   space = 8 + VaultAccount::INIT_SPACE   // struct is RuntimeVaultAccount
```

## 2. Missing derive (E0599)

The flat single-account branch emitted `#[account]` without `#[derive(InitSpace)]`, while `account_attr` always renders the space attribute for an Anchor `init`. The multi-account and ADT branches already emitted the derive; only the flat branch missed it — so **every single-account flat-state Anchor spec with an `init` handler** was affected.

## Fix

Both sites now share one derivation, `codegen_shared::state_struct_name(spec, on_account)`, so they cannot drift apart again. This is a narrow instance of #294's P1 item "build one canonical account/PDA plan and consume it"; the broader refactor is still worth doing.

## Testing

- Regression `init_space_target_matches_the_emitted_state_struct` asserts the invariant rather than either spelling: whatever struct `space =` names must be the emitted struct, and it must carry the derive.
- Full suite (21 targets), clippy `-D warnings`, rustfmt, `check --regen-drift`: green.
- Artifact gate residuals unchanged — lending 21/22 and multisig 46/51, the same six #263 class-4 guard fixtures as before this change.
- Snapshot and bundled-example churn is exactly five added `#[derive(InitSpace)]` lines.

## Why no gate caught it

No bundled example combines single-account flat state with an `init` PDA handler and an ADT name distinct from the program name. The runtime-journey fixture (#294 P0 item 2, in progress) does, and will be compiled by the gate.