### PR TITLE
feat(ci): cover the PDA-authority SPL Token CPI in the runtime journey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,6 +1911,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mollusk-svm-programs-token"
+version = "0.12.1-agave-4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe445a22e9fb2ab0d8bb38207f2f162eb7c0590afb5b83b2104fe04d42547d7"
+dependencies = [
+ "mollusk-svm",
+ "solana-account",
+ "solana-program-pack",
+ "solana-pubkey 4.2.0",
+ "solana-rent",
+ "spl-associated-token-account-interface",
+ "spl-token-interface",
+]
+
+[[package]]
 name = "mollusk-svm-result"
 version = "0.12.1-agave-4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +1991,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2050,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2264,9 +2312,14 @@ name = "qedgen-sandbox"
 version = "0.1.0"
 dependencies = [
  "mollusk-svm",
+ "mollusk-svm-programs-token",
+ "qedgen-hash-core",
  "solana-account",
  "solana-instruction",
+ "solana-program-pack",
  "solana-pubkey 4.2.0",
+ "spl-token-interface",
+ "tempfile",
 ]
 
 [[package]]
@@ -2952,6 +3005,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
 dependencies = [
  "borsh",
+ "bytemuck",
+ "bytemuck_derive",
  "curve25519-dalek",
  "five8",
  "five8_const",
@@ -3423,6 +3478,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4068648649653c2c50546e9a7fb761791b5ab0cda054c771bb5808d3a4b9eb52"
 dependencies = [
  "solana-define-syscall 4.0.1",
+]
+
+[[package]]
+name = "solana-program-option"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a88006a9b8594088cec9027ab77caaaa258a2aaa2083d3f086c44b42e50aeab"
+
+[[package]]
+name = "solana-program-pack"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7701cb15b90667ae1c89ef4ac35a59c61e66ce58ddee13d729472af7f41d59"
+dependencies = [
+ "solana-program-error",
 ]
 
 [[package]]
@@ -3926,6 +3996,36 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "spl-associated-token-account-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "spl-token-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/qedgen-sandbox/Cargo.toml
+++ b/crates/qedgen-sandbox/Cargo.toml
@@ -30,4 +30,9 @@ solana-pubkey = "4"
 # discriminator (first 8 bytes of sha256), reusing the repo's own
 # hashing crate instead of adding a second sha2 dependency.
 qedgen-hash-core = { version = "0.1.0", path = "../qedgen-hash-core" }
+# SPL Token program + Mint/TokenAccount fixtures for the PDA-signed
+# CPI journey. Version-matched to mollusk-svm above.
+mollusk-svm-programs-token = "0.12.1-agave-4.0"
+spl-token-interface = "2.0.0"
+solana-program-pack = "3"
 tempfile = "3"

--- a/crates/qedgen-sandbox/tests/runtime_journey.rs
+++ b/crates/qedgen-sandbox/tests/runtime_journey.rs
@@ -17,13 +17,19 @@
 //! handler bodies are committed — they are the agent-fill half that
 //! codegen deliberately leaves as `todo!()`.
 //!
-//! Scope: this covers the `Uninitialized -> Active` PDA initialization
-//! and its failure modes. The SPL Token CPI whose authority is a
-//! program PDA is the other half of the #294 requirement and needs the
-//! token program ELF wired into Mollusk — tracked separately.
+//! Two journeys, covering both halves of the #294 requirement:
 //!
-//! `#[ignore]` because it shells out to `cargo build-sbf` (~30s warm,
-//! minutes cold) and needs the Solana platform tools.
+//! - `pda_init_journey_and_constraint_violations` — the
+//!   `Uninitialized -> Active` PDA initialization plus its failure
+//!   modes (wrong seeds, non-canonical bump, unsigned payer, re-init).
+//! - `token_cpi_journey_with_pda_authority` — an SPL Token CPI whose
+//!   authority is the vault PDA, so the program signs with the vault's
+//!   seeds and bump. Those must agree with the generated
+//!   `#[account(seeds = …, bump)]` constraint; a mismatch compiles
+//!   cleanly and fails only at runtime.
+//!
+//! `#[ignore]` because they shell out to `cargo build-sbf` (~30s warm,
+//! minutes cold) and need the Solana platform tools.
 
 use mollusk_svm::program::keyed_account_for_system_program;
 use mollusk_svm::Mollusk;
@@ -194,8 +200,12 @@ impl Journey {
     fn new(deploy_dir: &Path) -> Self {
         std::env::set_var("SBF_OUT_DIR", deploy_dir);
         let program_id = Pubkey::from_str(PROGRAM_ID).expect("program id");
+        let mut mollusk = Mollusk::new(&program_id, "runtimevault");
+        // The vault CPIs into SPL Token; without the real program in the
+        // cache the transfer cannot execute at all.
+        mollusk_svm_programs_token::token::add_program(&mut mollusk);
         Self {
-            mollusk: Mollusk::new(&program_id, "runtimevault"),
+            mollusk,
             program_id,
         }
     }
@@ -232,6 +242,142 @@ impl Journey {
             (*vault, vault_account),
             (system_id, system_account),
         ]
+    }
+
+    /// Open a vault and return its post-state account. Every token
+    /// journey starts from a real, program-created vault rather than a
+    /// hand-built one, so the bump under test is the one `init`
+    /// actually stored.
+    fn open_vault(&self, owner: &Pubkey) -> (Pubkey, Account) {
+        let (vault, _) = self.vault_for(owner);
+        let result = self.mollusk.process_instruction(
+            &self.open_ix(owner, &vault, true),
+            &self.accounts(owner, &vault, Account::default()),
+        );
+        assert!(
+            result.program_result.is_ok(),
+            "open must succeed before a token journey: {:?}",
+            result.program_result
+        );
+        let account = result
+            .resulting_accounts
+            .iter()
+            .find(|(k, _)| k == &vault)
+            .map(|(_, a)| a.clone())
+            .expect("vault in result");
+        (vault, account)
+    }
+
+    /// `deposit` / `withdraw` share an account layout: owner, vault,
+    /// vault_ta, owner_ta, token_program.
+    fn token_ix(&self, handler: &str, ctx: &TokenCtx, amount: u64) -> Instruction {
+        let mut data = discriminator(handler);
+        data.extend_from_slice(&amount.to_le_bytes());
+        Instruction::new_with_bytes(
+            self.program_id,
+            &data,
+            vec![
+                AccountMeta::new(ctx.owner, true),
+                AccountMeta::new(ctx.vault, false),
+                AccountMeta::new(ctx.vault_ta, false),
+                AccountMeta::new(ctx.owner_ta, false),
+                AccountMeta::new_readonly(mollusk_svm_programs_token::token::ID, false),
+            ],
+        )
+    }
+}
+
+/// The account set a token journey threads between instructions.
+struct TokenCtx {
+    owner: Pubkey,
+    vault: Pubkey,
+    vault_ta: Pubkey,
+    owner_ta: Pubkey,
+    accounts: Vec<(Pubkey, Account)>,
+}
+
+impl TokenCtx {
+    /// Build a mint plus two token accounts: `owner_ta` holding
+    /// `owner_balance`, and `vault_ta` whose AUTHORITY IS THE VAULT PDA
+    /// — the arrangement that makes `withdraw` a PDA-signed CPI.
+    fn new(owner: Pubkey, vault: Pubkey, vault_account: Account, owner_balance: u64) -> Self {
+        use mollusk_svm_programs_token::token;
+        use spl_token_interface::state::{Account as TokenAccount, AccountState, Mint};
+
+        let mint = Pubkey::new_unique();
+        let owner_ta = Pubkey::new_unique();
+        let vault_ta = Pubkey::new_unique();
+
+        let mint_account = token::create_account_for_mint(Mint {
+            mint_authority: None.into(),
+            supply: owner_balance,
+            decimals: 0,
+            is_initialized: true,
+            freeze_authority: None.into(),
+        });
+        let token_account = |authority: Pubkey, amount: u64| {
+            token::create_account_for_token_account(TokenAccount {
+                mint,
+                owner: authority,
+                amount,
+                delegate: None.into(),
+                state: AccountState::Initialized,
+                is_native: None.into(),
+                delegated_amount: 0,
+                close_authority: None.into(),
+            })
+        };
+
+        let (system_id, _) = keyed_account_for_system_program();
+        let accounts = vec![
+            (owner, Account::new(10_000_000_000, 0, &system_id)),
+            (vault, vault_account),
+            (vault_ta, token_account(vault, 0)),
+            (owner_ta, token_account(owner, owner_balance)),
+            token::keyed_account(),
+            (mint, mint_account),
+        ];
+
+        Self {
+            owner,
+            vault,
+            vault_ta,
+            owner_ta,
+            accounts,
+        }
+    }
+
+    /// Carry an instruction's post-state forward, so a journey observes
+    /// the same account evolution a real transaction sequence would.
+    fn advance(&mut self, resulting: &[(Pubkey, Account)]) {
+        for (key, account) in resulting {
+            if let Some(slot) = self.accounts.iter_mut().find(|(k, _)| k == key) {
+                slot.1 = account.clone();
+            }
+        }
+    }
+
+    fn token_amount(&self, key: &Pubkey) -> u64 {
+        use solana_program_pack::Pack;
+        let account = self
+            .accounts
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, a)| a)
+            .expect("token account present");
+        spl_token_interface::state::Account::unpack(&account.data)
+            .expect("token account decodes")
+            .amount
+    }
+
+    fn vault_total(&self) -> u64 {
+        let account = self
+            .accounts
+            .iter()
+            .find(|(k, _)| k == &self.vault)
+            .map(|(_, a)| a)
+            .expect("vault present");
+        u64::from_le_bytes(account.data[40..48].try_into().unwrap())
     }
 }
 
