### PR TITLE
fix(codegen): enforce CPI mechanization contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The UX is **agent-first**: the user interacts with the SKILL (`SKILL.md`) and ag
 
 **Design principles:**
 - A DSL feature that *structurally eliminates* a proof obligation beats a new proof template or a shelled-out sorry.
-- Codegen mechanizes only deterministic translation; business logic (transfers, CPI authority, events, PDA creation) stays agent-filled `todo!()`.
+- Codegen mechanizes only deterministic translation. Supported direct CPIs with transaction signers, Anchor/Quasar lifecycle account creation, and Anchor builder-shape CPIs with assemblable PDA signer seeds are complete; transfer sugar, events, unsupported calls, Pinocchio PDA creation, and every other PDA-signed CPI stay agent-filled `todo!()`. The per-target contract lives in `docs/framework-support.md`.
 - When a template can't close a case, emit `sorry` with a comment — never bury it in tactics that might spuriously close.
 - Don't pre-shell to Leanstral/Aristotle for what a local LLM can do. Escalation is for *after* you've tried, not when you expect to need to.
 - The typed MIR (`mir.rs`) exists for bug-class elimination, not LoC: matches over the closed `Stmt` enum are exhaustive by discipline (no `_` arms — see the enum doc in `mir.rs`), so a new statement kind is a compile error at every `Stmt` consumer (Lean codegen, Rust scaffold, and the Kani/proptest effect lowering via `rust_codegen_util::stmt_effect_triple`), not silent drift. Conditional `effect { match … }` bodies lower to `Stmt::Branch` (Phase 5): Rust renders a `match`, the flat-state Lean transition applies exactly one arm (per-arm bound guards); the ADT Lean path still flattens arms to their union (`stmts_with_branch_union`). Measure intrinsics by bugs eliminated, not lines saved.

--- a/SKILL.md
+++ b/SKILL.md
@@ -101,7 +101,7 @@ Step 3. Scaffold generated artifacts.
 $QEDGEN codegen --spec program.qedspec --target anchor --all
 ```
 
-Use `--target quasar` for Quasar or `--target pinocchio` for Pinocchio (`#![no_std]` + `entrypoint!` dispatch, zeropod zero-copy state, `&AccountInfo` account structs with `.handler()` methods, checked effects, SPL Token CPIs). All three targets emit a full program scaffold; generic (non-SPL) and PDA-signed CPIs are not yet wired for Pinocchio.
+Use `--target quasar` for Quasar or `--target pinocchio` for Pinocchio (`#![no_std]` + `entrypoint!` dispatch, zeropod zero-copy state, `&AccountInfo` account structs with `.handler()` methods, checked effects, SPL Token CPIs). All three targets emit a full program scaffold. A CPI is emitted only when the target can produce the complete invocation: Anchor signs PDA-authorized builder CPIs with `new_with_signer` when the seeds come from the account's declared `pda [...]`; every other PDA-signed CPI is an explicit agent-fill site. Generic CPIs are mechanized for Anchor (transaction signers only) and remain agent-fill on Quasar and Pinocchio. See `docs/framework-support.md` for the per-operation contract.
 
 Step 4. Fill generated Rust.
 

--- a/crates/qedgen/src/codegen/codegen_shared/cpi.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/cpi.rs
@@ -1,5 +1,125 @@
 use super::*;
 
