### PR TITLE
fix(codegen): derive R28 from account seed plan

### DIFF
--- a/crates/qedgen/src/codegen/codegen_mir.rs
+++ b/crates/qedgen/src/codegen/codegen_mir.rs
@@ -1449,25 +1449,19 @@ fn emit_errors(
         !pre.is_empty() && !is_init
     });
 
-    // R28: runtime PDA verification auto-adds `InvalidPda`. Shares the
-    // firing predicate with `generate_guards` so the emitted check and
-    // this enum variant can't drift apart.
-    let needs_invalid_pda = parsed.handlers.iter().any(|h| {
-        let bound: std::collections::HashSet<&str> =
-            h.accounts.iter().map(|a| a.name.as_str()).collect();
-        h.accounts.iter().any(|acct| {
-            let Some(seeds) = &acct.pda_seeds else {
-                return false;
-            };
-            if acct.is_signer {
-                return false;
-            }
-            if crate::codegen_shared::handler_is_init_for(h, &acct.name) {
-                return false;
-            }
-            crate::codegen_shared::r28_pda_check_fires(target, parsed, seeds, &bound)
-        })
-    });
+    // R28: runtime PDA verification auto-adds `InvalidPda`. Both this error
+    // declaration and guard emission consume the account plan's SeedPlan, so
+    // the variant cannot drift from the generated check.
+    let needs_invalid_pda = !matches!(target, Target::Pinocchio)
+        && parsed.handlers.iter().any(|h| {
+            let state_acct = crate::codegen_shared::resolve_handler_state_account(h, parsed);
+            h.accounts.iter().any(|acct| {
+                let is_state = state_acct.map(|sa| sa.name == acct.name).unwrap_or(false);
+                let plan =
+                    crate::codegen_shared::AccountPlan::derive(acct, h, target, parsed, is_state);
+                matches!(plan.seeds, crate::codegen_shared::SeedPlan::Runtime)
+            })
+        });
 
     let mut codes: Vec<String> = mir.errors.variants.clone();
     if needs_lifecycle && !codes.iter().any(|c| c == "InvalidLifecycle") {

--- a/crates/qedgen/src/codegen/codegen_shared/account_attr.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/account_attr.rs
@@ -74,6 +74,18 @@ pub(crate) enum AccountLifecycle {
     },
 }
 
+/// One canonical decision for how an account's PDA seeds are enforced.
+/// Consumers must not re-derive the suppression predicate: the account macro
+/// renderer and R28 runtime guard are complementary projections of this enum.
+pub(crate) enum SeedPlan {
+    /// The account has no declared PDA seeds.
+    None,
+    /// The target account macro enforces these rendered seed expressions.
+    Macro(Vec<String>),
+    /// The target macro cannot represent this seed shape; R28 must enforce it.
+    Runtime,
+}
+
 /// Everything codegen decides about one handler-account, derived once.
 ///
 /// The point is single derivation: before this, the `space =` target, the
@@ -82,9 +94,7 @@ pub(crate) enum AccountLifecycle {
 /// #307 were both instances of exactly that.
 pub(crate) struct AccountPlan {
     pub(crate) lifecycle: AccountLifecycle,
-    /// Rendered seed expressions, or `None` when the account has no PDA
-    /// seeds or the target suppresses the directive.
-    pub(crate) seeds: Option<Vec<String>>,
+    pub(crate) seeds: SeedPlan,
 }
 
 impl AccountPlan {
@@ -168,7 +178,7 @@ impl AccountPlan {
 
         Self {
             lifecycle,
-            seeds: render_seeds(acct, handler, target, spec, is_init),
+            seeds: plan_seeds(acct, handler, target, spec, is_init),
         }
     }
 }
@@ -238,7 +248,7 @@ fn render_account_attr(plan: &AccountPlan) -> String {
         }
     }
 
-    if let Some(seeds) = &plan.seeds {
+    if let SeedPlan::Macro(seeds) = &plan.seeds {
         parts.push(format!("seeds = [{}]", seeds.join(", ")));
         parts.push("bump".to_string());
     }
@@ -265,16 +275,17 @@ fn render_account_attr(plan: &AccountPlan) -> String {
     }
 }
 
