### PR TITLE
refactor(codegen): derive one account plan and render from it

### DIFF
--- a/crates/qedgen/src/codegen/codegen_shared/account_attr.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/account_attr.rs
@@ -45,6 +45,121 @@ fn state_account_has_field(acct: &ParsedHandlerAccount, spec: &ParsedSpec, field
     spec.state_fields.iter().any(|(n, _)| n == field)
 }
 
+/// What this handler does to the account, and the facts that follow from
+/// it. Three rules that were previously scattered `if is_init` checks are
+/// encoded here as reachability, so the illegal combinations cannot be
+/// built at all (#311):
+///
+/// - `has_one` exists only on `Existing`. Anchor allocates and ZEROES an
+///   `init` account before evaluating constraints, so a prior-state
+///   binding can never hold there — that was #307, where every generated
+///   Anchor `init` handler with a matching `auth` field was unopenable.
+/// - `token_authority` exists only on `Init`. Anchor and Quasar both
+///   reject `token::authority` on an already-existing account.
+/// - `mut` exists only on `Existing`. `init` implies `mut`; emitting both
+///   trips "mut cannot be provided with init".
+pub(crate) enum AccountLifecycle {
+    /// Created by this handler.
+    Init {
+        payer: Option<String>,
+        /// `None` on Quasar, whose `init` analogue takes size from the
+        /// typed `Account<T>` wrapper.
+        space_target: Option<String>,
+        token_authority: Option<String>,
+    },
+    /// Pre-existing when the handler runs.
+    Existing {
+        writable: bool,
+        has_one: Option<String>,
+    },
+}
+
+/// Everything codegen decides about one handler-account, derived once.
+///
+/// The point is single derivation: before this, the `space =` target, the
+/// state struct name, the `has_one` binding, and the `init` decision were
+/// each recomputed at their point of use and could disagree — #305 and
+/// #307 were both instances of exactly that.
+pub(crate) struct AccountPlan {
+    pub(crate) lifecycle: AccountLifecycle,
+    /// Rendered seed expressions, or `None` when the account has no PDA
+    /// seeds or the target suppresses the directive.
+    pub(crate) seeds: Option<Vec<String>>,
+}
+
+impl AccountPlan {
+    /// Derive the plan. This is the ONLY place these facts are decided.
+    pub(crate) fn derive(
+        acct: &ParsedHandlerAccount,
+        handler: &ParsedHandler,
+        target: crate::Target,
+        spec: &ParsedSpec,
+        is_state_account: bool,
+    ) -> Self {
+        // Infer init from lifecycle. In multi-state specs only the
+        // account matching the handler's `on_account` is init'd —
+        // sibling writable PDAs in the same handler are pre-existing.
+        let lifecycle_is_init = handler.pre_status.as_deref() == Some("Uninitialized")
+            || handler.pre_status.as_deref() == Some("Empty");
+        let on_account_matches = match handler.on_account.as_deref() {
+            Some(adt_name) => {
+                let lower = adt_name.to_lowercase();
+                acct.name == lower || acct.name.starts_with(&lower)
+            }
+            None => true,
+        };
+        let is_init =
+            lifecycle_is_init && on_account_matches && !acct.is_signer && acct.pda_seeds.is_some();
+
+        let lifecycle = if is_init {
+            AccountLifecycle::Init {
+                payer: handler.signer_account().map(|s| s.name.clone()),
+                space_target: match target {
+                    // Shared derivation with `generate_state` — see
+                    // `state_struct_name` (#305).
+                    crate::Target::Anchor => Some(crate::codegen_shared::state_struct_name(
+                        spec,
+                        handler.on_account.as_deref(),
+                    )),
+                    _ => None,
+                },
+                token_authority: acct.authority.clone(),
+            }
+        } else {
+            // R25: lower `auth X` to `has_one = X` when the state-bearing
+            // account has a field named X. Without this binding, every
+            // handler taking an authority signer is reachable by ANY
+            // signer — the signer check verifies "someone signed", not
+            // "the right someone".
+            //
+            // With multi-variant ADT state the auth field often lives in
+            // a variant payload (`Active.owner`); Anchor's `has_one`
+            // macro cannot reach into the inner enum. Suppress there —
+            // Quasar's flat-struct emission keeps every field at top
+            // level, so `has_one = field` works.
+            let has_one = if is_state_account {
+                handler.who.as_ref().and_then(|who| {
+                    let reachable = state_account_has_field(acct, spec, who)
+                        && !(matches!(target, crate::Target::Anchor)
+                            && is_multi_variant_adt_with_field_in_variant(spec, who));
+                    reachable.then(|| who.clone())
+                })
+            } else {
+                None
+            };
+            AccountLifecycle::Existing {
+                writable: acct.is_writable,
+                has_one,
+            }
+        };
+
+        Self {
+            lifecycle,
+            seeds: render_seeds(acct, handler, target, spec, is_init),
+        }
+    }
+}
+
 /// Generate the #[account(...)] attribute for codegen, target-aware.
 ///
 /// Anchor and Quasar both spell the attribute `#[account(...)]` but