@@ -370,5 +516,99 @@ fn pda_init_journey_and_constraint_violations() {
             .program_result
             .is_err(),
         "open must reject re-initialization of an existing vault"
+    );
+}
+
+/// The other half of #294's P0 item 2: an SPL Token CPI whose authority
+/// is a program PDA.
+///
+/// `deposit` moves tokens with the OWNER as authority — an ordinary
+/// signed CPI. `withdraw` moves them back with the VAULT PDA as
+/// authority, so the program must sign the CPI with the vault's seeds
+/// and bump. Those seeds have to agree with the generated
+/// `#[account(seeds = …, bump)]` constraint; a mismatch compiles
+/// cleanly and fails only here.
+#[test]
+#[ignore = "shells out to cargo build-sbf; needs Solana platform tools"]
+fn token_cpi_journey_with_pda_authority() {
+    const STARTING_BALANCE: u64 = 1_000;
+    const DEPOSIT: u64 = 400;
+    const WITHDRAW: u64 = 150;
+
+    let deploy = build_fixture_program();
+    let journey = Journey::new(&deploy);
+
+    let owner = Pubkey::new_unique();
+    let (vault, vault_account) = journey.open_vault(&owner);
+    let mut ctx = TokenCtx::new(owner, vault, vault_account, STARTING_BALANCE);
+
+    // ---- Owner-authorized CPI: deposit ------------------------------
+    let result = journey
+        .mollusk
+        .process_instruction(&journey.token_ix("deposit", &ctx, DEPOSIT), &ctx.accounts);
+    assert!(
+        result.program_result.is_ok(),
+        "deposit must succeed with the owner as token authority: {:?}",
+        result.program_result
+    );
+    ctx.advance(&result.resulting_accounts);
+
+    assert_eq!(
+        ctx.token_amount(&ctx.owner_ta),
+        STARTING_BALANCE - DEPOSIT,
+        "deposit must debit the owner's token account"
+    );
+    assert_eq!(
+        ctx.token_amount(&ctx.vault_ta),
+        DEPOSIT,
+        "deposit must credit the vault's token account"
+    );
+    assert_eq!(
+        ctx.vault_total(),
+        DEPOSIT,
+        "deposit must track the balance in vault state"
+    );
+
+    // ---- PDA-authorized CPI: withdraw -------------------------------
+    // The vault PDA is the token authority here, so this only succeeds
+    // if the signer seeds the handler passes match the seeds and bump
+    // on the generated account constraint.
+    let result = journey
+        .mollusk
+        .process_instruction(&journey.token_ix("withdraw", &ctx, WITHDRAW), &ctx.accounts);
+    assert!(
+        result.program_result.is_ok(),
+        "withdraw must succeed: the CPI signer seeds must match the \
+         generated seeds/bump constraint: {:?}",
+        result.program_result
+    );
+    ctx.advance(&result.resulting_accounts);
+
+    assert_eq!(
+        ctx.token_amount(&ctx.vault_ta),
+        DEPOSIT - WITHDRAW,
+        "withdraw must debit the vault's token account via the PDA-signed CPI"
+    );
+    assert_eq!(
+        ctx.token_amount(&ctx.owner_ta),
+        STARTING_BALANCE - DEPOSIT + WITHDRAW,
+        "withdraw must credit the owner's token account"
+    );
+    assert_eq!(
+        ctx.vault_total(),
+        DEPOSIT - WITHDRAW,
+        "withdraw must track the balance in vault state"
+    );
+
+    // ---- Guard still holds over the CPI path ------------------------
+    // `requires total >= amount`: overdrawing must reject rather than
+    // attempt a CPI that would fail deeper in the token program.
+    let result = journey.mollusk.process_instruction(
+        &journey.token_ix("withdraw", &ctx, DEPOSIT * 10),
+        &ctx.accounts,
+    );
+    assert!(
+        result.program_result.is_err(),
+        "withdraw must reject an amount exceeding the tracked total"
     );
 }