-/// Render this account's PDA seed expressions, or `None` when it has no
-/// seeds or the target suppresses the directive.
-fn render_seeds(
+/// Decide once whether the macro or R28 owns PDA enforcement for this account.
+fn plan_seeds(
     acct: &ParsedHandlerAccount,
     handler: &ParsedHandler,
     target: crate::Target,
     spec: &ParsedSpec,
     is_init: bool,
-) -> Option<Vec<String>> {
-    let seeds = acct.pda_seeds.as_ref()?;
+) -> SeedPlan {
+    let Some(seeds) = acct.pda_seeds.as_ref() else {
+        return SeedPlan::None;
+    };
     {
         let bound_account_names: std::collections::HashSet<&str> =
             handler.accounts.iter().map(|a| a.name.as_str()).collect();
@@ -320,9 +331,9 @@ fn render_seeds(
                 || anchor_variant_field_seed;
 
         if suppress_seeds {
-            return None;
+            return SeedPlan::Runtime;
         }
-        Some(
+        SeedPlan::Macro(
             seeds
                 .iter()
                 .map(|seed| {

--- a/crates/qedgen/src/codegen/codegen_shared/guards.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/guards.rs
@@ -284,16 +284,11 @@ pub(crate) fn generate_guards(
     Ok(())
 }
 
-/// R28: per-handler PDA verification. R13 suppresses
-/// `seeds = [...]` on Quasar non-init handlers when seeds
-/// reference state fields (the macro's `Bumps::seeds()` method
-/// can't auto-capture `self.<state-field>`). Owner+discriminator
-/// protects against type confusion but not wrong-PDA passing —
-/// the audit's MED-tier finding. Emit a runtime
-/// `verify_program_address` check using the stored bump for
-/// every account whose `seeds = [...]` would have been
-/// suppressed. The cost is one syscall (~544 CU on first-try
-/// bump 255) per affected handler load.
+/// R28: emit runtime PDA verification exactly when the account plan assigns
+/// seed enforcement to `SeedPlan::Runtime`. The account macro and this guard
+/// are complementary by construction; neither re-derives the other's
+/// suppression predicate. The cost is one syscall (~544 CU on first-try bump
+/// 255) per affected handler load.
 fn emit_r28_pda_checks(
     out: &mut String,
     handler: &ParsedHandler,
@@ -301,27 +296,26 @@ fn emit_r28_pda_checks(
     target: Target,
     err_enum: &str,
 ) {
+    if matches!(target, Target::Pinocchio) {
+        return; // Pinocchio has a dedicated account/guard emitter.
+    }
+    // Same state-account resolution as the scaffold's attribute emission —
+    // `derive` consults it for init detection on type-qualified
+    // single-account specs (#263), and a mismatch here would re-emit the
+    // macro-owned check at runtime.
+    let state_acct = resolve_handler_state_account(handler, spec);
     for acct in &handler.accounts {
-        let Some(ref seeds) = acct.pda_seeds else {
+        let is_state = state_acct.map(|sa| sa.name == acct.name).unwrap_or(false);
+        let plan = AccountPlan::derive(acct, handler, target, spec, is_state);
+        if !matches!(plan.seeds, SeedPlan::Runtime) {
             continue;
-        };
-        let is_init_target = handler_is_init_for(handler, &acct.name) && !acct.is_signer;
-        if is_init_target {
-            continue; // init flow already verifies via #[account(seeds=…, bump)]
         }
-        // Was R13 going to suppress on this handler? Mirror the
-        // detection logic from `quasar_account_attr`. Quasar fires on
-        // any state-field seed (its R13 suppression is broader);
-        // Anchor (v2.29 extension) only when the seed references a
-        // variant-payload field on a multi-variant ADT — the
-        // `seeds = [...]` macro can't route through the accessor, so
-        // `quasar_account_attr` suppressed it and the runtime check
-        // emits here instead.
+        let seeds = acct
+            .pda_seeds
+            .as_ref()
+            .expect("SeedPlan::Runtime requires declared PDA seeds");
         let bound_account_names: std::collections::HashSet<&str> =
             handler.accounts.iter().map(|a| a.name.as_str()).collect();
-        if !r28_pda_check_fires(target, spec, seeds, &bound_account_names) {
-            continue;
-        }
 
         let mut seed_exprs: Vec<String> = Vec::with_capacity(seeds.len() + 1);
         for seed in seeds {
@@ -763,41 +757,6 @@ pub(crate) fn handler_is_init_for(handler: &ParsedHandler, acct_name: &str) -> b
     ) && match handler.on_account.as_deref() {
         Some(adt) => account_name_matches_adt(adt, acct_name),
         None => true,
-    }
-}
-
-/// R28 firing predicate for one account's `pda_seeds`: does the runtime
-/// PDA verification emit for this (target, seeds) pair? Quasar fires on
-/// any state-field seed (non-literal, not a bound handler account);
-/// Anchor only under a multi-variant ADT state when the seed is a
-/// variant-payload field; Pinocchio never (dedicated emitter). Shared
-/// between `generate_guards` (the check emission) and
-/// `codegen_mir::emit_errors` (the `InvalidPda` variant) so the guard
-/// can't reference a variant the error enum didn't declare.
-pub(crate) fn r28_pda_check_fires(
-    target: Target,
-    spec: &ParsedSpec,
-    seeds: &[String],
-    bound_account_names: &std::collections::HashSet<&str>,
-) -> bool {
-    let is_state_seed = |seed: &String| {
-        let is_literal = seed.starts_with('"') && seed.ends_with('"');
-        !is_literal && !bound_account_names.contains(seed.as_str())
-    };
-    match target {
-        Target::Quasar => seeds.iter().any(is_state_seed),
-        Target::Anchor => {
-            is_multi_variant_adt_state(spec)
-                && seeds.iter().any(|seed| {
-                    is_state_seed(seed)
-                        && spec.account_types.iter().any(|a| {
-                            a.variants
-                                .iter()
-                                .any(|v| v.fields.iter().any(|(n, _)| n == seed))
-                        })
-                })
-        }
-        Target::Pinocchio => false,
     }
 }
 

--- a/crates/qedgen/src/codegen/codegen_shared/tests.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/tests.rs
@@ -3096,3 +3096,77 @@ handler bump_total (amount : U64) : Vault.Active -> Vault.Active {
         "non-init state account keeps its auth binding:\n{non_init}"
     );
 }
+
+/// #317 — init accounts whose seeds reference a state field are enforced by
+/// the account macro. R28 must not independently reclassify the same seeds and
+/// add a second runtime check (or its `InvalidPda` error variant).
+#[test]
+fn account_plan_keeps_init_seed_enforcement_macro_only() {
+    const SRC: &str = r#"spec InitSeeds
+
+type Vault
+  | Uninitialized
+  | Active of { authority : Pubkey }
+
+type Error | Bad
+
+handler open : Vault.Uninitialized -> Vault.Active {
+  permissionless
+  accounts {
+    payer          : signer, writable
+    vault          : writable, pda ["vault", authority]
+    system_program : program
+  }
+  effect { authority := payer.pubkey }
+}
+"#;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let spec_path = dir.path().join("init-seeds.qedspec");
+    std::fs::write(&spec_path, SRC).expect("write spec");
+    std::fs::create_dir_all(dir.path().join(".qed")).expect("create .qed");
+    let spec = crate::check::parse_spec_file(&spec_path).expect("parse");
+    let mir = crate::mir::lower(&spec);
+
+    for target in [Target::Anchor, Target::Quasar] {
+        let target_name = match target {
+            Target::Anchor => "anchor",
+            Target::Quasar => "quasar",
+            Target::Pinocchio => unreachable!(),
+        };
+        let out_dir = dir.path().join(target_name);
+        crate::codegen_mir::generate(
+            &mir,
+            &spec,
+            &spec_path,
+            &out_dir,
+            target,
+            crate::codegen_mir::RegenOptions::default(),
+        )
+        .expect("codegen");
+
+        let guards = std::fs::read_to_string(out_dir.join("src/guards.rs")).expect("guards.rs");
+        let errors = std::fs::read_to_string(out_dir.join("src/errors.rs")).expect("errors.rs");
+        let account_surface = match target {
+            Target::Anchor => std::fs::read_to_string(out_dir.join("src/lib.rs")).expect("lib.rs"),
+            Target::Quasar => {
+                std::fs::read_to_string(out_dir.join("src/instructions/open.rs")).expect("open.rs")
+            }
+            Target::Pinocchio => unreachable!(),
+        };
+
+        assert!(
+            account_surface.contains("init")
+                && account_surface.contains("seeds = [b\"vault\", vault.authority.as_ref()]")
+                && account_surface.contains("bump"),
+            "{target:?} macro must own init seed enforcement:\n{account_surface}"
+        );
+        assert!(
+            !guards.contains("R28 PDA check"),
+            "{target:?} must not duplicate macro enforcement at runtime:\n{guards}"
+        );
+        assert!(
+            !errors.contains("InvalidPda"),
+            "{target:?} must not declare an unused R28 error variant:\n{errors}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #317.

Stacked on #318 so the review diff contains only #317.

Introduces a canonical SeedPlan (none, macro, runtime), makes R28 and InvalidPda consume it, and removes the duplicated suppression predicate. Init state-field seeds remain macro-enforced without a redundant runtime syscall.

Verification:
- cargo test -p qedgen-solana-skills
- cargo clippy -p qedgen-solana-skills --all-targets -- -D warnings
- codegen snapshot and generated-rustfmt gates