### PR TITLE
refactor(codegen): keep effect targets typed

### DIFF
--- a/crates/qedgen/src/check/model.rs
+++ b/crates/qedgen/src/check/model.rs
@@ -426,6 +426,11 @@ pub struct ParsedErrorCode {
 pub struct ParsedEffect {
     /// Target field path (`counter`, `accounts[i].capital`, `Variant.field`).
     pub field: String,
+    /// Name-resolved, structured target path. Production effects carry this
+    /// from the adapter so MIR/codegen never need to reparse `field` or
+    /// discover subscripts with string scanning. `None` is reserved for
+    /// legacy ingest and hand-built fixtures.
+    pub lhs: Option<crate::mir::expr_tree::TreePath>,
     /// Op kind: "set" | "add" | "add_sat" | "add_wrap" | "sub" | "sub_sat" |
     /// "sub_wrap". "add"/"sub" are the checked defaults; `_sat` / `_wrap`
     /// carry the explicit opt-in from `+=!` / `+=?`.
@@ -465,6 +470,7 @@ impl ParsedEffect {
     ) -> Self {
         ParsedEffect {
             field: field.into(),
+            lhs: None,
             op: op.into(),
             value: value.into(),
             value_rust: String::new(),

--- a/crates/qedgen/src/codegen/kani_mir/conformance.rs
+++ b/crates/qedgen/src/codegen/kani_mir/conformance.rs
@@ -63,7 +63,8 @@ pub(crate) fn emit_effect_conformance_harnesses(
             .ok_or_else(|| anyhow::anyhow!("MIR has no handler `{}`", op.name))?;
         let triples = util::block_effect_triples(body);
         for (field, op_kind, value) in triples.iter().cloned() {
-            let harness_name = format!("verify_{}_effect_{}", op.name, sanitize_ident(&field));
+            let field_name = util::effect_path_source(field);
+            let harness_name = format!("verify_{}_effect_{}", op.name, sanitize_ident(&field_name));
             emit_one_conformance_harness(
                 out,
                 ConformanceHarness {
@@ -75,7 +76,7 @@ pub(crate) fn emit_effect_conformance_harnesses(
                     field_type_lookup: &field_type_lookup,
                     harness_name: &harness_name,
                     assume_lines: &[],
-                    effect: (&field, op_kind, value),
+                    effect: (field, op_kind, value),
                     sibling_triples: &triples,
                 },
             )?;
@@ -115,7 +116,7 @@ pub(crate) fn emit_effect_conformance_harnesses(
                         "verify_{}_arm{}_effect_{}",
                         op.name,
                         idx,
-                        sanitize_ident(&field)
+                        sanitize_ident(&util::effect_path_source(field))
                     );
                     emit_one_conformance_harness(
                         out,
@@ -128,7 +129,7 @@ pub(crate) fn emit_effect_conformance_harnesses(
                             field_type_lookup: &field_type_lookup,
                             harness_name: &harness_name,
                             assume_lines: &assume,
-                            effect: (&field, op_kind, value),
+                            effect: (field, op_kind, value),
                             sibling_triples: &arm_triples,
                         },
                     )?;
@@ -144,7 +145,7 @@ pub(crate) fn emit_effect_conformance_harnesses(
                     let harness_name = format!(
                         "verify_{}_default_effect_{}",
                         op.name,
-                        sanitize_ident(&field)
+                        sanitize_ident(&util::effect_path_source(field))
                     );
                     emit_one_conformance_harness(
                         out,
@@ -157,7 +158,7 @@ pub(crate) fn emit_effect_conformance_harnesses(
                             field_type_lookup: &field_type_lookup,
                             harness_name: &harness_name,
                             assume_lines: &assumes,
-                            effect: (&field, op_kind, value),
+                            effect: (field, op_kind, value),
                             sibling_triples: &default_triples,
                         },
                     )?;
@@ -181,10 +182,10 @@ pub(crate) struct ConformanceHarness<'a> {
     pub(crate) harness_name: &'a str,
     pub(crate) assume_lines: &'a [String],
     /// The target effect: `(field, op_kind, value)`.
-    pub(crate) effect: (&'a str, &'a str, &'a crate::mir::Expr),
+    pub(crate) effect: (&'a crate::mir::Path, &'a str, &'a crate::mir::Expr),
     /// The effect set that can legally fire alongside the target — the
     /// whole flat body, or one Branch arm.
-    pub(crate) sibling_triples: &'a [(String, &'static str, &'a crate::mir::Expr)],
+    pub(crate) sibling_triples: &'a [(&'a crate::mir::Path, &'static str, &'a crate::mir::Expr)],
 }
 
 /// One effect-conformance harness: symbolic (or zeroed-init) state,
@@ -211,6 +212,9 @@ pub(crate) fn emit_one_conformance_harness(
     } = ctx;
 
     let is_init = op.pre_status.as_deref() == Some("Uninitialized");
+    let effect_path = field;
+    let field_owned = util::effect_path_source(effect_path);
+    let field = field_owned.as_str();
 
     let base = util::effect_target_base(field);
     if !field_type_lookup.contains_key(base) {
@@ -310,12 +314,12 @@ pub(crate) fn emit_one_conformance_harness(
     // missing here, so `s.voted[member_index] == 1` was an E0277 that
     // only surfaced once the Kani compile gate began to run for this
     // example.
-    let field_read = crate::rust_codegen_util::cast_subscripts(field);
+    let field_read = util::render_effect_target(effect_path, parsed, "s");
     let expected_eq = |expected: &str| -> String {
         if has_try {
-            format!("Some(s.{field_read}) == (|| Some({expected}))()")
+            format!("Some({field_read}) == (|| Some({expected}))()")
         } else {
-            format!("s.{field_read} == {expected}")
+            format!("{field_read} == {expected}")
         }
     };
     match op_kind {
@@ -369,7 +373,7 @@ pub(crate) fn emit_one_conformance_harness(
         if fname.as_str() != field {
             let sibling_mutated = sibling_triples
                 .iter()
-                .any(|(f, _, _)| f.as_str() == fname.as_str());
+                .any(|(f, _, _)| util::effect_path_source(f) == fname.as_str());
             if !sibling_mutated {
                 let assertion = util::rewrite_kani_pubkey_comparisons(
                     &format!("s.{fname} == pre_{fname}"),

--- a/crates/qedgen/src/codegen/proptest_gen_mir.rs
+++ b/crates/qedgen/src/codegen/proptest_gen_mir.rs
@@ -1153,8 +1153,10 @@ fn emit_overflow_tests_for(
             }
             // Strip variant prefix so `Active.balance` resolves to `balance`
             // for the flat-State model (fn name + field lookup).
-            let field_owned =
-                rust_codegen_util::strip_variant_prefix_for_flat_state(&field_raw, spec);
+            let field_owned = rust_codegen_util::strip_variant_prefix_for_flat_state(
+                &rust_codegen_util::effect_path_source(field_raw),
+                spec,
+            );
             let field = field_owned.as_str();
 
             let dsl_type = all_fields
@@ -1769,7 +1771,7 @@ handler approve (member_index : U8) (member_pubkey : Pubkey) : State.Active -> S
         );
         // (c) Effect-LHS subscript is cast to usize.
         assert!(
-            body.contains("s.voted[member_index as usize] = 1"),
+            body.contains("s.voted[(member_index) as usize] = 1"),
             "effect-LHS subscript casts to usize:\n{body}"
         );
     }

--- a/crates/qedgen/src/codegen/rust_codegen_util/effect.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/effect.rs
@@ -131,6 +131,50 @@ pub fn strip_variant_prefix_for_flat_state(path: &str, spec: &ParsedSpec) -> Str
     path.to_string()
 }
 
+/// Source spelling of a MIR target path. This is the compatibility view for
+/// schema lookups and diagnostics; Rust emission must use
+/// [`render_effect_target`] so structured subscripts reach the canonical
+/// precedence-aware renderer.
+pub fn effect_path_source(path: &crate::mir::Path) -> String {
+    path.segments.join(".")
+}
+
+/// Render an effect target with its runtime receiver. Adapter-built paths
+/// use the same canonical renderer as every other Rust expression, including
+/// structural `usize` casts for index segments. The fallback is only for
+/// legacy/fixture paths that predate the typed carrier.
+pub fn render_effect_target(path: &crate::mir::Path, spec: &ParsedSpec, receiver: &str) -> String {
+    use crate::mir::expr_tree::{BindingKind, TreeSeg};
+    if let Some(mut tree) = path.tree.clone() {
+        let root_is_variant = spec
+            .account_types
+            .iter()
+            .any(|a| a.variants.iter().any(|v| v.name == tree.root));
+        if root_is_variant {
+            tree.root = "state".to_string();
+            tree.binding = BindingKind::StateField;
+        }
+        if matches!(tree.binding, BindingKind::StateField | BindingKind::Ghost) {
+            if let Some(TreeSeg::Field(first)) = tree.segments.first() {
+                let is_variant = spec
+                    .account_types
+                    .iter()
+                    .any(|a| a.variants.iter().any(|v| v.name == *first));
+                if is_variant {
+                    tree.segments.remove(0);
+                }
+            }
+        }
+        return super::tree_render::render_rust(
+            &crate::mir::ExprTree::Path(tree),
+            super::tree_render::RustCx::native()
+                .with_binder(super::tree_render::Binder::SelfAcct(receiver)),
+        );
+    }
+    let flat = strip_variant_prefix_for_flat_state(&effect_path_source(path), spec);
+    format!("{receiver}.{}", cast_subscripts(&flat))
+}
+
 /// Project an effect-shaped MIR `Stmt` back onto the `(field, op_kind,
 /// value)` triple the string templates below consume — the #66 adaptor
 /// that makes `Stmt` the iteration source for the Kani/proptest transition
@@ -145,20 +189,20 @@ pub fn strip_variant_prefix_for_flat_state(path: &str, spec: &ParsedSpec) -> Str
 /// for the Kani/proptest backends.
 pub fn stmt_effect_triple(
     stmt: &crate::mir::Stmt,
-) -> Option<(String, &'static str, &crate::mir::Expr)> {
+) -> Option<(&crate::mir::Path, &'static str, &crate::mir::Expr)> {
     use crate::mir::Stmt;
     match stmt {
-        Stmt::Assign { path, rhs } => Some((path.segments.join("."), "set", rhs)),
+        Stmt::Assign { path, rhs } => Some((path, "set", rhs)),
         Stmt::CheckedAdd { path, delta, .. } => {
             // The lowered per-site error name is Lean/scaffold surface;
             // the pure model signals overflow via `return false`.
-            Some((path.segments.join("."), "add", delta))
+            Some((path, "add", delta))
         }
-        Stmt::CheckedSub { path, delta, .. } => Some((path.segments.join("."), "sub", delta)),
-        Stmt::SatAdd { path, delta } => Some((path.segments.join("."), "add_sat", delta)),
-        Stmt::SatSub { path, delta } => Some((path.segments.join("."), "sub_sat", delta)),
-        Stmt::WrapAdd { path, delta } => Some((path.segments.join("."), "add_wrap", delta)),
-        Stmt::WrapSub { path, delta } => Some((path.segments.join("."), "sub_wrap", delta)),
+        Stmt::CheckedSub { path, delta, .. } => Some((path, "sub", delta)),
+        Stmt::SatAdd { path, delta } => Some((path, "add_sat", delta)),
+        Stmt::SatSub { path, delta } => Some((path, "sub_sat", delta)),
+        Stmt::WrapAdd { path, delta } => Some((path, "add_wrap", delta)),
+        Stmt::WrapSub { path, delta } => Some((path, "sub_wrap", delta)),
         // Guard surface: `requires X else Err` folds into the guard
         // conjunction via `collect_full_guard*`, not the body.
         Stmt::RequireOrAbort { .. } => None,
@@ -185,7 +229,7 @@ pub fn stmt_effect_triple(
 /// see conditionally-applied effects.
 pub fn block_effect_triples(
     body: &crate::mir::Block,
-) -> Vec<(String, &'static str, &crate::mir::Expr)> {
+) -> Vec<(&crate::mir::Path, &'static str, &crate::mir::Expr)> {
     body.stmts.iter().filter_map(stmt_effect_triple).collect()
 }
 
@@ -194,10 +238,10 @@ pub fn block_effect_triples(
 /// and tests) where a conditionally-applied effect counts.
 pub fn block_effect_triples_deep(
     body: &crate::mir::Block,
-) -> Vec<(String, &'static str, &crate::mir::Expr)> {
+) -> Vec<(&crate::mir::Path, &'static str, &crate::mir::Expr)> {
     fn walk<'a>(
         stmts: &'a [crate::mir::Stmt],
-        out: &mut Vec<(String, &'static str, &'a crate::mir::Expr)>,
+        out: &mut Vec<(&'a crate::mir::Path, &'static str, &'a crate::mir::Expr)>,
     ) {
         for s in stmts {
             if let Some(t) = stmt_effect_triple(s) {
@@ -250,13 +294,13 @@ pub fn state_field_reads(
 /// Takes the exact triple stream the caller will emit (post pubkey-skip
 /// filtering), so every snapshot is referenced by an emitted statement.
 pub fn parallel_snapshot_fields(
-    triples: &[(String, &'static str, &crate::mir::Expr)],
+    triples: &[(&crate::mir::Path, &'static str, &crate::mir::Expr)],
     spec: &ParsedSpec,
 ) -> Vec<String> {
     let mut written: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut read: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for (field, _, value) in triples {
-        let flat = strip_variant_prefix_for_flat_state(field, spec);
+        let flat = strip_variant_prefix_for_flat_state(&effect_path_source(field), spec);
         written.insert(effect_target_base(&flat).to_string());
         state_field_reads(mir_expr_tree(value), &mut read);
     }
@@ -334,7 +378,7 @@ pub fn emit_one_effect(
     out: &mut String,
     spec: &ParsedSpec,
     wrapping: bool,
-    field: &str,
+    field: &crate::mir::Path,
     op_kind: &str,
     value: &crate::mir::Expr,
     indent: &str,
@@ -350,7 +394,7 @@ fn emit_one_effect_inner(
     out: &mut String,
     spec: &ParsedSpec,
     wrapping: bool,
-    field: &str,
+    field: &crate::mir::Path,
     op_kind: &str,
     value: &crate::mir::Expr,
     indent: &str,
@@ -364,8 +408,10 @@ fn emit_one_effect_inner(
     // the variant itself is tracked via `s.status`. Subscripts are cast to
     // `usize` — params bind at their spec types (`u8` etc.) while Rust
     // arrays index by `usize` (`s.voted[member_index]` was E0277, #295).
-    let field_owned = cast_subscripts(&strip_variant_prefix_for_flat_state(field, spec));
+    let effect_path = field;
+    let field_owned = strip_variant_prefix_for_flat_state(&effect_path_source(effect_path), spec);
     let field = field_owned.as_str();
+    let field_target = render_effect_target(effect_path, spec, "s");
     // Tree-native RHS (#151 Slice 1): one render call replaces the
     // adapter's pre-rendered string + `resolve_value`'s binder surgery +
     // the account-pubkey substring rewrite. Fallibility is structural,
@@ -407,17 +453,17 @@ fn emit_one_effect_inner(
     let rust_value = substitute_pre_reads(&rust_value, "s", pre_fields);
     match op_kind {
         "set" => {
-            out.push_str(&format!("{indent}s.{field} = {rust_value};\n"));
+            out.push_str(&format!("{indent}{field_target} = {rust_value};\n"));
         }
         "add" => {
             if wrapping {
                 out.push_str(&format!(
-                    "{indent}s.{field} = s.{field}.wrapping_add({rust_value});\n"
+                    "{indent}{field_target} = {field_target}.wrapping_add({rust_value});\n"
                 ));
             } else {
                 out.push_str(&format!(
-                    "{indent}match s.{field}.checked_add({rust_value}) {{\n\
-                     {indent}    Some(__v) => s.{field} = __v,\n\
+                    "{indent}match {field_target}.checked_add({rust_value}) {{\n\
+                     {indent}    Some(__v) => {field_target} = __v,\n\
                      {indent}    None => return false,\n\
                      {indent}}}\n"
                 ));
@@ -425,23 +471,23 @@ fn emit_one_effect_inner(
         }
         "add_sat" => {
             out.push_str(&format!(
-                "{indent}s.{field} = s.{field}.saturating_add({rust_value});\n"
+                "{indent}{field_target} = {field_target}.saturating_add({rust_value});\n"
             ));
         }
         "add_wrap" => {
             out.push_str(&format!(
-                "{indent}s.{field} = s.{field}.wrapping_add({rust_value});\n"
+                "{indent}{field_target} = {field_target}.wrapping_add({rust_value});\n"
             ));
         }
         "sub" => {
             if wrapping {
                 out.push_str(&format!(
-                    "{indent}s.{field} = s.{field}.wrapping_sub({rust_value});\n"
+                    "{indent}{field_target} = {field_target}.wrapping_sub({rust_value});\n"
                 ));
             } else {
                 out.push_str(&format!(
-                    "{indent}match s.{field}.checked_sub({rust_value}) {{\n\
-                     {indent}    Some(__v) => s.{field} = __v,\n\
+                    "{indent}match {field_target}.checked_sub({rust_value}) {{\n\
+                     {indent}    Some(__v) => {field_target} = __v,\n\
                      {indent}    None => return false,\n\
                      {indent}}}\n"
                 ));
@@ -449,12 +495,12 @@ fn emit_one_effect_inner(
         }
         "sub_sat" => {
             out.push_str(&format!(
-                "{indent}s.{field} = s.{field}.saturating_sub({rust_value});\n"
+                "{indent}{field_target} = {field_target}.saturating_sub({rust_value});\n"
             ));
         }
         "sub_wrap" => {
             out.push_str(&format!(
-                "{indent}s.{field} = s.{field}.wrapping_sub({rust_value});\n"
+                "{indent}{field_target} = {field_target}.wrapping_sub({rust_value});\n"
             ));
         }
         _ => {
@@ -471,7 +517,7 @@ pub fn emit_one_effect_with_account_env(
     out: &mut String,
     spec: &ParsedSpec,
     wrapping: bool,
-    field: &str,
+    field: &crate::mir::Path,
     op_kind: &str,
     value: &crate::mir::Expr,
     indent: &str,

--- a/crates/qedgen/src/codegen/rust_codegen_util/emit.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/emit.rs
@@ -462,7 +462,7 @@ pub fn emit_transition_fn_inner(
         let mut pairs: Vec<(String, String)> = Vec::new();
         for (field, _, value) in block_effect_triples_deep(body) {
             field_string_subscripts(
-                &strip_variant_prefix_for_flat_state(&field, spec),
+                &strip_variant_prefix_for_flat_state(&effect_path_source(field), spec),
                 &mut pairs,
             );
             if let Some(tree) = value.tree.as_ref() {
@@ -494,11 +494,12 @@ pub fn emit_transition_fn_inner(
     // conformance harnesses' `pre_<field>` assertions instead of the
     // emission order. Computed from the exact triples emitted below
     // (post pubkey-skip), so every snapshot is referenced.
-    let emitted_triples: Vec<(String, &'static str, &crate::mir::Expr)> =
+    let emitted_triples: Vec<(&crate::mir::Path, &'static str, &crate::mir::Expr)> =
         block_effect_triples_deep(body)
             .into_iter()
             .filter(|(field, _, _)| {
-                account_env_struct.is_some() || !field_type_is_pubkey(field, op, spec)
+                account_env_struct.is_some()
+                    || !field_type_is_pubkey(&effect_path_source(field), op, spec)
             })
             .collect();
     let pre_fields = parallel_snapshot_fields(&emitted_triples, spec);
@@ -536,8 +537,8 @@ pub fn emit_transition_fn_inner(
         out.push_str(&format!("    match {} {{\n", scrutinee_rust));
         let emit_arm_block = |out: &mut String, block: &crate::mir::Block| {
             for (field, op_kind, value) in block_effect_triples(block) {
-                let field = field.as_str();
-                if account_env_struct.is_none() && field_type_is_pubkey(field, op, spec) {
+                let field_name = effect_path_source(field);
+                if account_env_struct.is_none() && field_type_is_pubkey(&field_name, op, spec) {
                     continue;
                 }
                 if account_env_struct.is_some() {
@@ -564,7 +565,7 @@ pub fn emit_transition_fn_inner(
                         &pre_fields,
                     );
                 }
-                emit_after_store_hooks(out, &mir.hooks, field, "            ");
+                emit_after_store_hooks(out, &mir.hooks, &field_name, "            ");
             }
         };
         for arm in arms {
@@ -595,8 +596,8 @@ pub fn emit_transition_fn_inner(
         // triple these templates consume (byte-identical; see its doc)
         // and skips non-effect variants in-stream without reordering.
         for (field, op_kind, value) in block_effect_triples(body) {
-            let field = field.as_str();
-            if account_env_struct.is_none() && field_type_is_pubkey(field, op, spec) {
+            let field_name = effect_path_source(field);
+            if account_env_struct.is_none() && field_type_is_pubkey(&field_name, op, spec) {
                 continue;
             }
             if account_env_struct.is_some() {
@@ -623,7 +624,7 @@ pub fn emit_transition_fn_inner(
                     &pre_fields,
                 );
             }
-            emit_after_store_hooks(out, &mir.hooks, field, "    ");
+            emit_after_store_hooks(out, &mir.hooks, &field_name, "    ");
         }
     }
 

--- a/crates/qedgen/src/codegen/rust_codegen_util/tests.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tests.rs
@@ -20,6 +20,7 @@ state {
   cap : U64,
   owner : Pubkey,
 }
+
 type Error | Overflow | Unauthorized
 handler churn (amount : U64) (who : Pubkey) {
   requires amount > 0 else Unauthorized
@@ -40,7 +41,7 @@ handler churn (amount : U64) (who : Pubkey) {
         let body = mir.handler_block(&op.name).expect("mir body");
         let got: Vec<(String, String, String)> = block_effect_triples(body)
             .into_iter()
-            .map(|(f, k, v)| (f, k.to_string(), mir_expr_rust(v)))
+            .map(|(f, k, v)| (effect_path_source(f), k.to_string(), mir_expr_rust(v)))
             .collect();
         let want: Vec<(String, String, String)> = op
             .effects
@@ -61,6 +62,27 @@ handler churn (amount : U64) (who : Pubkey) {
     assert_eq!(
         kinds,
         vec!["add", "add_sat", "add_wrap", "sub", "sub_sat", "sub_wrap", "set"]
+    );
+}
+
+#[test]
+fn effect_lhs_stays_structured_and_uses_the_canonical_rust_renderer() {
+    let src = r#"spec TypedLhs
+const CAP = 4
+type State | Active of { voted : Map[CAP] U8 }
+handler vote (member_index : U8) : State.Active -> State.Active {
+  effect { Active.voted[member_index] := 1 }
+}
+"#;
+    let spec = parse_str(src).expect("parse");
+    let mir = crate::mir::lower(&spec);
+    let body = mir.handler_block("vote").expect("MIR body");
+    let (path, _, _) = stmt_effect_triple(&body.stmts[0]).expect("effect");
+
+    assert!(path.tree.is_some(), "adapter effects retain a typed LHS");
+    assert_eq!(
+        render_effect_target(path, &spec, "s"),
+        "s.voted[(member_index) as usize]"
     );
 }
 
@@ -158,7 +180,7 @@ fn stmt_effect_triples_round_trip_bundled_examples() {
                 .unwrap_or_else(|| panic!("MIR missing `{}` in {:?}", op.name, spec_path));
             let got: Vec<(String, String, String)> = block_effect_triples(body)
                 .into_iter()
-                .map(|(f, k, v)| (f, k.to_string(), mir_expr_rust(v)))
+                .map(|(f, k, v)| (effect_path_source(f), k.to_string(), mir_expr_rust(v)))
                 .collect();
             let want: Vec<(String, String, String)> = op
                 .effects

--- a/crates/qedgen/src/codegen/unit_test.rs
+++ b/crates/qedgen/src/codegen/unit_test.rs
@@ -567,10 +567,9 @@ fn effect_triples(op_name: &str, mir: &crate::mir::Mir, spec: &ParsedSpec) -> Ve
         .into_iter()
         .filter(|(field, _, value)| !effect_is_account_valued(field, value, op_name, spec))
         .map(|(field, kind, value)| {
+            let target = crate::rust_codegen_util::render_effect_target(field, spec, "state");
             (
-                cast_subscripts(
-                    &crate::rust_codegen_util::strip_variant_prefix_for_flat_state(&field, spec),
-                ),
+                target.strip_prefix("state.").unwrap_or(&target).to_string(),
                 kind,
                 // `state.` receiver, same binder as `render_for_state` —
                 // the native default renders state reads as `s.<field>`,
@@ -593,7 +592,7 @@ fn effect_triples(op_name: &str, mir: &crate::mir::Mir, spec: &ParsedSpec) -> Ve
 ///   `apply_*`/test scopes have no such binding, so rendering it
 ///   verbatim is an E0425 (#297).
 fn effect_is_account_valued(
-    field: &str,
+    field: &crate::mir::Path,
     value: &crate::mir::Expr,
     op_name: &str,
     spec: &ParsedSpec,
@@ -602,7 +601,13 @@ fn effect_is_account_valued(
         .handlers
         .iter()
         .find(|o| o.name == op_name)
-        .is_some_and(|op| crate::rust_codegen_util::field_type_is_pubkey(field, op, spec));
+        .is_some_and(|op| {
+            crate::rust_codegen_util::field_type_is_pubkey(
+                &crate::rust_codegen_util::effect_path_source(field),
+                op,
+                spec,
+            )
+        });
     dest_is_pubkey
         || crate::rust_codegen_util::tree_render::tree_mentions_account(
             crate::rust_codegen_util::mir_expr_tree(value),
@@ -622,7 +627,10 @@ fn suppressed_effect_notes(op_name: &str, mir: &crate::mir::Mir, spec: &ParsedSp
         .map(|(field, _, value)| {
             format!(
                 "{} := {}",
-                crate::rust_codegen_util::strip_variant_prefix_for_flat_state(&field, spec),
+                crate::rust_codegen_util::strip_variant_prefix_for_flat_state(
+                    &crate::rust_codegen_util::effect_path_source(field),
+                    spec,
+                ),
                 crate::rust_codegen_util::mir_expr_rust(value)
             )
         })
@@ -638,7 +646,7 @@ fn parallel_pre_fields(op_name: &str, mir: &crate::mir::Mir, spec: &ParsedSpec) 
     let Some(h) = mir.handlers.iter().find(|h| h.name == op_name) else {
         return Vec::new();
     };
-    let triples: Vec<(String, &'static str, &crate::mir::Expr)> =
+    let triples: Vec<(&crate::mir::Path, &'static str, &crate::mir::Expr)> =
         crate::rust_codegen_util::block_effect_triples_deep(&h.body)
             .into_iter()
             .filter(|(field, _, value)| !effect_is_account_valued(field, value, op_name, spec))
@@ -650,36 +658,6 @@ fn parallel_pre_fields(op_name: &str, mir: &crate::mir::Mir, spec: &ParsedSpec) 
 /// receiver this file renders with.
 fn substitute_pre_state_reads(value: &str, pre_fields: &[String]) -> String {
     crate::rust_codegen_util::substitute_pre_reads(value, "state", pre_fields)
-}
-
-/// Rewrite `[ident]` subscripts to `[ident as usize]` — unit tests bind
-/// params at their spec types (`u8` etc.) while Rust arrays index by
-/// `usize`. Numeric and compound subscripts pass through unchanged.
-fn cast_subscripts(field: &str) -> String {
-    let mut out = String::new();
-    let mut rest = field;
-    while let Some(i) = rest.find('[') {
-        out.push_str(&rest[..=i]);
-        rest = &rest[i + 1..];
-        let Some(j) = rest.find(']') else {
-            out.push_str(rest);
-            return out;
-        };
-        let idx = &rest[..j];
-        let is_numeric = !idx.is_empty() && idx.chars().all(|c| c.is_ascii_digit());
-        let is_ident = !idx.is_empty()
-            && idx.chars().all(|c| c.is_alphanumeric() || c == '_')
-            && !idx.starts_with(|c: char| c.is_ascii_digit());
-        if is_ident && !is_numeric {
-            out.push_str(&format!("{} as usize", idx));
-        } else {
-            out.push_str(idx);
-        }
-        out.push(']');
-        rest = &rest[j + 1..];
-    }
-    out.push_str(rest);
-    out
 }
 
 /// Identifier-safe form of an effect-target path for `pre_*` snapshot

--- a/crates/qedgen/src/mir/mod.rs
+++ b/crates/qedgen/src/mir/mod.rs
@@ -834,18 +834,24 @@ pub struct Path {
     /// First segment indicates the namespace (`state`, an account
     /// binding name, a handler param).
     pub segments: Vec<Symbol>,
+    /// Structured source path for effect targets. This is populated by the
+    /// parser adapter and retained through lowering; legacy constructors
+    /// leave it empty.
+    pub tree: Option<expr_tree::TreePath>,
 }
 
 impl Path {
     pub fn single(name: impl Into<Symbol>) -> Self {
         Path {
             segments: vec![name.into()],
+            tree: None,
         }
     }
 
     pub fn dotted(parts: &[&str]) -> Self {
         Path {
             segments: parts.iter().map(|s| s.to_string()).collect(),
+            tree: None,
         }
     }
 }
@@ -1573,7 +1579,8 @@ fn lower_effects(effects: &[crate::check::ParsedEffect]) -> Vec<Stmt> {
     let mut stmts = Vec::new();
     for eff in effects {
         let err_override = eff.on_error.clone();
-        let path = parse_field_path(&eff.field);
+        let mut path = parse_field_path(&eff.field);
+        path.tree = eff.lhs.clone();
         let tree = eff.tree.clone();
         let value = &eff.value;
         // `value` doubles as the Lean form; the Rust form comes from the
@@ -1624,6 +1631,7 @@ fn lower_effects(effects: &[crate::check::ParsedEffect]) -> Vec<Stmt> {
 fn parse_field_path(s: &str) -> Path {
     Path {
         segments: s.split('.').map(|seg| seg.to_string()).collect(),
+        tree: None,
     }
 }
 

--- a/crates/qedgen/src/spec/chumsky_adapter/effects.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/effects.rs
@@ -17,6 +17,7 @@ use super::*;
 /// RHS carrier (#151 Slice 0) — built for every shape, simple or compound.
 pub(super) struct RenderedEffect {
     pub triple: (String, String, String),
+    pub lhs: crate::mir::expr_tree::TreePath,
     pub on_error: Option<String>,
     pub value_rust: String,
     pub tree: Option<crate::mir::ExprTree>,
@@ -29,6 +30,7 @@ impl RenderedEffect {
         let (field, op, value) = self.triple;
         crate::check::ParsedEffect {
             field,
+            lhs: Some(self.lhs),
             op,
             value,
             value_rust: self.value_rust,
@@ -56,6 +58,24 @@ fn render_effect(
     // index casting is applied at the codegen.rs::mechanize_effect site
     // so the Lean output stays untouched.
     let field = stmt.lhs.to_source_string();
+    // An effect LHS is a write into state even when its bare field name
+    // collides with a handler parameter. Expression canonicalization cannot
+    // make that assumption, so root the target explicitly here.
+    let lhs_path = if stmt.lhs.root == "state" {
+        stmt.lhs.clone()
+    } else {
+        let mut segments = Vec::with_capacity(stmt.lhs.segments.len() + 1);
+        segments.push(a::PathSeg::Field(stmt.lhs.root.clone()));
+        segments.extend(stmt.lhs.segments.iter().cloned());
+        a::Path {
+            root: "state".to_string(),
+            segments,
+        }
+    };
+    let lhs_node = Node::new(a::Expr::Path(lhs_path), 0..0);
+    let crate::mir::ExprTree::Path(lhs) = build_expr_tree(&lhs_node, tcx) else {
+        unreachable!("an effect target path must build as ExprTree::Path")
+    };
     // Per-effect semantic tag:
     //   - "add" / "sub"               = checked (default)
     //   - "add_sat" / "sub_sat"       = saturating (`+=!` / `-=!`)
@@ -93,6 +113,7 @@ fn render_effect(
     };
     RenderedEffect {
         triple: (field, op.to_string(), value),
+        lhs,
         on_error,
         value_rust,
         tree,
@@ -182,6 +203,15 @@ pub(super) fn render_effect_or_expand_variant_promotion(
                                 );
                                 RenderedEffect {
                                     triple: (lhs_str, "set".to_string(), value_str),
+                                    lhs: crate::mir::expr_tree::TreePath {
+                                        root: "state".to_string(),
+                                        binding: crate::mir::expr_tree::BindingKind::StateField,
+                                        segments: vec![
+                                            crate::mir::expr_tree::TreeSeg::Field(variant.clone()),
+                                            crate::mir::expr_tree::TreeSeg::Field(fname.clone()),
+                                        ],
+                                        ty: None,
+                                    },
                                     on_error: None,
                                     value_rust,
                                     tree,

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -1258,13 +1258,13 @@ fn apply_propose(state: &mut MultisigState) {
 /// Apply `approve` effects to state.
 fn apply_approve(state: &mut MultisigState, member_index: u8) {
     state.approval_count += 1;
-    state.voted[member_index as usize] = 1;
+    state.voted[(member_index) as usize] = 1;
 }
 
 /// Apply `reject` effects to state.
 fn apply_reject(state: &mut MultisigState, member_index: u8) {
     state.rejection_count += 1;
-    state.voted[member_index as usize] = 1;
+    state.voted[(member_index) as usize] = 1;
 }
 
 /// Apply `execute` effects to state.
@@ -1281,7 +1281,7 @@ fn apply_cancel_proposal(state: &mut MultisigState) {
 
 /// Apply `add_member` effects to state.
 fn apply_add_member(state: &mut MultisigState, member_index: u8, member_pubkey: [u8; 32]) {
-    state.members[member_index as usize] = member_pubkey;
+    state.members[(member_index) as usize] = member_pubkey;
 }
 
 /// Apply `remove_member` effects to state.
@@ -1385,7 +1385,7 @@ mod tests {
         let pre_approval_count = state.approval_count;
         apply_approve(&mut state, member_index);
         assert_eq!(state.approval_count, pre_approval_count + 1);
-        assert_eq!(state.voted[member_index as usize], 1);
+        assert_eq!(state.voted[(member_index) as usize], 1);
     }
 
     #[test]
@@ -1403,7 +1403,7 @@ mod tests {
         let pre_rejection_count = state.rejection_count;
         apply_reject(&mut state, member_index);
         assert_eq!(state.rejection_count, pre_rejection_count + 1);
-        assert_eq!(state.voted[member_index as usize], 1);
+        assert_eq!(state.voted[(member_index) as usize], 1);
     }
 
     #[test]
@@ -1453,7 +1453,7 @@ mod tests {
         let member_index: u8 = 0;
         let member_pubkey: [u8; 32] = [1u8; 32];
         apply_add_member(&mut state, member_index, member_pubkey);
-        assert_eq!(state.members[member_index as usize], member_pubkey);
+        assert_eq!(state.members[(member_index) as usize], member_pubkey);
     }
 
     #[test]
@@ -2436,7 +2436,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -2456,7 +2456,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -2502,7 +2502,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }
@@ -3362,7 +3362,7 @@ fn verify_approve_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if approve(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -3458,7 +3458,7 @@ fn verify_reject_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if reject(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -3660,7 +3660,7 @@ fn verify_add_member_effect_members_member_index() {
     let pre_rejection_count = s.rejection_count;
     if add_member(&mut s, member_index, member_pubkey) {
         assert!(
-            pubkey_eq(&s.members[member_index as usize], &member_pubkey),
+            pubkey_eq(&s.members[(member_index) as usize], &member_pubkey),
             "members[member_index] must equal member_pubkey"
         );
         assert!(
@@ -4010,7 +4010,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -4030,7 +4030,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -4076,7 +4076,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }

--- a/crates/qedgen/tests/snapshots/multisig.kani.rs
+++ b/crates/qedgen/tests/snapshots/multisig.kani.rs
@@ -141,7 +141,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -161,7 +161,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -207,7 +207,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }
@@ -1067,7 +1067,7 @@ fn verify_approve_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if approve(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -1163,7 +1163,7 @@ fn verify_reject_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if reject(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -1365,7 +1365,7 @@ fn verify_add_member_effect_members_member_index() {
     let pre_rejection_count = s.rejection_count;
     if add_member(&mut s, member_index, member_pubkey) {
         assert!(
-            pubkey_eq(&s.members[member_index as usize], &member_pubkey),
+            pubkey_eq(&s.members[(member_index) as usize], &member_pubkey),
             "members[member_index] must equal member_pubkey"
         );
         assert!(

--- a/crates/qedgen/tests/snapshots/multisig.proptest.rs
+++ b/crates/qedgen/tests/snapshots/multisig.proptest.rs
@@ -134,7 +134,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -154,7 +154,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -200,7 +200,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }

--- a/examples/rust/multisig/programs/src/tests.rs
+++ b/examples/rust/multisig/programs/src/tests.rs
@@ -54,13 +54,13 @@ fn apply_propose(state: &mut MultisigState) {
 /// Apply `approve` effects to state.
 fn apply_approve(state: &mut MultisigState, member_index: u8) {
     state.approval_count += 1;
-    state.voted[member_index as usize] = 1;
+    state.voted[(member_index) as usize] = 1;
 }
 
 /// Apply `reject` effects to state.
 fn apply_reject(state: &mut MultisigState, member_index: u8) {
     state.rejection_count += 1;
-    state.voted[member_index as usize] = 1;
+    state.voted[(member_index) as usize] = 1;
 }
 
 /// Apply `execute` effects to state.
@@ -77,7 +77,7 @@ fn apply_cancel_proposal(state: &mut MultisigState) {
 
 /// Apply `add_member` effects to state.
 fn apply_add_member(state: &mut MultisigState, member_index: u8, member_pubkey: [u8; 32]) {
-    state.members[member_index as usize] = member_pubkey;
+    state.members[(member_index) as usize] = member_pubkey;
 }
 
 /// Apply `remove_member` effects to state.
@@ -181,7 +181,7 @@ mod tests {
         let pre_approval_count = state.approval_count;
         apply_approve(&mut state, member_index);
         assert_eq!(state.approval_count, pre_approval_count + 1);
-        assert_eq!(state.voted[member_index as usize], 1);
+        assert_eq!(state.voted[(member_index) as usize], 1);
     }
 
     #[test]
@@ -199,7 +199,7 @@ mod tests {
         let pre_rejection_count = state.rejection_count;
         apply_reject(&mut state, member_index);
         assert_eq!(state.rejection_count, pre_rejection_count + 1);
-        assert_eq!(state.voted[member_index as usize], 1);
+        assert_eq!(state.voted[(member_index) as usize], 1);
     }
 
     #[test]
@@ -249,7 +249,7 @@ mod tests {
         let member_index: u8 = 0;
         let member_pubkey: [u8; 32] = [1u8; 32];
         apply_add_member(&mut state, member_index, member_pubkey);
-        assert_eq!(state.members[member_index as usize], member_pubkey);
+        assert_eq!(state.members[(member_index) as usize], member_pubkey);
     }
 
     #[test]

--- a/examples/rust/multisig/programs/tests/kani.rs
+++ b/examples/rust/multisig/programs/tests/kani.rs
@@ -141,7 +141,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -161,7 +161,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -207,7 +207,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }
@@ -1067,7 +1067,7 @@ fn verify_approve_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if approve(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -1163,7 +1163,7 @@ fn verify_reject_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if reject(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -1365,7 +1365,7 @@ fn verify_add_member_effect_members_member_index() {
     let pre_rejection_count = s.rejection_count;
     if add_member(&mut s, member_index, member_pubkey) {
         assert!(
-            pubkey_eq(&s.members[member_index as usize], &member_pubkey),
+            pubkey_eq(&s.members[(member_index) as usize], &member_pubkey),
             "members[member_index] must equal member_pubkey"
         );
         assert!(

--- a/examples/rust/multisig/programs/tests/proptest.rs
+++ b/examples/rust/multisig/programs/tests/proptest.rs
@@ -134,7 +134,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -154,7 +154,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -200,7 +200,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }

--- a/examples/rust/multisig/src/tests.rs
+++ b/examples/rust/multisig/src/tests.rs
@@ -54,13 +54,13 @@ fn apply_propose(state: &mut MultisigState) {
 /// Apply `approve` effects to state.
 fn apply_approve(state: &mut MultisigState, member_index: u8) {
     state.approval_count += 1;
-    state.voted[member_index as usize] = 1;
+    state.voted[(member_index) as usize] = 1;
 }
 
 /// Apply `reject` effects to state.
 fn apply_reject(state: &mut MultisigState, member_index: u8) {
     state.rejection_count += 1;
-    state.voted[member_index as usize] = 1;
+    state.voted[(member_index) as usize] = 1;
 }
 
 /// Apply `execute` effects to state.
@@ -77,7 +77,7 @@ fn apply_cancel_proposal(state: &mut MultisigState) {
 
 /// Apply `add_member` effects to state.
 fn apply_add_member(state: &mut MultisigState, member_index: u8, member_pubkey: [u8; 32]) {
-    state.members[member_index as usize] = member_pubkey;
+    state.members[(member_index) as usize] = member_pubkey;
 }
 
 /// Apply `remove_member` effects to state.
@@ -181,7 +181,7 @@ mod tests {
         let pre_approval_count = state.approval_count;
         apply_approve(&mut state, member_index);
         assert_eq!(state.approval_count, pre_approval_count + 1);
-        assert_eq!(state.voted[member_index as usize], 1);
+        assert_eq!(state.voted[(member_index) as usize], 1);
     }
 
     #[test]
@@ -199,7 +199,7 @@ mod tests {
         let pre_rejection_count = state.rejection_count;
         apply_reject(&mut state, member_index);
         assert_eq!(state.rejection_count, pre_rejection_count + 1);
-        assert_eq!(state.voted[member_index as usize], 1);
+        assert_eq!(state.voted[(member_index) as usize], 1);
     }
 
     #[test]
@@ -249,7 +249,7 @@ mod tests {
         let member_index: u8 = 0;
         let member_pubkey: [u8; 32] = [1u8; 32];
         apply_add_member(&mut state, member_index, member_pubkey);
-        assert_eq!(state.members[member_index as usize], member_pubkey);
+        assert_eq!(state.members[(member_index) as usize], member_pubkey);
     }
 
     #[test]

--- a/examples/rust/multisig/tests/kani.rs
+++ b/examples/rust/multisig/tests/kani.rs
@@ -141,7 +141,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -161,7 +161,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -207,7 +207,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }
@@ -1067,7 +1067,7 @@ fn verify_approve_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if approve(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -1163,7 +1163,7 @@ fn verify_reject_effect_voted_member_index() {
     let pre_rejection_count = s.rejection_count;
     if reject(&mut s, member_index) {
         assert!(
-            s.voted[member_index as usize] == 1,
+            s.voted[(member_index) as usize] == 1,
             "voted[member_index] must equal 1"
         );
         assert!(
@@ -1365,7 +1365,7 @@ fn verify_add_member_effect_members_member_index() {
     let pre_rejection_count = s.rejection_count;
     if add_member(&mut s, member_index, member_pubkey) {
         assert!(
-            pubkey_eq(&s.members[member_index as usize], &member_pubkey),
+            pubkey_eq(&s.members[(member_index) as usize], &member_pubkey),
             "members[member_index] must equal member_pubkey"
         );
         assert!(

--- a/examples/rust/multisig/tests/proptest.rs
+++ b/examples/rust/multisig/tests/proptest.rs
@@ -134,7 +134,7 @@ fn approve(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.approval_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -154,7 +154,7 @@ fn reject(s: &mut State, member_index: u8) -> bool {
         Some(__v) => s.rejection_count = __v,
         None => return false,
     }
-    s.voted[member_index as usize] = 1;
+    s.voted[(member_index) as usize] = 1;
     s.status = Status::HasProposal;
     true
 }
@@ -200,7 +200,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
     if !(((member_index) as usize) < s.members.len()) {
         return false;
     }
-    s.members[member_index as usize] = member_pubkey;
+    s.members[(member_index) as usize] = member_pubkey;
     s.status = Status::Active;
     true
 }


### PR DESCRIPTION
## Summary
- carry a name-resolved effect LHS path from the parser adapter through ParsedEffect and MIR
- project typed MIR paths into transition, unit-test, and Kani emitters
- render effect reads and writes with the canonical precedence-aware Rust tree renderer
- remove the duplicated unit-test subscript rewrite and cover state-field/parameter name collisions

This is the typed-effect-LHS slice of #313. The guard/strategy expression composition sweep remains a separate follow-up.

## Verification
- cargo test --manifest-path crates/qedgen/Cargo.toml
- cargo clippy --manifest-path crates/qedgen/Cargo.toml --all-targets -- -D warnings
- cargo fmt --manifest-path crates/qedgen/Cargo.toml -- --check

Progresses #313