### PR DESCRIPTION
Closes #308. Completes #294's P0 item 2 — the PDA-init half landed in #309, this adds the SPL Token CPI whose authority is a program PDA.

## The blocker was not real

#308 recorded the blocker as a missing token-program ELF, needing either a vendored `spl_token.so` or hand-packed account data. Neither is necessary: **`mollusk-svm-programs-token` publishes `0.12.1-agave-4.0`**, an exact match for the pinned `mollusk-svm`. It ships the SPL Token ELF plus `Mint` / `TokenAccount` fixture builders. My earlier lookup missed it because the version query misparsed.

## The journey

Opens a real vault through the program (not a hand-built account, so the bump under test is the one `init` actually stored), then drives both CPI directions:

- **`deposit`** — the OWNER is the token authority, an ordinary signed CPI.
- **`withdraw`** — the VAULT PDA is the token authority, so the program signs the CPI with the vault's seeds and bump. This succeeds only when those seeds agree with the generated `#[account(seeds = …, bump)]` constraint. Both spellings compile; only one works at runtime.

Every step asserts both token balances and the tracked vault total, and carries post-state forward so the journey observes the account evolution a real transaction sequence would. A closing overdraw asserts the `requires total >= amount` guard still rejects ahead of the CPI rather than failing deeper inside the token program.

## Testing

Both journeys green locally, 66s for the pair. Logs confirm every negative control fires for the right reason: `ConstraintSeeds` (2006) for wrong seeds and for a non-canonical bump, `AccountNotSigner` (3010) for the unsigned payer, `InsufficientFunds` (6001) for the overdraw.

Full suite (21 targets), clippy `-D warnings` across all targets, and rustfmt clean. No codegen change, so no snapshot or example churn.