+/// The only two legal outcomes for a spec-level CPI call.
+///
+/// A target either emits the complete invocation, including every signer the
+/// interface requires, or it emits an explicit agent-fill site. In particular,
+/// a PDA signer may never fall through to an unsigned `invoke()` / `.invoke()`
+/// that looks complete but can only fail at runtime.
+pub(crate) enum CpiPlan {
+    Complete(String),
+    AgentFill(CpiFillReason),
+}
+
+pub(crate) enum CpiFillReason {
+    /// One or more interface signer slots bind to caller-owned PDAs and the
+    /// target's emitter did not assemble signer seeds for them (Anchor builder
+    /// shapes do — `CpiContext::new_with_signer`; every other path emits
+    /// unsigned invocations).
+    PdaSigner { accounts: Vec<String> },
+    /// The target has no complete lowering for this interface/handler shape.
+    Unsupported { target: Target },
+}
+
+impl CpiFillReason {
+    pub(crate) fn render(&self) -> String {
+        match self {
+            Self::PdaSigner { accounts } => format!(
+                "PDA signer authority ({}) requires signer-seed assembly; fill the complete signed CPI",
+                accounts.join(", ")
+            ),
+            Self::Unsupported { target } => format!(
+                "{} does not fully mechanize this CPI shape; fill the complete invocation",
+                target_name(*target)
+            ),
+        }
+    }
+}
+
+fn target_name(target: Target) -> &'static str {
+    match target {
+        Target::Anchor => "Anchor",
+        Target::Quasar => "Quasar",
+        Target::Pinocchio => "Pinocchio",
+    }
+}
+
+/// Build the per-call mechanization plan.
+///
+/// Target dispatch runs first; the PDA-signer check is a post-condition on
+/// the emitted artifact. A call whose signer slots bind caller PDAs is
+/// `Complete` only if the emitted code actually signs for them
+/// (`new_with_signer` / `invoke_signed`) — the Anchor builder shapes do, and
+/// the runtime journey (#308/#310) proves that path on-chain. Any emitter
+/// that would produce a plausible but unsigned invocation for a program
+/// authority (Anchor generic `invoke`, the builder's plain-`new` fallback
+/// when seeds aren't assemblable, Quasar, Pinocchio) resolves to an explicit
+/// agent-fill site instead.
+pub(crate) fn plan_cpi(
+    call: &crate::check::ParsedCall,
+    handler: &ParsedHandler,
+    spec: &ParsedSpec,
+    target: Target,
+) -> CpiPlan {
+    let Some(iface) = spec
+        .interfaces
+        .iter()
+        .find(|i| i.name == call.target_interface)
+    else {
+        return CpiPlan::AgentFill(CpiFillReason::Unsupported { target });
+    };
+
+    let pda_signers = iface
+        .handlers
+        .iter()
+        .find(|h| h.name == call.target_handler)
+        .into_iter()
+        .flat_map(|h| h.accounts.iter().filter(|a| a.is_signer))
+        .filter_map(|signer_slot| {
+            let arg = call.args.iter().find(|a| a.name == signer_slot.name)?;
+            handler
+                .accounts
+                .iter()
+                .find(|a| a.name == arg.rust_expr && a.pda_seeds.is_some())
+                .map(|a| a.name.clone())
+        })
+        .collect::<Vec<_>>();
+
+    let is_spl_token = iface.program_id.as_deref() == Some(SPL_TOKEN_PROGRAM_ID);
+    let is_system = iface.program_id.as_deref() == Some(SYSTEM_PROGRAM_ID);
+
+    let emitted = match (target, is_spl_token, is_system) {
+        (Target::Anchor, true, _) => emit_spl_token_cpi_anchor(call, handler, spec),
+        (Target::Anchor, false, true) => emit_system_cpi_anchor(call, handler, iface, spec),
+        (Target::Anchor, false, false) => emit_generic_cpi_anchor(call, handler, iface, spec),
+        (Target::Quasar, true, _) => emit_spl_token_cpi_quasar(call, handler, spec),
+        (Target::Quasar, false, true) => emit_system_cpi_quasar(call, handler, spec),
+        // Quasar generic CPI not implemented (would use `BufCpiCall`).
+        (Target::Quasar, false, false) => None,
+        (Target::Pinocchio, true, _) => emit_spl_token_cpi_pinocchio(call, handler, spec),
+        (Target::Pinocchio, false, true) => emit_system_cpi_pinocchio(call, handler, spec),
+        // Pinocchio generic CPI not implemented (raw invoke_signed).
+        (Target::Pinocchio, false, false) => None,
+    };
+
+    match emitted {
+        Some(code) if pda_signers.is_empty() || code_signs_for_pda(&code) => {
+            CpiPlan::Complete(code)
+        }
+        _ if !pda_signers.is_empty() => CpiPlan::AgentFill(CpiFillReason::PdaSigner {
+            accounts: pda_signers,
+        }),
+        _ => CpiPlan::AgentFill(CpiFillReason::Unsupported { target }),
+    }
+}
+
+/// Whether emitted CPI code signs for a program-owned PDA. Checked on the
+/// artifact itself (not re-derived from dispatch) so no emitter — present or
+/// future — can ship an unsigned invocation for a PDA signer.
+fn code_signs_for_pda(code: &str) -> bool {
+    code.contains("new_with_signer") || code.contains("invoke_signed")
+}
+
 /// Try to emit a real CPI invocation for one `call Interface.handler(...)`
 /// site. Dispatch on `(target, is_spl_token, is_system)`:
 ///