@@ -72,62 +187,82 @@ pub(crate) fn quasar_account_attr(
     is_state_account: bool,
 ) -> String {
     let _ = state_name;
-    let mut parts = Vec::new();
+    let plan = AccountPlan::derive(acct, handler, target, spec, is_state_account);
+    render_account_attr(&plan)
+}
 
-    // Infer init from lifecycle. In multi-state specs only the account
-    // matching the handler's `on_account` is init'd — sibling writable
-    // PDAs in the same handler are pre-existing.
-    let lifecycle_is_init = handler.pre_status.as_deref() == Some("Uninitialized")
-        || handler.pre_status.as_deref() == Some("Empty");
-    let on_account_matches = match handler.on_account.as_deref() {
-        // Multi-state: only the named state account init's.
-        Some(adt_name) => {
-            let lower = adt_name.to_lowercase();
-            acct.name == lower || acct.name.starts_with(&lower)
-        }
-        // Single-state spec: any writable PDA can be the init target.
-        None => true,
-    };
-    let is_init =
-        lifecycle_is_init && on_account_matches && !acct.is_signer && acct.pda_seeds.is_some();
+/// Render the `#[account(...)]` attribute from the plan. Pure projection:
+/// every decision was made in `AccountPlan::derive`.
+fn render_account_attr(plan: &AccountPlan) -> String {
+    let mut parts: Vec<String> = Vec::new();
 
-    // `mut` is mutually exclusive with `init` in Anchor (init implies
-    // mut) — emitting both trips `mut cannot be provided with init`.
-    if acct.is_writable && !is_init {
-        parts.push("mut".to_string());
-    }
-
-    if is_init {
-        parts.push("init".to_string());
-        if let Some(signer) = handler.signer_account() {
-            parts.push(format!("payer = {}", signer.name));
-        }
-        // Anchor requires `space = <bytes>` with `init`. We derive
-        // `InitSpace` on every account type / inner enum / record, so
-        // the canonical form is `space = 8 + <AccountStruct>::INIT_SPACE`
-        // (8 = Anchor discriminator). The struct name must match what
-        // `generate_state` emits.
-        let space_target = match target {
-            // Shared derivation with `generate_state` — see
-            // `state_struct_name`. Keying on `on_account` alone emitted
-            // `<Adt>Account` for single-account specs whose ADT name
-            // differs from the program name, against a struct actually
-            // named `<Program>Account` (E0433, scaffold did not
-            // compile).
-            crate::Target::Anchor => {
-                crate::codegen_shared::state_struct_name(spec, handler.on_account.as_deref())
+    match &plan.lifecycle {
+        AccountLifecycle::Existing { writable, has_one } => {
+            if *writable {
+                parts.push("mut".to_string());
             }
-            // Quasar handles space differently — its `init`
-            // analogue takes size from the typed `Account<T>`
-            // wrapper. Skip the `space` attribute on Quasar.
-            _ => String::new(),
-        };
-        if !space_target.is_empty() {
-            parts.push(format!("space = 8 + {}::INIT_SPACE", space_target));
+            if let Some(field) = has_one {
+                // Emitted after seeds below to preserve attribute order.
+                let _ = field;
+            }
+        }
+        AccountLifecycle::Init {
+            payer,
+            space_target,
+            ..
+        } => {
+            parts.push("init".to_string());
+            if let Some(payer) = payer {
+                parts.push(format!("payer = {payer}"));
+            }
+            // Anchor requires `space = <bytes>` with `init`. Every
+            // account type derives `InitSpace`, so the canonical form is
+            // `space = 8 + <AccountStruct>::INIT_SPACE` (8 = Anchor
+            // discriminator).
+            if let Some(target_struct) = space_target {
+                parts.push(format!("space = 8 + {target_struct}::INIT_SPACE"));
+            }
         }
     }
 
-    if let Some(ref seeds) = acct.pda_seeds {
+    if let Some(seeds) = &plan.seeds {
+        parts.push(format!("seeds = [{}]", seeds.join(", ")));
+        parts.push("bump".to_string());
+    }
+
+    match &plan.lifecycle {
+        AccountLifecycle::Init {
+            token_authority, ..
+        } => {
+            if let Some(auth) = token_authority {
+                parts.push(format!("token::authority = {auth}"));
+            }
+        }
+        AccountLifecycle::Existing { has_one, .. } => {
+            if let Some(field) = has_one {
+                parts.push(format!("has_one = {field}"));
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("    #[account({})]\n", parts.join(", "))
+    }
+}
+
+/// Render this account's PDA seed expressions, or `None` when it has no
+/// seeds or the target suppresses the directive.
+fn render_seeds(
+    acct: &ParsedHandlerAccount,
+    handler: &ParsedHandler,
+    target: crate::Target,
+    spec: &ParsedSpec,
+    is_init: bool,
+) -> Option<Vec<String>> {
+    let seeds = acct.pda_seeds.as_ref()?;
+    {
         let bound_account_names: std::collections::HashSet<&str> =
             handler.accounts.iter().map(|a| a.name.as_str()).collect();
 
@@ -171,8 +306,11 @@ pub(crate) fn quasar_account_attr(
             (matches!(target, crate::Target::Quasar) && !is_init && needs_state_field_seed)
                 || anchor_variant_field_seed;
 
-        if !suppress_seeds {
-            let seed_parts: Vec<String> = seeds
+        if suppress_seeds {
+            return None;
+        }
+        Some(
+            seeds
                 .iter()
                 .map(|seed| {
                     if let Some(inner) = seed.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
@@ -192,64 +330,7 @@ pub(crate) fn quasar_account_attr(
                         format!("{}.{}.as_ref()", acct.name, seed)
                     }
                 })
-                .collect();
-            parts.push(format!("seeds = [{}]", seed_parts.join(", ")));
-            parts.push("bump".to_string());
-        }
-    }
-
-    // `token::authority = X` is only valid on accounts that are also
-    // `init` / `init_if_needed` — quasar (and anchor) reject it on
-    // already-existing accounts. The spec authority annotation
-    // captures "this token account should belong to this authority";
-    // for non-init accounts that's already enforced at init time and
-    // doesn't need re-emission. For init accounts we emit it so the
-    // macro can wire up the SPL InitToken CPI correctly.
-    if is_init {
-        if let Some(ref auth) = acct.authority {
-            parts.push(format!("token::authority = {}", auth));
-        }
-    }
-
-    // R25: lower `auth X` to `has_one = X` when the state-bearing
-    // account has a field named X. Without this binding, every handler
-    // taking an authority signer is reachable by ANY signer — the
-    // signer check verifies "someone signed", not "the right someone".
-    // Anchor and Quasar both accept `has_one = field`.
-    //
-    // With multi-variant ADT state the auth field often lives in a
-    // variant payload (`Active.owner`); Anchor's `has_one` macro can't
-    // reach into the inner enum ("no field `owner` on `Account<…>`").
-    // Skip emission there — the auth gap surfaces via a TODO line next
-    // to the handler body rather than being dropped silently.
-    // Never on an `init` account: Anchor allocates and ZEROES the
-    // account, then evaluates constraints, so `has_one = owner`
-    // compares an all-zero field against the payer and always fails
-    // (ConstraintHasOne / 2001) — the handler body that populates the
-    // field has not run yet. The account is being created here, so
-    // there is no prior binding to check; authorization on init comes
-    // from the payer's signature and the PDA seeds. Caught by the #294
-    // runtime journey: pre-fix, every generated `init` handler whose
-    // `auth` matched a state field could never be opened at all.
-    if is_state_account && !is_init {
-        if let Some(ref who) = handler.who {
-            if state_account_has_field(acct, spec, who) {
-                // Suppress only on Anchor: its wrapper-struct +
-                // inner-enum emission hides variant-payload fields from
-                // `has_one`; Quasar's flat-struct emission keeps every
-                // field at top level so `has_one = field` works.
-                let suppress_for_anchor_variant = matches!(target, crate::Target::Anchor)
-                    && is_multi_variant_adt_with_field_in_variant(spec, who);
-                if !suppress_for_anchor_variant {
-                    parts.push(format!("has_one = {}", who));
-                }
-            }
-        }
-    }
-
-    if parts.is_empty() {
-        String::new()
-    } else {
-        format!("    #[account({})]\n", parts.join(", "))
+                .collect(),
+        )
     }
 }

--- a/crates/qedgen/src/codegen/codegen_shared/tests.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/tests.rs
@@ -2723,3 +2723,98 @@ handler deposit (amount : U64) : State.Active -> State.Active {
         "        self.state.last_seen = self.state.balance;\n"
     );
 }
+
+/// #311 / #307: the account plan encodes three rules as reachability, so
+/// the illegal attribute combinations cannot be constructed. This checks
+/// them at the emission level, where a user would feel them.
+///
+/// `has_one` on an `init` account is the one that shipped broken: Anchor
+/// zeroes the account before evaluating constraints, so the binding could
+/// never hold and every such handler was unopenable.
+#[test]
+fn account_plan_keeps_init_and_has_one_disjoint() {
+    const SRC: &str = r#"spec PlanRules
+
+type Vault
+  | Uninitialized
+  | Active of {
+      owner : Pubkey,
+      total : U64,
+    }
+
+type Error | Bad
+
+pda vault ["vault", owner]
+
+handler open : Vault.Uninitialized -> Vault.Active {
+  auth owner
+  accounts {
+    owner          : signer, writable
+    vault          : writable, pda ["vault", owner]
+    system_program : program
+  }
+  effect {
+    owner := owner.pubkey
+    total := 0
+  }
+}
+
+handler bump_total (amount : U64) : Vault.Active -> Vault.Active {
+  auth owner
+  accounts {
+    owner : signer, writable
+    vault : writable, pda ["vault", owner]
+  }
+  requires amount > 0 else Bad
+  effect { total += amount }
+}
+"#;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let spec_path = dir.path().join("plan.qedspec");
+    std::fs::write(&spec_path, SRC).expect("write spec");
+    std::fs::create_dir_all(dir.path().join(".qed")).expect("create .qed");
+
+    let spec = crate::check::parse_spec_file(&spec_path).expect("parse");
+    let mir = crate::mir::lower(&spec);
+    let out_dir = dir.path().join("programs");
+    crate::codegen_mir::generate(
+        &mir,
+        &spec,
+        &spec_path,
+        &out_dir,
+        crate::Target::Anchor,
+        crate::codegen_mir::RegenOptions::default(),
+    )
+    .expect("anchor codegen");
+    let lib = std::fs::read_to_string(out_dir.join("src/lib.rs")).expect("lib.rs");
+
+    let init_attr = lib
+        .lines()
+        .find(|l| l.contains("#[account(") && l.contains("init"))
+        .expect("an init account attribute is emitted");
+    assert!(
+        !init_attr.contains("has_one"),
+        "has_one must never accompany init — the account is zeroed when \
+         constraints run:\n{init_attr}"
+    );
+    assert!(
+        !init_attr.contains("mut,") && !init_attr.contains(", mut"),
+        "init implies mut; emitting both trips the Anchor macro:\n{init_attr}"
+    );
+    assert!(
+        init_attr.contains("payer =") && init_attr.contains("space ="),
+        "init must carry payer and space:\n{init_attr}"
+    );
+
+    // The non-init handler over the same account DOES bind the authority
+    // — suppression is specific to init, not a blanket drop.
+    let non_init = lib
+        .lines()
+        .filter(|l| l.contains("#[account(") && !l.contains("init"))
+        .find(|l| l.contains("has_one"))
+        .expect("a non-init state account still binds has_one");
+    assert!(
+        non_init.contains("has_one = owner"),
+        "non-init state account keeps its auth binding:\n{non_init}"
+    );
+}


### PR DESCRIPTION
Fixes #311.

Account attributes were assembled from facts each recomputed at the point of use: whether the account is `init`, which struct backs it, its seeds, its authority, whether it carries a `has_one` binding. Any two could disagree — and two shipped bugs were exactly that:

- **#305** — the `space =` target named a different struct than `generate_state` emitted (E0433).
- **#307** — the `has_one` lowering never consulted `is_init`, so **every generated Anchor `init` handler with a matching `auth` field was unopenable**.

`AccountPlan::derive` is now the only place those facts are decided; `render_account_attr` is a pure projection of it.

## Rules encoded as reachability, not checks

The three rules previously enforced by scattered `if is_init` tests are now properties of `AccountLifecycle`, so the illegal combinations cannot be constructed at all:

| Field | Lives on | Why |
|---|---|---|
| `has_one` | `Existing` only | Anchor zeroes an `init` account before evaluating constraints, so a prior-state binding can never hold (#307) |
| `token_authority` | `Init` only | Both frameworks reject `token::authority` on an already-existing account |
| `mut` | `Existing` only | `init` implies `mut`; emitting both trips the Anchor macro |

This is the difference between fixing #307 and making it unrepresentable.

## Pure restructuring

- **Zero snapshot churn, zero bundled-example churn** — the strongest evidence the refactor preserves behavior.
- Artifact gate stays green: 3 passed, 0 failed.
- Full suite (21 targets), clippy `-D warnings` across all targets, rustfmt, `check --regen-drift`: clean.

Regression `account_plan_keeps_init_and_has_one_disjoint` checks the rules where a user would feel them — the emitted attribute — and also asserts the non-init handler over the same account still binds `has_one`, so the suppression is specific to `init` rather than a blanket drop.

## Follow-on found while mapping the seams

`r28_pda_check_fires` (the runtime PDA guard) is meant to be the complement of `render_seeds`' suppression, but derives its condition independently and lacks the `is_init` term. The result is that an `init` account gets *both* the macro-side `seeds = [...]` and a redundant runtime check. No soundness gap — I checked for the dangerous direction (suppressed seeds with no runtime check) and it does not occur — but it is the same duplication shape this issue is about. Making the two complementary by construction changes generated output, so it belongs in its own change rather than riding along with a zero-churn refactor.