@@ -14,31 +134,16 @@ use super::*;
 /// Returns `None` for unrecognized interfaces/handlers and unimplemented
 /// branches (Quasar/Pinocchio generic) — the caller falls back to a
 /// structured comment + `todo!()` for the agent to fill.
+#[cfg(test)]
 pub(crate) fn try_emit_cpi(
     call: &crate::check::ParsedCall,
     handler: &ParsedHandler,
     spec: &ParsedSpec,
     target: Target,
 ) -> Option<String> {
-    let iface = spec
-        .interfaces
-        .iter()
-        .find(|i| i.name == call.target_interface)?;
-    let is_spl_token = iface.program_id.as_deref() == Some(SPL_TOKEN_PROGRAM_ID);
-    let is_system = iface.program_id.as_deref() == Some(SYSTEM_PROGRAM_ID);
-
-    match (target, is_spl_token, is_system) {
-        (Target::Anchor, true, _) => emit_spl_token_cpi_anchor(call, handler, spec),
-        (Target::Anchor, false, true) => emit_system_cpi_anchor(call, handler, iface, spec),
-        (Target::Anchor, false, false) => emit_generic_cpi_anchor(call, handler, iface, spec),
-        (Target::Quasar, true, _) => emit_spl_token_cpi_quasar(call, handler, spec),
-        (Target::Quasar, false, true) => emit_system_cpi_quasar(call, handler, spec),
-        // Quasar generic CPI not implemented (would use `BufCpiCall`).
-        (Target::Quasar, false, false) => None,
-        (Target::Pinocchio, true, _) => emit_spl_token_cpi_pinocchio(call, handler, spec),
-        (Target::Pinocchio, false, true) => emit_system_cpi_pinocchio(call, handler, spec),
-        // Pinocchio generic CPI not implemented (raw invoke_signed).
-        (Target::Pinocchio, false, false) => None,
+    match plan_cpi(call, handler, spec, target) {
+        CpiPlan::Complete(code) => Some(code),
+        CpiPlan::AgentFill(_) => None,
     }
 }
 

--- a/crates/qedgen/src/codegen/codegen_shared/generators.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/generators.rs
@@ -344,8 +344,12 @@ pub(crate) fn render_pinocchio_handler_scaffold(
             param_names.join(", ")
         ));
     }
-    emit_pinocchio_effect_body(&mut out, handler, spec);
-    out.push_str("        Ok(())\n");
+    let needs_fill = emit_pinocchio_effect_body(&mut out, handler, spec);
+    if needs_fill {
+        out.push_str("        todo!(\"fill non-mechanical effects, events, transfers, calls\")\n");
+    } else {
+        out.push_str("        Ok(())\n");
+    }
     out.push_str("    }\n");
     out.push_str("}\n\n");
 
@@ -429,7 +433,7 @@ pub(crate) fn emit_pinocchio_effect_body(
     out: &mut String,
     handler: &ParsedHandler,
     spec: &ParsedSpec,
-) {
+) -> bool {
     let prog = to_pascal_case(&spec.program_name);
     let err = format!("{}Error", prog);
     let has = |n: &str| spec.error_codes.iter().any(|c| c == n);
@@ -519,30 +523,69 @@ pub(crate) fn emit_pinocchio_effect_body(
     if complex_effects {
         out.push_str("        // TODO(slice 6 4b-cont): non-scalar effects (array / nested /\n        // variant-payload writes) + multi-account state.\n");
     }
+
+    // Anchor and Quasar lifecycle init is owned by their account macros.
+    // Pinocchio has no equivalent implicit creation step: mutating the zero-copy
+    // view without first allocating/assigning the PDA would be a plausible but
+    // incomplete operation, so make the ownership boundary executable.
+    let needs_pda_creation = matches!(
+        handler.pre_status.as_deref(),
+        Some("Uninitialized" | "Empty")
+    ) && handler
+        .accounts
+        .iter()
+        .any(|a| !a.is_signer && a.pda_seeds.is_some());
+    if needs_pda_creation {
+        out.push_str(
+            "        // Lifecycle init requires PDA allocation/assignment — agent fill: create the complete signed System CPI\n",
+        );
+    }
     // Explicit `call Interface.handler(...)` sites. Non-SPL (generic
     // invoke) call sites return `None` and fall through to a breadcrumb.
     let mut any_unmechanized_call = false;
     for c in &handler.calls {
-        match try_emit_cpi(c, handler, spec, Target::Pinocchio) {
-            Some(rendered) => {
+        match plan_cpi(c, handler, spec, Target::Pinocchio) {
+            CpiPlan::Complete(rendered) => {
                 out.push_str(&format!(
                     "        // Spec call: {}.{}\n",
                     c.target_interface, c.target_handler
                 ));
                 out.push_str(&rendered);
             }
-            None => any_unmechanized_call = true,
+            CpiPlan::AgentFill(reason) => {
+                out.push_str(&format!(
+                    "        // Spec call: {}.{} — agent fill: {}\n",
+                    c.target_interface,
+                    c.target_handler,
+                    reason.render(),
+                ));
+                any_unmechanized_call = true;
+            }
         }
-    }
-    if any_unmechanized_call {
-        out.push_str("        // TODO(slice 7): generic (non-SPL) CPI call sites are not yet\n        // mechanized for Pinocchio (raw invoke_signed + Borsh).\n");
     }
 
     // `transfers { … }` stays agent-fill on every target (CPI/authority
     // business logic); events carry no payload binding in the spec.
-    if !handler.emits.is_empty() || !handler.transfers.is_empty() {
-        out.push_str("        // TODO(slice 6 4b-cont): events / transfers.\n");
+    for emit in &handler.emits {
+        out.push_str(&format!(
+            "        // Spec event: emit {} — agent fill\n",
+            emit
+        ));
     }
+    for transfer in &handler.transfers {
+        out.push_str(&format!(
+            "        // Spec transfer: {} -> {} amount={} — agent fill: assemble the complete CPI and authority\n",
+            transfer.from,
+            transfer.to,
+            transfer.amount.as_deref().unwrap_or("?"),
+        ));
+    }
+
+    complex_effects
+        || needs_pda_creation
+        || any_unmechanized_call
+        || !handler.emits.is_empty()
+        || !handler.transfers.is_empty()
 }
 
 /// `true` when the spec's state is a multi-variant ADT (≥2 variants in a

--- a/crates/qedgen/src/codegen/codegen_shared/scaffold.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/scaffold.rs
@@ -303,8 +303,8 @@ pub(crate) fn render_handler_scaffold(
         if c.result_binding.is_none() {
             continue;
         }
-        match try_emit_cpi(c, handler, spec, target) {
-            Some(rendered) => {
+        match plan_cpi(c, handler, spec, target) {
+            CpiPlan::Complete(rendered) => {
                 out.push_str(&format!(
                     "        // Spec call: {}.{} (binding: {})\n",
                     c.target_interface,
@@ -314,7 +314,7 @@ pub(crate) fn render_handler_scaffold(
                 out.push_str(&rendered);
                 emitted_call_indices.insert(idx);
             }
-            None => {
+            CpiPlan::AgentFill(reason) => {
                 let args = c
                     .args
                     .iter()
@@ -322,11 +322,12 @@ pub(crate) fn render_handler_scaffold(
                     .collect::<Vec<_>>()
                     .join(", ");
                 out.push_str(&format!(
-                    "        // Spec call: {}.{}({}) (binding: {}) — needs fill\n",
+                    "        // Spec call: {}.{}({}) (binding: {}) — agent fill: {}\n",
                     c.target_interface,
                     c.target_handler,
                     args,
-                    c.result_binding.as_deref().unwrap_or("_")
+                    c.result_binding.as_deref().unwrap_or("_"),
+                    reason.render(),
                 ));
                 any_unmechanized_call_pre = true;
                 emitted_call_indices.insert(idx);
@@ -486,15 +487,15 @@ pub(crate) fn render_handler_scaffold(
         if emitted_call_indices.contains(&idx) {
             continue;
         }
-        match try_emit_cpi(c, handler, spec, target) {
-            Some(rendered) => {
+        match plan_cpi(c, handler, spec, target) {
+            CpiPlan::Complete(rendered) => {
                 out.push_str(&format!(
-                    "        // Spec call: {}.{} (Anchor CPI emitted by v2.8 G4)\n",
+                    "        // Spec call: {}.{} (complete CPI emitted)\n",
                     c.target_interface, c.target_handler
                 ));
                 out.push_str(&rendered);
             }
-            None => {
+            CpiPlan::AgentFill(reason) => {
                 let args = c
                     .args
                     .iter()
@@ -502,8 +503,11 @@ pub(crate) fn render_handler_scaffold(
                     .collect::<Vec<_>>()
                     .join(", ");
                 out.push_str(&format!(
-                    "        // Spec call: {}.{}({}) — v2.9 will emit a generic Anchor CPI\n",
-                    c.target_interface, c.target_handler, args
+                    "        // Spec call: {}.{}({}) — agent fill: {}\n",
+                    c.target_interface,
+                    c.target_handler,
+                    args,
+                    reason.render(),
                 ));
                 any_unmechanized_call = true;
             }

--- a/crates/qedgen/src/codegen/codegen_shared/tests.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/tests.rs
@@ -754,6 +754,145 @@ handler send (n : U64) : State.Active -> State.Active {
     );
 }
 
+/// #314 — an interface signer slot bound to a caller PDA must resolve to a
+/// complete SIGNED invocation or an explicit agent-fill site, never a
+/// plausible but unsigned invoke. Anchor's builder shapes own signer-seed
+/// assembly (`new_with_signer`, proven by the runtime journey); Quasar and
+/// Pinocchio do not, so they must choose the explicit agent-fill outcome.
+#[test]
+fn cpi_pda_authority_signs_on_anchor_and_is_agent_fill_elsewhere() {
+    let spec = crate::chumsky_adapter::parse_str(
+        r#"spec Caller
+program_id "11111111111111111111111111111111"
+
+interface Token {
+  program_id "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+  handler transfer (amount : U64) {
+    accounts {
+      from      : writable
+      to        : writable
+      authority : signer
+    }
+  }
+}
+
+type State | Active of { owner : Pubkey }
+type Error | E
+
+handler send (n : U64) : State.Active -> State.Active {
+  permissionless
+  accounts {
+    owner         : readonly
+    vault         : writable, pda ["vault", owner]
+    src           : writable
+    dst           : writable
+    token_program : program
+  }
+  call Token.transfer(from = src, to = dst, amount = n, authority = vault)
+}
+"#,
+    )
+    .unwrap();
+    let handler = spec.handlers.iter().find(|h| h.name == "send").unwrap();
+    let call = handler.calls.first().unwrap();
+
+    match plan_cpi(call, handler, &spec, Target::Anchor) {
+        CpiPlan::Complete(rendered) => assert!(
+            rendered.contains("CpiContext::new_with_signer"),
+            "Anchor must sign for the PDA authority; got:\n{rendered}"
+        ),
+        CpiPlan::AgentFill(reason) => panic!(
+            "Anchor owns signer-seed assembly for builder shapes; got fill: {}",
+            reason.render()
+        ),
+    }
+
+    for target in [Target::Quasar, Target::Pinocchio] {
+        match plan_cpi(call, handler, &spec, target) {
+            CpiPlan::AgentFill(CpiFillReason::PdaSigner { accounts }) => {
+                assert_eq!(accounts, vec!["vault"]);
+            }
+            CpiPlan::AgentFill(other) => {
+                panic!("expected PDA-signer reason, got: {}", other.render())
+            }
+            CpiPlan::Complete(rendered) => {
+                panic!("{target:?} emitted a plausible but unsigned PDA CPI:\n{rendered}")
+            }
+        }
+    }
+}
+
+/// #314 — Pinocchio cannot rely on an account macro to allocate and assign a
+/// lifecycle-created PDA. The handler body must request an explicit fill site
+/// instead of mutating state and returning `Ok(())` as though creation happened.
+#[test]
+fn pinocchio_lifecycle_pda_creation_requires_fill() {
+    let spec = crate::chumsky_adapter::parse_str(
+        r#"spec Caller
+type State | Uninitialized | Active of { owner : Pubkey }
+type Error | E
+handler open : State.Uninitialized -> State.Active {
+  permissionless
+  accounts {
+    payer : signer, writable
+    state : writable, pda ["state", payer]
+  }
+  effect { owner := payer.pubkey }
+}
+"#,
+    )
+    .unwrap();
+    let handler = spec.handlers.iter().find(|h| h.name == "open").unwrap();
+    let mut rendered = String::new();
+
+    let needs_fill = emit_pinocchio_effect_body(&mut rendered, handler, &spec);
+
+    assert!(needs_fill, "PDA creation must force the handler fill tail");
+    assert!(
+        rendered.contains("Lifecycle init requires PDA allocation/assignment")
+            && rendered.contains("complete signed System CPI"),
+        "fill site must state the complete missing operation:\n{rendered}"
+    );
+}
+
+#[test]
+fn pinocchio_events_and_transfer_sugar_require_fill() {
+    let spec = crate::chumsky_adapter::parse_str(
+        r#"spec Caller
+type State | Active of { total : U64 }
+type Error | E
+event Sent { amount : U64 }
+handler send (n : U64) : State.Active -> State.Active {
+  permissionless
+  accounts {
+    state         : writable
+    owner         : signer
+    src           : writable, type token
+    dst           : writable, type token
+    token_program : program
+  }
+  transfers { from src to dst amount n authority owner }
+  emits Sent
+}
+"#,
+    )
+    .unwrap();
+    let handler = spec.handlers.iter().find(|h| h.name == "send").unwrap();
+    let mut rendered = String::new();
+
+    let needs_fill = emit_pinocchio_effect_body(&mut rendered, handler, &spec);
+
+    assert!(
+        needs_fill,
+        "events/transfers must force the handler fill tail"
+    );
+    assert!(
+        rendered.contains("Spec event: emit Sent — agent fill")
+            && rendered.contains("Spec transfer: src -> dst amount=n — agent fill"),
+        "both unmechanized intents must be explicit:\n{rendered}"
+    );
+}
+
 /// Helper for the Quasar / Pinocchio CPI tests — same SPL Token
 /// transfer fixture shape used in
 /// `cpi_emits_anchor_spl_transfer_for_canonical_program_id`, but

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.codegen.txt
@@ -101,7 +101,7 @@ impl Deposit {
     pub fn handler(&self, amount: u64) -> Result<()> {
         guards::deposit(self, amount)?;
         // Spec effect (needs fill): pool_balance add amount
-        // Spec call: Token.transfer(amount=amount) — v2.9 will emit a generic Anchor CPI
+        // Spec call: Token.transfer(amount=amount) — agent fill: Anchor does not fully mechanize this CPI shape; fill the complete invocation
         todo!("fill non-mechanical effects, events, transfers, calls")
     }
 }

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -158,7 +158,7 @@ impl<'info> Cancel<'info> {
         guards::cancel(self)?;
         let _ = bumps;
         // Spec: emit!(EscrowCancelled)
-        // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
+        // Spec call: Token.transfer (complete CPI emitted)
         {
             use anchor_spl::token::{self, Transfer};
             let cpi_accounts = Transfer {
@@ -196,7 +196,7 @@ impl<'info> Exchange<'info> {
         verified,
         spec = "..",
         handler = "exchange",
-        hash = "9146f9898fc03101",
+        hash = "e3c2c7a52553d8bc",
         spec_hash = "914eb8b51ea56c85"
     )]
     #[inline(always)]
@@ -204,7 +204,7 @@ impl<'info> Exchange<'info> {
         guards::exchange(self)?;
         let _ = bumps;
         // Spec: emit!(EscrowExchanged)
-        // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
+        // Spec call: Token.transfer (complete CPI emitted)
         {
             use anchor_spl::token::{self, Transfer};
             let cpi_accounts = Transfer {
@@ -218,20 +218,7 @@ impl<'info> Exchange<'info> {
                 self.escrow.taker_amount,
             )?;
         }
-        // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
-        {
-            use anchor_spl::token::{self, Transfer};
-            let cpi_accounts = Transfer {
-                from: self.escrow_ta.to_account_info(),
-                to: self.taker_ta.to_account_info(),
-                authority: self.escrow.to_account_info(),
-            };
-            let cpi_program = self.token_program.to_account_info();
-            token::transfer(
-                CpiContext::new(cpi_program, cpi_accounts),
-                self.escrow.initializer_amount,
-            )?;
-        }
+        // Spec call: Token.transfer(from=escrow_ta, to=taker_ta, amount=initializer_amount, authority=escrow) — agent fill: PDA signer authority (escrow) requires signer-seed assembly; fill the complete signed CPI
         todo!("fill non-mechanical effects, events, transfers, calls")
     }
 }
@@ -268,7 +255,7 @@ impl<'info> Initialize<'info> {
         self.escrow.initializer_amount = deposit_amount;
         self.escrow.taker_amount = receive_amount;
         // Spec: emit!(EscrowInitialized)
-        // Spec call: Token.transfer (Anchor CPI emitted by v2.8 G4)
+        // Spec call: Token.transfer (complete CPI emitted)
         {
             use anchor_spl::token::{self, Transfer};
             let cpi_accounts = Transfer {

--- a/crates/qedgen/tests/snapshots/pinocchio-vault-greenfield.codegen.txt
+++ b/crates/qedgen/tests/snapshots/pinocchio-vault-greenfield.codegen.txt
@@ -191,8 +191,8 @@ impl Withdraw<'_> {
             amount: amount,
         }
         .invoke()?;
-        // TODO(slice 6 4b-cont): events / transfers.
-        Ok(())
+        // Spec event: emit Withdrawn — agent fill
+        todo!("fill non-mechanical effects, events, transfers, calls")
     }
 }
 

--- a/docs/framework-support.md
+++ b/docs/framework-support.md
@@ -37,6 +37,33 @@ sBPF assembly is selected by `pragma sbpf` in the spec, not by a `Target`.
 | Miri divergence repros (`verify/miri_verify`) | ❌ | ❌ | ✅ | ❌ | n/a |
 | Ratchet / readiness (`verify/ratchet`) | ✅ | ✅ | ❌ no ratchet crate | ❌ | ❌ |
 
+## Codegen ownership contract: CPIs, PDA creation, and events
+
+“Complete” means codegen emits the whole operation required by the spec. If
+account resolution fails, a handler is unsupported, or signer seeds would have
+to be guessed, the scaffold emits a reasoned agent-fill site and a `todo!()`.
+It never emits a plausible unsigned CPI for a PDA authority.
+
+| Operation | Anchor | Quasar | Pinocchio |
+|---|---|---|---|
+| Lifecycle-created state PDA (`Uninitialized`/`Empty` → active) | ✅ account macro owns `init`, payer, space, seeds, bump | ✅ account macro owns `init`, payer, seeds, bump | ⚠️ agent fill: complete signed System allocation/assignment |
+| `transfers { ... }` sugar | ⚠️ agent fill: CPI accounts + authority | ⚠️ agent fill: CPI accounts + authority | ⚠️ agent fill: CPI accounts + authority |
+| Direct canonical SPL Token `call`, transaction signer authority | ✅ transfer, mint, burn, initialize, close | ⚠️ transfer, mint, burn, close; initialize is agent fill | ✅ transfer, mint, burn, initialize, close |
+| Direct System transfer, transaction signer authority | ✅ | ✅ | ✅ |
+| Direct System create/assign, non-PDA signer | ✅ generic invocation | ⚠️ agent fill | ⚠️ agent fill |
+| Generic interface `call`, transaction signer authority | ✅ discriminator + args + account metas | ⚠️ agent fill | ⚠️ agent fill |
+| Any direct `call` whose signer slot binds a program PDA | ✅ builder shapes (SPL Token, System transfer) sign via `new_with_signer` when seeds are the account's declared `pda [...]`; ⚠️ agent fill otherwise (generic invoke, unassemblable seeds) | ⚠️ agent fill: complete CPI with signer seeds | ⚠️ agent fill: complete CPI with signer seeds |
+| Events | ⚠️ agent fill: payload binding + framework emission | ⚠️ agent fill: payload binding + framework emission | ⚠️ agent fill: payload binding + framework emission |
+
+The executable boundary lives in `codegen_shared::cpi::CpiPlan`:
+`Complete(code)` and `AgentFill(reason)` are the only outcomes. The PDA-signer
+check is a post-condition on the emitted artifact: a call whose signer slots
+bind caller PDAs is `Complete` only if the emitted code signs for them
+(`new_with_signer` / `invoke_signed`), so an ordinary unsigned `invoke` can
+never ship for a PDA-authorized call. Pinocchio likewise turns lifecycle PDA
+creation, transfer sugar, events, and unsupported calls into a hard handler
+`todo!()` rather than returning `Ok(())` after a breadcrumb.
+
 The two *deprecated* rows (`qedgen spec --idl`, `qedgen adapt --program`)
 remain functional in v2.x with a runtime warning and are removed in v3.0.
 The brownfield front door is spec elicitation: `qedgen probe --program <c>


### PR DESCRIPTION
Fixes #314.

Defines a typed complete-vs-agent-fill CPI boundary (`CpiPlan`), makes Pinocchio lifecycle creation/events/transfers hard fill sites, and documents the per-target ownership matrix.

Rebased onto main after #263, which mechanized Anchor PDA-signer builder CPIs (`new_with_signer`, proven by the runtime journey). The PDA-signer rule is now a post-condition on the emitted artifact instead of a pre-dispatch gate: a call whose signer slots bind caller PDAs is `Complete` only if the emitted code signs for them (`new_with_signer` / `invoke_signed`); every unsigned path (Anchor generic invoke, the builder's plain-new fallback on unassemblable seeds, Quasar, Pinocchio) resolves to an explicit agent-fill site. This also converts a latent defect visible in the escrow-split fixture — an unsigned plain-`new` transfer for a PDA authority with a state-field seed — into an explicit fill site.

Verification:
- cargo test -p qedgen-solana-skills
- cargo clippy -p qedgen-solana-skills --all-targets -- -D warnings
- codegen snapshot and generated-rustfmt gates
- check --regen-drift clean