### PR TITLE
refactor(codegen): centralize Rust expression composition

### DIFF
--- a/crates/qedgen/src/codegen/kani_impl/tests.rs
+++ b/crates/qedgen/src/codegen/kani_impl/tests.rs
@@ -457,7 +457,7 @@ handler recompute (n : U64) {
     // Panic-freedom is claimed UNDER the handler's preconditions — the `requires`
     // guard is assumed (not asserted).
     assert!(
-        compact(&body).contains(&compact("kani::assume((n <= pre_cap));")),
+        compact(&body).contains(&compact("kani::assume(n <= pre_cap);")),
         "panic-free harness assumes the `requires` guard; got:\n{body}"
     );
     // Call-only: no `assert!` and no ensures/reject scaffolding in this proof.
@@ -3159,8 +3159,9 @@ handler deposit (amt : U64) {
     let is_ok_pos = body
         .find("if result.is_ok()")
         .expect("harness must have `if result.is_ok()`");
-    let assume_pos = body
+    let assume_pos = body[is_ok_pos..]
         .find("kani::assume(amt > 0)")
+        .map(|i| is_ok_pos + i)
         .expect("assume present (just asserted above)");
     let assert_pos = body[is_ok_pos..]
         .find("assert!")
@@ -3666,7 +3667,7 @@ fn context_mode_emits_try_accounts_gate() {
     // state account in place (`ctx_accounts.settings.<field>`).
     assert!(
         compact(&body).contains(&compact("let pre_status = ctx_accounts.settings.status;"))
-            && compact(&body).contains(&compact("kani::assume((pre_status == 1));"))
+            && compact(&body).contains(&compact("kani::assume(pre_status == 1);"))
             && compact(&body)
                 .contains(&compact("ctx_accounts.settings.threshold == new_threshold")),
         "requires assume off the pre-snapshot; ensures reads ctx_accounts.<state>; got:\n{body}"
@@ -3768,7 +3769,7 @@ handler decrement (amount : U64) {
         "nested-old parent record snapshotted via clone; got:\n{body}"
     );
     assert!(
-        compact(&body).contains(&compact("kani::assume((amount <= pre_window.remaining));")),
+        compact(&body).contains(&compact("kani::assume(amount <= pre_window.remaining);")),
         "requires reads the nested pre-snapshot path; got:\n{body}"
     );
     assert!(

--- a/crates/qedgen/src/codegen/kani_mir/tests.rs
+++ b/crates/qedgen/src/codegen/kani_mir/tests.rs
@@ -566,11 +566,11 @@ fn bare_state_field_requires_reach_harness_with_receiver() {
     );
     let out = render(&mir, &parsed);
     assert!(
-        out.contains("if !((s.active == 0) && (amount > 0))"),
+        out.contains("if !(s.active == 0 && amount > 0)"),
         "transition guard must read state through `s`:\n{out}"
     );
     assert!(
-        out.contains("kani::assume(!((s.active == 0) && (amount > 0)));"),
+        out.contains("kani::assume(!(s.active == 0 && amount > 0));"),
         "guard-rejection assume must read state through `s`:\n{out}"
     );
     assert!(
@@ -676,7 +676,7 @@ fn compound_effect_rhs_and_arith_predicates_render_soundly() {
     );
     // … guard addition evaluates in u128 (matches the Lean Nat model) …
     assert!(
-        out.contains("(((now) as u128) >= ((s.start) as u128) + ((s.period) as u128))"),
+        out.contains("((now) as u128) >= ((s.start) as u128) + ((s.period) as u128)"),
         "guard arithmetic must widen to u128:\n{out}"
     );
     // … and the property predicate can't overflow while being evaluated.

--- a/crates/qedgen/src/codegen/proptest_gen_mir.rs
+++ b/crates/qedgen/src/codegen/proptest_gen_mir.rs
@@ -15,6 +15,121 @@ use crate::codegen_shared::{map_type, write_generated_file, DslTypeExt};
 use crate::mir::Mir;
 use crate::rust_codegen_util;
 
+/// Small typed syntax for proptest strategy expressions. Strategy selection
+/// decides the shape; this renderer owns calls, ranges, macro alternatives,
+/// and method chaining so nested strategies are not assembled by interpolating
+/// already-rendered Rust fragments.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StrategyExpr {
+    Atom(String),
+    Range {
+        start: String,
+        end: Option<String>,
+        inclusive: bool,
+    },
+    Call {
+        callee: String,
+        args: Vec<StrategyExpr>,
+    },
+    OneOf(Vec<StrategyExpr>),
+    Method {
+        receiver: Box<StrategyExpr>,
+        method: String,
+        args: Vec<StrategyExpr>,
+    },
+}
+
+impl StrategyExpr {
+    fn atom(value: impl Into<String>) -> Self {
+        Self::Atom(value.into())
+    }
+
+    fn range(start: impl Into<String>, end: impl Into<String>) -> Self {
+        Self::Range {
+            start: start.into(),
+            end: Some(end.into()),
+            inclusive: true,
+        }
+    }
+
+    fn half_open_range(start: impl Into<String>, end: impl Into<String>) -> Self {
+        Self::Range {
+            start: start.into(),
+            end: Some(end.into()),
+            inclusive: false,
+        }
+    }
+
+    fn range_from(start: impl Into<String>) -> Self {
+        Self::Range {
+            start: start.into(),
+            end: None,
+            inclusive: false,
+        }
+    }
+
+    fn call(callee: impl Into<String>, args: Vec<Self>) -> Self {
+        Self::Call {
+            callee: callee.into(),
+            args,
+        }
+    }
+
+    fn one_of(choices: Vec<Self>) -> Self {
+        Self::OneOf(choices)
+    }
+
+    fn method(self, method: impl Into<String>, args: Vec<Self>) -> Self {
+        Self::Method {
+            receiver: Box::new(self),
+            method: method.into(),
+            args,
+        }
+    }
+
+    fn render(&self) -> String {
+        match self {
+            Self::Atom(value) => value.clone(),
+            Self::Range {
+                start,
+                end,
+                inclusive,
+            } => match (end, inclusive) {
+                (Some(end), true) => format!("{start}..={end}"),
+                (Some(end), false) => format!("{start}..{end}"),
+                (None, _) => format!("{start}.."),
+            },
+            Self::Call { callee, args } => format!(
+                "{callee}({})",
+                args.iter().map(Self::render).collect::<Vec<_>>().join(", ")
+            ),
+            Self::OneOf(choices) => format!(
+                "prop_oneof![{}]",
+                choices
+                    .iter()
+                    .map(Self::render)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Self::Method {
+                receiver,
+                method,
+                args,
+            } => format!(
+                "{}.{method}({})",
+                receiver.render(),
+                args.iter().map(Self::render).collect::<Vec<_>>().join(", ")
+            ),
+        }
+    }
+}
+
+impl std::fmt::Display for StrategyExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.render())
+    }
+}
+
 /// Generate the proptest harness file at `output_path`.
 pub fn generate(mir: &Mir, parsed: &ParsedSpec, output_path: &Path) -> Result<()> {
     if parsed.handlers.is_empty() {
@@ -25,53 +140,75 @@ pub fn generate(mir: &Mir, parsed: &ParsedSpec, output_path: &Path) -> Result<()
 
 /// Proptest strategy for a DSL primitive type; compound types go through
 /// `strategy_for_field`, which dispatches here once unwrapped.
-fn strategy_for_type(dsl_type: &str) -> &str {
+fn strategy_for_type(dsl_type: &str) -> StrategyExpr {
     match dsl_type {
-        "U8" => "0u8..=255u8",
-        "U16" => "0u16..=u16::MAX",
-        "U32" => "0u32..=u32::MAX",
-        "U64" => "0u64..=u64::MAX",
-        "U128" => "0u128..=u128::MAX",
-        "I8" => "i8::MIN..=i8::MAX",
-        "I16" => "i16::MIN..=i16::MAX",
-        "I32" => "i32::MIN..=i32::MAX",
-        "I64" => "i64::MIN..=i64::MAX",
-        "I128" => "any::<i128>()",
-        "Bool" => "any::<bool>()",
-        "Pubkey" => "prop::array::uniform32(0u8..)",
+        "U8" => StrategyExpr::range("0u8", "255u8"),
+        "U16" => StrategyExpr::range("0u16", "u16::MAX"),
+        "U32" => StrategyExpr::range("0u32", "u32::MAX"),
+        "U64" => StrategyExpr::range("0u64", "u64::MAX"),
+        "U128" => StrategyExpr::range("0u128", "u128::MAX"),
+        "I8" => StrategyExpr::range("i8::MIN", "i8::MAX"),
+        "I16" => StrategyExpr::range("i16::MIN", "i16::MAX"),
+        "I32" => StrategyExpr::range("i32::MIN", "i32::MAX"),
+        "I64" => StrategyExpr::range("i64::MIN", "i64::MAX"),
+        "I128" => StrategyExpr::call("any::<i128>", Vec::new()),
+        "Bool" => StrategyExpr::call("any::<bool>", Vec::new()),
+        "Pubkey" => StrategyExpr::call(
+            "prop::array::uniform32",
+            vec![StrategyExpr::range_from("0u8")],
+        ),
         // Byte tokens (#191): `uniform32` maxes out at 32, so Bytes64 uses
         // proptest's const-generic array `Arbitrary` (proptest ≥ 1.0).
-        "Bytes32" => "prop::array::uniform32(0u8..)",
-        "Bytes64" => "any::<[u8; 64]>()",
+        "Bytes32" => StrategyExpr::call(
+            "prop::array::uniform32",
+            vec![StrategyExpr::range_from("0u8")],
+        ),
+        "Bytes64" => StrategyExpr::call("any::<[u8; 64]>", Vec::new()),
         // Fin[N] arrives here with the wrapper stripped; modelled as a small
         // usize range since real usage is as an index.
-        "Fin" => "0usize..=1024usize",
-        _ => "0u64..=u64::MAX",
+        "Fin" => StrategyExpr::range("0usize", "1024usize"),
+        _ => StrategyExpr::range("0u64", "u64::MAX"),
     }
 }
 
 /// Boundary-biased strategy for guard rejection tests: mixes near-0 and
 /// near-MAX values so both `> 0` and `<= LARGE_CONST` guards reject often.
-fn boundary_strategy_for_type(dsl_type: &str) -> &str {
+fn boundary_strategy_for_type(dsl_type: &str) -> StrategyExpr {
+    let edge_ranges = |min: &str, low: &str, high: &str, max: &str| {
+        StrategyExpr::one_of(vec![
+            StrategyExpr::range(min, low),
+            StrategyExpr::range(high, max),
+        ])
+    };
     match dsl_type {
-        "U8" => "prop_oneof![0u8..=3u8, 252u8..=255u8]",
-        "U16" => "prop_oneof![0u16..=3u16, (u16::MAX - 3)..=u16::MAX]",
-        "U32" => "prop_oneof![0u32..=3u32, (u32::MAX - 3)..=u32::MAX]",
-        "U64" => "prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]",
-        "U128" => "prop_oneof![0u128..=3u128, (u128::MAX - 3)..=u128::MAX]",
-        "I8" => "prop_oneof![i8::MIN..=(i8::MIN + 3), (i8::MAX - 3)..=i8::MAX]",
-        "I16" => "prop_oneof![i16::MIN..=(i16::MIN + 3), (i16::MAX - 3)..=i16::MAX]",
-        "I32" => "prop_oneof![i32::MIN..=(i32::MIN + 3), (i32::MAX - 3)..=i32::MAX]",
-        "I64" => "prop_oneof![i64::MIN..=(i64::MIN + 3), (i64::MAX - 3)..=i64::MAX]",
-        "I128" => "any::<i128>()",
-        "Bool" => "any::<bool>()",
-        "Pubkey" => "prop::array::uniform32(0u8..1u8)",
-        "Bytes32" => "prop::array::uniform32(0u8..1u8)",
-        "Bytes64" => {
-            "prop::collection::vec(0u8..1u8, 64).prop_map(|v| <[u8; 64]>::try_from(v).unwrap())"
-        }
-        "Fin" => "prop_oneof![0usize..=3usize, 1020usize..=1024usize]",
-        _ => "prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]",
+        "U8" => edge_ranges("0u8", "3u8", "252u8", "255u8"),
+        "U16" => edge_ranges("0u16", "3u16", "(u16::MAX - 3)", "u16::MAX"),
+        "U32" => edge_ranges("0u32", "3u32", "(u32::MAX - 3)", "u32::MAX"),
+        "U64" => edge_ranges("0u64", "3u64", "(u64::MAX - 3)", "u64::MAX"),
+        "U128" => edge_ranges("0u128", "3u128", "(u128::MAX - 3)", "u128::MAX"),
+        "I8" => edge_ranges("i8::MIN", "(i8::MIN + 3)", "(i8::MAX - 3)", "i8::MAX"),
+        "I16" => edge_ranges("i16::MIN", "(i16::MIN + 3)", "(i16::MAX - 3)", "i16::MAX"),
+        "I32" => edge_ranges("i32::MIN", "(i32::MIN + 3)", "(i32::MAX - 3)", "i32::MAX"),
+        "I64" => edge_ranges("i64::MIN", "(i64::MIN + 3)", "(i64::MAX - 3)", "i64::MAX"),
+        "I128" => StrategyExpr::call("any::<i128>", Vec::new()),
+        "Bool" => StrategyExpr::call("any::<bool>", Vec::new()),
+        "Pubkey" | "Bytes32" => StrategyExpr::call(
+            "prop::array::uniform32",
+            vec![StrategyExpr::half_open_range("0u8", "1u8")],
+        ),
+        "Bytes64" => StrategyExpr::call(
+            "prop::collection::vec",
+            vec![
+                StrategyExpr::half_open_range("0u8", "1u8"),
+                StrategyExpr::atom("64"),
+            ],
+        )
+        .method(
+            "prop_map",
+            vec![StrategyExpr::atom("|v| <[u8; 64]>::try_from(v).unwrap()")],
+        ),
+        "Fin" => edge_ranges("0usize", "3usize", "1020usize", "1024usize"),
+        _ => edge_ranges("0u64", "3u64", "(u64::MAX - 3)", "u64::MAX"),
     }
 }
 
@@ -83,7 +220,7 @@ fn strategy_for_field(
     spec: &ParsedSpec,
     mode: StrategyMode,
     field_bound: Option<&str>,
-) -> Result<String> {
+) -> Result<StrategyExpr> {
     let dsl_type = dsl_type.trim();
 
     // Map[BOUND] T → strict-length Vec<T> → [T; N] via TryInto.
@@ -97,8 +234,16 @@ fn strategy_for_field(
                 let inner_src = rest[close + 1..].trim();
                 let n = spec.resolve_map_bound(bound_src)?;
                 let inner_strategy = strategy_for_field(inner_src, spec, mode, None)?;
-                return Ok(format!(
-                    "prop::collection::vec({inner_strategy}, {n}..={n}).prop_map(|v| v.try_into().ok().unwrap())"
+                return Ok(StrategyExpr::call(
+                    "prop::collection::vec",
+                    vec![
+                        inner_strategy,
+                        StrategyExpr::range(n.to_string(), n.to_string()),
+                    ],
+                )
+                .method(
+                    "prop_map",
+                    vec![StrategyExpr::atom("|v| v.try_into().ok().unwrap()")],
                 ));
             }
         }
@@ -111,14 +256,14 @@ fn strategy_for_field(
     // Fin[N] → usize; bound is informational.
     if dsl_type.starts_with("Fin[") {
         return Ok(match mode {
-            StrategyMode::Full => strategy_for_type("Fin").to_string(),
-            StrategyMode::Boundary => boundary_strategy_for_type("Fin").to_string(),
+            StrategyMode::Full => strategy_for_type("Fin"),
+            StrategyMode::Boundary => boundary_strategy_for_type("Fin"),
         });
     }
 
     // Record type → arb_<Name>() — emitted by emit_record_prop_composes.
     if spec.records.iter().any(|r| r.name == dsl_type) {
-        return Ok(format!("arb_{}()", dsl_type));
+        return Ok(StrategyExpr::call(format!("arb_{}", dsl_type), Vec::new()));
     }
 
     // Unit-variant sum type → arb_<Name>() (emit_unit_sum_prop_oneofs).
@@ -129,7 +274,7 @@ fn strategy_for_field(
             && !s.variants.is_empty()
             && s.variants.iter().all(|v| v.fields.is_empty())
     }) {
-        return Ok(format!("arb_{}()", dsl_type));
+        return Ok(StrategyExpr::call(format!("arb_{}", dsl_type), Vec::new()));
     }
 
     // Type alias: resolve transitively and recurse.
@@ -144,21 +289,25 @@ fn strategy_for_field(
             StrategyMode::Boundary => {
                 let n: u128 = bound.parse().unwrap_or(u128::MAX);
                 if n < 3 {
-                    format!("0{rt}..={b}{rt}", rt = rust_type, b = bound)
+                    StrategyExpr::range(format!("0{rust_type}"), format!("{bound}{rust_type}"))
                 } else {
-                    format!(
-                        "prop_oneof![0{rt}..=3{rt}, ({b} - 3)..={b}{rt}]",
-                        rt = rust_type,
-                        b = bound
-                    )
+                    StrategyExpr::one_of(vec![
+                        StrategyExpr::range(format!("0{rust_type}"), format!("3{rust_type}")),
+                        StrategyExpr::range(
+                            format!("({bound} - 3)"),
+                            format!("{bound}{rust_type}"),
+                        ),
+                    ])
                 }
             }
-            StrategyMode::Full => format!("0{rt}..={b}{rt}", rt = rust_type, b = bound),
+            StrategyMode::Full => {
+                StrategyExpr::range(format!("0{rust_type}"), format!("{bound}{rust_type}"))
+            }
         });
     }
     Ok(match mode {
-        StrategyMode::Boundary => boundary_strategy_for_type(dsl_type).to_string(),
-        StrategyMode::Full => strategy_for_type(dsl_type).to_string(),
+        StrategyMode::Boundary => boundary_strategy_for_type(dsl_type),
+        StrategyMode::Full => strategy_for_type(dsl_type),
     })
 }
 
@@ -1270,7 +1419,10 @@ fn emit_sequence_test_for(
                 // Type-dispatched strategy — see the effect-conformance
                 // site above (#295).
                 .map(|(_, t)| strategy_for_field(t, spec, StrategyMode::Full, None))
-                .collect::<Result<Vec<_>>>()?;
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .map(|strategy| strategy.render())
+                .collect();
             let names: Vec<&str> = op.takes_params.iter().map(|(n, _)| n.as_str()).collect();
             // proptest's tuple `Strategy` impl caps at arity 12; >12-arg
             // handlers (common for brownfield init handlers) hit E0599.
@@ -1780,11 +1932,11 @@ handler approve (member_index : U8) (member_pubkey : Pubkey) : State.Active -> S
     fn strategy_for_field_primitive_routes_through_strategy_for_type() {
         let spec = ParsedSpec::default();
         let s = strategy_for_field("U64", &spec, StrategyMode::Full, None).unwrap();
-        assert_eq!(s, "0u64..=u64::MAX");
+        assert_eq!(s.render(), "0u64..=u64::MAX");
         let s = strategy_for_field("U128", &spec, StrategyMode::Full, None).unwrap();
-        assert_eq!(s, "0u128..=u128::MAX");
+        assert_eq!(s.render(), "0u128..=u128::MAX");
         let s = strategy_for_field("I128", &spec, StrategyMode::Full, None).unwrap();
-        assert_eq!(s, "any::<i128>()");
+        assert_eq!(s.render(), "any::<i128>()");
     }
 
     #[test]
@@ -1797,12 +1949,13 @@ handler approve (member_index : U8) (member_pubkey : Pubkey) : State.Active -> S
             ..ParsedSpec::default()
         };
         let s = strategy_for_field("Map[N] U64", &spec, StrategyMode::Full, None).unwrap();
+        let rendered = s.render();
         assert!(
-            s.starts_with("prop::collection::vec(0u64..=u64::MAX, 4..=4)"),
+            rendered.starts_with("prop::collection::vec(0u64..=u64::MAX, 4..=4)"),
             "unexpected Map-primitive strategy: {s}"
         );
         assert!(
-            s.contains(".prop_map(|v| v.try_into().ok().unwrap())"),
+            rendered.contains(".prop_map(|v| v.try_into().ok().unwrap())"),
             "missing try_into prop_map: {s}"
         );
     }
@@ -1819,11 +1972,12 @@ handler noop { }
 "#;
         let spec = parse_str(src).expect("parse");
         let s = strategy_for_field("Account", &spec, StrategyMode::Full, None).unwrap();
-        assert_eq!(s, "arb_Account()");
+        assert_eq!(s.render(), "arb_Account()");
 
         let s = strategy_for_field("Map[N] Account", &spec, StrategyMode::Full, None).unwrap();
         assert!(
-            s.starts_with("prop::collection::vec(arb_Account(), 4..=4)"),
+            s.render()
+                .starts_with("prop::collection::vec(arb_Account(), 4..=4)"),
             "Map-record strategy didn't call into arb_Account: {s}"
         );
     }
@@ -1834,7 +1988,7 @@ handler noop { }
         // `Map[N] <SumName>` references, so test the strategy in isolation.
         let spec = spec_with_unit_sum("Status", &["Open", "Closed", "Cancelled"]);
         let s = strategy_for_field("Status", &spec, StrategyMode::Full, None).unwrap();
-        assert_eq!(s, "arb_Status()");
+        assert_eq!(s.render(), "arb_Status()");
     }
 
     #[test]
@@ -1849,7 +2003,7 @@ handler noop { }
 "#;
         let spec = parse_str(src).expect("parse");
         let s = strategy_for_field("AccountIdx", &spec, StrategyMode::Full, None).unwrap();
-        assert_eq!(s, "0usize..=1024usize");
+        assert_eq!(s.render(), "0usize..=1024usize");
     }
 
     #[test]
@@ -1927,8 +2081,12 @@ handler noop { }
     fn strategy_for_field_boundary_small_bound_avoids_underflow() {
         let spec = ParsedSpec::default();
         let s = strategy_for_field("U64", &spec, StrategyMode::Boundary, Some("2")).unwrap();
-        assert_eq!(s, "0u64..=2u64");
-        assert!(!s.contains("- 3"), "must not emit `(b - 3)` for b < 3");
+        let rendered = s.render();
+        assert_eq!(rendered, "0u64..=2u64");
+        assert!(
+            !rendered.contains("- 3"),
+            "must not emit `(b - 3)` for b < 3"
+        );
     }
 
     // ========================================================================

--- a/crates/qedgen/src/codegen/rust_codegen_util/guards.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/guards.rs
@@ -22,10 +22,7 @@ pub fn collect_full_guard_with_account_env(
     let mut parts = Vec::new();
     for req in &op.requires {
         for tree in projected_requires_trees(req, account_binder) {
-            parts.push(format!(
-                "({})",
-                render_requires_tree(tree, wrapping, account_binder)
-            ));
+            parts.push(render_requires_conjunct(tree, wrapping, account_binder));
         }
     }
     if parts.is_empty() {
@@ -188,38 +185,39 @@ fn requires_tree(req: &crate::check::ParsedRequires) -> &crate::mir::ExprTree {
         .expect("ParsedRequires.tree is always populated by the chumsky adapter (#151/#156)")
 }
 
-/// One projected requires tree as a Rust predicate. Tree-native (#151
-/// Slice 1): one render call under the right arithmetic policy —
-/// `Widened` (math-exact; issue #146) or the `Wrapping` proptest-guard
-/// composite.
-fn render_requires_tree(
+/// Render one projected requires tree for an outer conjunction. The tree
+/// renderer owns both arithmetic policy and the minimum parentheses needed
+/// in that slot.
+fn render_requires_conjunct(
     tree: &crate::mir::ExprTree,
     wrapping: bool,
     account_binder: Option<&str>,
 ) -> String {
-    use super::tree_render::{render_rust, ArithMode, RustCx};
+    use super::tree_render::{render_rust_conjunct, ArithMode, RustCx};
     let arith = if wrapping {
         ArithMode::Wrapping
     } else {
         ArithMode::Widened
     };
-    let cx = RustCx::native()
-        .with_arith(arith)
-        .with_acct_env(account_binder);
-    render_rust(tree, cx)
+    render_rust_conjunct(
+        tree,
+        RustCx::native()
+            .with_arith(arith)
+            .with_acct_env(account_binder),
+    )
 }
 
 /// Per-conjunct guard terms of a handler's requires clauses, rendered as
 /// Rust predicates. Tree-native conjunct split: the top `And` node's
-/// operands, matching the legacy top-level `&&` string split (each
-/// operand keeps the parens the bool-op rendering gave it). Without an
-/// account env, terms are the account-free projection (#295).
+/// operands become independent terms, and the renderer adds grouping only
+/// where an outer conjunction needs it. Without an account env, terms are
+/// the account-free projection (#295).
 pub fn collect_guard_terms_with_account_env(
     op: &ParsedHandler,
     wrapping: bool,
     account_binder: Option<&str>,
 ) -> Vec<String> {
-    use super::tree_render::{render_rust, top_conjuncts, ArithMode, RustCx};
+    use super::tree_render::{render_rust_conjunct, top_conjuncts, ArithMode, RustCx};
 
     let mut terms = Vec::new();
     for req in &op.requires {
@@ -237,14 +235,8 @@ pub fn collect_guard_terms_with_account_env(
         let projected = projected_requires_trees(req, account_binder);
         for tree in &projected {
             let conjuncts = top_conjuncts(tree);
-            let multi = conjuncts.len() > 1 || projected.len() > 1;
             for c in conjuncts {
-                let rendered = render_rust(c, cx);
-                terms.push(if multi {
-                    format!("({})", rendered)
-                } else {
-                    rendered
-                });
+                terms.push(render_rust_conjunct(c, cx));
             }
         }
     }

--- a/crates/qedgen/src/codegen/rust_codegen_util/tests.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tests.rs
@@ -474,8 +474,8 @@ handler swap (amount : U64) (min_out : U64) : State.Active -> State.Active {
         exprs,
         vec![
             "accounts.admin.pubkey == s.admin_key",
-            "(amount >= min_out)",
-            "(min_out > 0)",
+            "amount >= min_out",
+            "min_out > 0",
         ]
     );
 }

--- a/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
@@ -206,8 +206,8 @@ impl<'a> RustCx<'a> {
 }
 
 /// Operator precedence for minimal-paren rendering. Higher binds tighter.
-/// `Atom` never needs wrapping; strings that self-parenthesize (bool ops,
-/// casts, `let`/`if` blocks, method-call chains) report `Atom`.
+/// `Atom` never needs wrapping; casts, `let`/`if` blocks, and method-call
+/// chains report it.
 ///
 /// The paren rules preserve the *tree's* evaluation order, not just parse
 /// validity: `Add(a, Sub(b, c))` must render `a + (b - c)` — `a + b - c`
@@ -215,15 +215,24 @@ impl<'a> RustCx<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Prec {
     Or,
+    And,
     Cmp,
     AddSub,
     MulDiv,
+    Unary,
     Atom,
 }
 
 /// Render `e` under `cx`. Entry point for every Rust-emitting consumer.
 pub fn render_rust(e: &ExprTree, cx: RustCx) -> String {
     render(e, cx, false).0
+}
+
+/// Render `e` for one operand of an outer `&&` composition. Callers that
+/// combine requires clauses use this instead of adding parentheses to an
+/// already-rendered string, keeping precedence ownership in this module.
+pub fn render_rust_conjunct(e: &ExprTree, cx: RustCx) -> String {
+    atom_for(Prec::And, render(e, cx, false))
 }
 
 /// Core renderer: returns the rendered string plus its top-level
@@ -285,22 +294,28 @@ fn render(e: &ExprTree, cx: RustCx, inside_old: bool) -> (String, Prec) {
                 Prec::Atom,
             )
         }
-        // Bool ops parenthesize both operands unconditionally — matches the
-        // legacy output byte-for-byte and sidesteps `&&`/`||` precedence.
         ExprTree::BoolOp { op, lhs, rhs } => {
-            let l = render(lhs, cx, inside_old).0;
-            let r = render(rhs, cx, inside_old).0;
-            let s = match op {
-                TreeBoolOp::And => format!("({}) && ({})", l, r),
-                TreeBoolOp::Or => format!("({}) || ({})", l, r),
+            let l = render(lhs, cx, inside_old);
+            let r = render(rhs, cx, inside_old);
+            match op {
+                TreeBoolOp::And => (
+                    format!("{} && {}", atom_for(Prec::And, l), atom_for(Prec::And, r)),
+                    Prec::And,
+                ),
+                TreeBoolOp::Or => (
+                    format!("{} || {}", atom_for(Prec::Or, l), atom_for(Prec::Or, r)),
+                    Prec::Or,
+                ),
                 // `a implies b` ≡ `!a || b`.
-                TreeBoolOp::Implies => format!("(!({})) || ({})", l, r),
-            };
-            (s, Prec::Atom)
+                TreeBoolOp::Implies => (
+                    format!("!{} || {}", atom_for(Prec::Unary, l), atom_for(Prec::Or, r)),
+                    Prec::Or,
+                ),
+            }
         }
         ExprTree::Not(inner) => (
-            format!("!({})", render(inner, cx, inside_old).0),
-            Prec::Atom,
+            format!("!{}", atom_for(Prec::Unary, render(inner, cx, inside_old))),
+            Prec::Unary,
         ),
         ExprTree::Cmp { op, lhs, rhs } => (render_cmp(*op, lhs, rhs, cx, inside_old), Prec::Cmp),
         ExprTree::Arith { op, lhs, rhs } => render_arith(*op, lhs, rhs, cx, inside_old),
@@ -1264,9 +1279,9 @@ pub fn tree_references_abstract_binder(e: &ExprTree) -> bool {
 }
 
 /// Immediate conjuncts of the top node: `And(l, r)` → `[l, r]`, anything
-/// else → `[e]`. Deliberately NON-recursive — the legacy string splitter
-/// only broke the *top-level* `&&` (nested conjunctions sit inside the
-/// bool-op's own parens), and per-term guard emission must match it.
+/// else → `[e]`. Deliberately non-recursive: a nested conjunction remains
+/// one term, with grouping supplied by the precedence-aware renderer when
+/// its outer composition requires it.
 pub fn top_conjuncts(e: &ExprTree) -> Vec<&ExprTree> {
     match e {
         ExprTree::BoolOp {
@@ -1672,6 +1687,50 @@ mod tests {
             rhs: Box::new(param("c", Ty::U64)),
         };
         assert_eq!(render_rust(&scaled, RustCx::native()), "(a + b) * c");
+    }
+
+    #[test]
+    fn boolean_precedence_uses_only_structural_parentheses() {
+        fn cmp(name: &str, value: u128) -> ExprTree {
+            ExprTree::Cmp {
+                op: TreeCmpOp::Eq,
+                lhs: Box::new(param(name, Ty::U64)),
+                rhs: Box::new(ExprTree::Int(value)),
+            }
+        }
+
+        let nested_or = ExprTree::BoolOp {
+            op: TreeBoolOp::And,
+            lhs: Box::new(cmp("a", 1)),
+            rhs: Box::new(ExprTree::BoolOp {
+                op: TreeBoolOp::Or,
+                lhs: Box::new(cmp("b", 2)),
+                rhs: Box::new(cmp("c", 3)),
+            }),
+        };
+        assert_eq!(
+            render_rust(&nested_or, RustCx::native()),
+            "a == 1 && (b == 2 || c == 3)"
+        );
+
+        let and_under_or = ExprTree::BoolOp {
+            op: TreeBoolOp::Or,
+            lhs: Box::new(cmp("a", 1)),
+            rhs: Box::new(ExprTree::BoolOp {
+                op: TreeBoolOp::And,
+                lhs: Box::new(cmp("b", 2)),
+                rhs: Box::new(cmp("c", 3)),
+            }),
+        };
+        assert_eq!(
+            render_rust(&and_under_or, RustCx::native()),
+            "a == 1 || b == 2 && c == 3"
+        );
+
+        assert_eq!(
+            render_rust(&ExprTree::Not(Box::new(cmp("a", 1))), RustCx::native()),
+            "!(a == 1)"
+        );
     }
 
     #[test]

--- a/crates/qedgen/tests/snapshots/bundled-stdlib-demo.proptest.rs
+++ b/crates/qedgen/tests/snapshots/bundled-stdlib-demo.proptest.rs
@@ -83,7 +83,7 @@ proptest! {
     #[test]
     fn initialize_rejects_invalid(s in arb_boundary_state(), initial in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((initial > 0)));
+        prop_assume!(!(initial > 0));
         prop_assert!(!initialize(&mut s, initial),
             "initialize must reject when guard is violated");
     }
@@ -94,7 +94,7 @@ proptest! {
     #[test]
     fn deposit_rejects_invalid(s in arb_boundary_state(), amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((amount > 0)));
+        prop_assume!(!(amount > 0));
         prop_assert!(!deposit(&mut s, amount),
             "deposit must reject when guard is violated");
     }

--- a/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow-split.codegen.txt
@@ -123,7 +123,7 @@ pub fn initialize<'info>(
         return Err(EscrowError::Unauthorized.into());
     }
     // requires: deposit_amount > 0 ∧ receive_amount > 0
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return Err(EscrowError::InvalidAmount.into());
     }
     // lifecycle: status := Open

--- a/crates/qedgen/tests/snapshots/escrow-split.kani.rs
+++ b/crates/qedgen/tests/snapshots/escrow-split.kani.rs
@@ -100,7 +100,7 @@ fn exchange(s: &mut State) -> bool {
 }
 
 fn initialize(s: &mut State, deposit_amount: u64, receive_amount: u64) -> bool {
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -131,7 +131,7 @@ fn verify_initialize_rejects_invalid() {
     kani::assume(s.status == Status::Uninitialized);
     let deposit_amount: u64 = kani::any();
     let receive_amount: u64 = kani::any();
-    kani::assume(!((deposit_amount > 0) && (receive_amount > 0)));
+    kani::assume(!(deposit_amount > 0 && receive_amount > 0));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !initialize(&mut s, deposit_amount, receive_amount),

--- a/crates/qedgen/tests/snapshots/escrow-split.proptest.rs
+++ b/crates/qedgen/tests/snapshots/escrow-split.proptest.rs
@@ -89,7 +89,7 @@ fn exchange(s: &mut State) -> bool {
 }
 
 fn initialize(s: &mut State, deposit_amount: u64, receive_amount: u64) -> bool {
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -106,7 +106,7 @@ proptest! {
     #[test]
     fn initialize_rejects_invalid(s in arb_boundary_state(), deposit_amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], receive_amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((deposit_amount > 0) && (receive_amount > 0)));
+        prop_assume!(!(deposit_amount > 0 && receive_amount > 0));
         prop_assert!(!initialize(&mut s, deposit_amount, receive_amount),
             "initialize must reject when guard is violated");
     }

--- a/crates/qedgen/tests/snapshots/escrow.codegen.txt
+++ b/crates/qedgen/tests/snapshots/escrow.codegen.txt
@@ -4018,7 +4018,7 @@ pub fn initialize<'info>(
         return Err(EscrowError::Unauthorized.into());
     }
     // requires: deposit_amount > 0 ∧ receive_amount > 0
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return Err(EscrowError::InvalidAmount.into());
     }
     // lifecycle: status := Open

--- a/crates/qedgen/tests/snapshots/escrow.kani.rs
+++ b/crates/qedgen/tests/snapshots/escrow.kani.rs
@@ -125,7 +125,7 @@ fn initialize(
     deposit_amount: u64,
     receive_amount: u64,
 ) -> bool {
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -209,7 +209,7 @@ fn verify_initialize_rejects_invalid() {
             pubkey: kani::any(),
         },
     };
-    kani::assume(!((deposit_amount > 0) && (receive_amount > 0)));
+    kani::assume(!(deposit_amount > 0 && receive_amount > 0));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !initialize(&mut s, &accounts, deposit_amount, receive_amount),

--- a/crates/qedgen/tests/snapshots/escrow.proptest.rs
+++ b/crates/qedgen/tests/snapshots/escrow.proptest.rs
@@ -78,7 +78,7 @@ prop_compose! {
 }
 
 fn initialize(s: &mut State, deposit_amount: u64, receive_amount: u64) -> bool {
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -111,7 +111,7 @@ proptest! {
     #[test]
     fn initialize_rejects_invalid(s in arb_boundary_state(), deposit_amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], receive_amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((deposit_amount > 0) && (receive_amount > 0)));
+        prop_assume!(!(deposit_amount > 0 && receive_amount > 0));
         prop_assert!(!initialize(&mut s, deposit_amount, receive_amount),
             "initialize must reject when guard is violated");
     }

--- a/crates/qedgen/tests/snapshots/kani-cpi-account-bindings.kani.rs
+++ b/crates/qedgen/tests/snapshots/kani-cpi-account-bindings.kani.rs
@@ -128,7 +128,7 @@ fn initialize(s: &mut State, accounts: &InitializeAccounts) -> bool {
 }
 
 fn unbound_transfer(s: &mut State, accounts: &UnboundTransferAccounts, amount: u64) -> bool {
-    if !((pubkey_eq(&accounts.admin.pubkey, &s.admin_key)) && (amount > 0)) {
+    if !(pubkey_eq(&accounts.admin.pubkey, &s.admin_key) && amount > 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -139,7 +139,7 @@ fn unbound_transfer(s: &mut State, accounts: &UnboundTransferAccounts, amount: u
 }
 
 fn bound_transfer(s: &mut State, accounts: &BoundTransferAccounts, amount: u64) -> bool {
-    if !((pubkey_eq(&accounts.admin.pubkey, &s.admin_key)) && (amount > 0)) {
+    if !(pubkey_eq(&accounts.admin.pubkey, &s.admin_key) && amount > 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -185,7 +185,7 @@ fn stable_swap_large_guard(
     if !(pubkey_ne(&input_mint, &output_mint)) {
         return false;
     }
-    if !((pubkey_eq(&input_mint, &output_mint)) || (amount_in >= min_out)) {
+    if !(pubkey_eq(&input_mint, &output_mint) || amount_in >= min_out) {
         return false;
     }
     if mul_bps_floor_u128(amount_in, fee_bps) > amount_in {
@@ -234,7 +234,7 @@ fn verify_unbound_transfer_rejects_invalid() {
             pubkey: kani::any(),
         },
     };
-    kani::assume(!((pubkey_eq(&accounts.admin.pubkey, &s.admin_key)) && (amount > 0)));
+    kani::assume(!(pubkey_eq(&accounts.admin.pubkey, &s.admin_key) && amount > 0));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !unbound_transfer(&mut s, &accounts, amount),
@@ -268,7 +268,7 @@ fn verify_bound_transfer_rejects_invalid() {
             pubkey: kani::any(),
         },
     };
-    kani::assume(!((pubkey_eq(&accounts.admin.pubkey, &s.admin_key)) && (amount > 0)));
+    kani::assume(!(pubkey_eq(&accounts.admin.pubkey, &s.admin_key) && amount > 0));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !bound_transfer(&mut s, &accounts, amount),
@@ -617,7 +617,7 @@ fn verify_stable_swap_large_guard_rejects_invalid_7_pubkey_eq_input_mint_output_
     kani::assume(fee_bps <= 10000);
     kani::assume(lane < 32);
     kani::assume(pubkey_ne(&input_mint, &output_mint));
-    kani::assume(!((pubkey_eq(&input_mint, &output_mint)) || (amount_in >= min_out)));
+    kani::assume(!(pubkey_eq(&input_mint, &output_mint) || amount_in >= min_out));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !stable_swap_large_guard(
@@ -672,7 +672,7 @@ fn verify_stable_swap_large_guard_rejects_invalid_8_mul_bps_floor_u128_amount_in
     kani::assume(fee_bps <= 10000);
     kani::assume(lane < 32);
     kani::assume(pubkey_ne(&input_mint, &output_mint));
-    kani::assume((pubkey_eq(&input_mint, &output_mint)) || (amount_in >= min_out));
+    kani::assume((pubkey_eq(&input_mint, &output_mint) || amount_in >= min_out));
     let __qed_bps_floor_1 = mul_bps_floor_u128(amount_in, fee_bps);
     kani::assume(__qed_bps_floor_1 > amount_in);
     kani::cover!(true, "guard-violation domain is satisfiable");
@@ -728,7 +728,7 @@ fn verify_stable_swap_large_guard_rejects_invalid_9_amount_in_min_out() {
     kani::assume(fee_bps <= 10000);
     kani::assume(lane < 32);
     kani::assume(pubkey_ne(&input_mint, &output_mint));
-    kani::assume((pubkey_eq(&input_mint, &output_mint)) || (amount_in >= min_out));
+    kani::assume((pubkey_eq(&input_mint, &output_mint) || amount_in >= min_out));
     let __qed_bps_floor_1 = mul_bps_floor_u128(amount_in, fee_bps);
     kani::assume(__qed_bps_floor_1 <= amount_in);
     kani::assume(amount_in < min_out);
@@ -785,7 +785,7 @@ fn verify_stable_swap_large_guard_rejects_invalid_10_amount_in_1000000000000000(
     kani::assume(fee_bps <= 10000);
     kani::assume(lane < 32);
     kani::assume(pubkey_ne(&input_mint, &output_mint));
-    kani::assume((pubkey_eq(&input_mint, &output_mint)) || (amount_in >= min_out));
+    kani::assume((pubkey_eq(&input_mint, &output_mint) || amount_in >= min_out));
     let __qed_bps_floor_1 = mul_bps_floor_u128(amount_in, fee_bps);
     kani::assume(__qed_bps_floor_1 <= amount_in);
     kani::assume(amount_in >= min_out);
@@ -840,7 +840,7 @@ fn verify_unbound_transfer_ensures_0() {
             pubkey: kani::any(),
         },
     };
-    kani::assume((pubkey_eq(&accounts.admin.pubkey, &s.admin_key)) && (amount > 0));
+    kani::assume(pubkey_eq(&accounts.admin.pubkey, &s.admin_key) && amount > 0);
     let pre = s.clone();
     if unbound_transfer(&mut s, &accounts, amount) {
         let post = &s;
@@ -880,7 +880,7 @@ fn verify_bound_transfer_ensures_0() {
             pubkey: kani::any(),
         },
     };
-    kani::assume((pubkey_eq(&accounts.admin.pubkey, &s.admin_key)) && (amount > 0));
+    kani::assume(pubkey_eq(&accounts.admin.pubkey, &s.admin_key) && amount > 0);
     let pre = s.clone();
     if bound_transfer(&mut s, &accounts, amount) {
         let post = &s;
@@ -926,16 +926,16 @@ fn verify_stable_swap_large_guard_ensures_0() {
         },
     };
     kani::assume(
-        (pubkey_eq(&accounts.admin.pubkey, &s.admin_key))
-            && (amount_in > 0)
-            && (min_out > 0)
-            && (fee_bps <= 10000)
-            && (lane < 32)
-            && (pubkey_ne(&input_mint, &output_mint))
-            && ((pubkey_eq(&input_mint, &output_mint)) || (amount_in >= min_out))
-            && (mul_bps_floor_u128(amount_in, fee_bps) <= amount_in)
-            && (amount_in >= min_out)
-            && (amount_in <= 1000000000000000),
+        pubkey_eq(&accounts.admin.pubkey, &s.admin_key)
+            && amount_in > 0
+            && min_out > 0
+            && fee_bps <= 10000
+            && lane < 32
+            && pubkey_ne(&input_mint, &output_mint)
+            && (pubkey_eq(&input_mint, &output_mint) || amount_in >= min_out)
+            && mul_bps_floor_u128(amount_in, fee_bps) <= amount_in
+            && amount_in >= min_out
+            && amount_in <= 1000000000000000,
     );
     let pre = s.clone();
     if stable_swap_large_guard(

--- a/crates/qedgen/tests/snapshots/lending.codegen.txt
+++ b/crates/qedgen/tests/snapshots/lending.codegen.txt
@@ -704,7 +704,7 @@ pub fn borrow<'info>(ctx: &mut Borrow<'info>, amount: u64, collateral: u64) -> R
         return Err(LendingError::Unauthorized.into());
     }
     // requires: amount > 0 ∧ collateral > 0
-    if !((amount > 0) && (collateral > 0)) {
+    if !(amount > 0 && collateral > 0) {
         return Err(LendingError::InvalidAmount.into());
     }
     // lifecycle: status := Active

--- a/crates/qedgen/tests/snapshots/lending.kani.rs
+++ b/crates/qedgen/tests/snapshots/lending.kani.rs
@@ -381,7 +381,7 @@ mod loan {
     // ============================================================================
 
     fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
-        if !((amount > 0) && (collateral > 0)) {
+        if !(amount > 0 && collateral > 0) {
             return false;
         }
         if s.status != Status::Empty {
@@ -433,7 +433,7 @@ mod loan {
         kani::assume(s.status == Status::Empty);
         let amount: u64 = kani::any();
         let collateral: u64 = kani::any();
-        kani::assume(!((amount > 0) && (collateral > 0)));
+        kani::assume(!(amount > 0 && collateral > 0));
         kani::cover!(true, "guard-violation domain is satisfiable");
         assert!(
             !borrow(&mut s, amount, collateral),

--- a/crates/qedgen/tests/snapshots/lending.proptest.rs
+++ b/crates/qedgen/tests/snapshots/lending.proptest.rs
@@ -142,7 +142,7 @@ mod pool {
         #[test]
         fn init_pool_rejects_invalid(s in arb_boundary_state(), rate in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
             let mut s = s;
-            prop_assume!(!((rate > 0)));
+            prop_assume!(!(rate > 0));
             prop_assert!(!init_pool(&mut s, rate),
                 "init_pool must reject when guard is violated");
         }
@@ -153,7 +153,7 @@ mod pool {
         #[test]
         fn deposit_rejects_invalid(s in arb_boundary_state(), amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
             let mut s = s;
-            prop_assume!(!((amount > 0)));
+            prop_assume!(!(amount > 0));
             prop_assert!(!deposit(&mut s, amount),
                 "deposit must reject when guard is violated");
         }
@@ -306,7 +306,7 @@ mod loan {
     }
 
     fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
-        if !((amount > 0) && (collateral > 0)) {
+        if !(amount > 0 && collateral > 0) {
             return false;
         }
         if s.status != Status::Empty {
@@ -345,7 +345,7 @@ mod loan {
         #[test]
         fn borrow_rejects_invalid(s in arb_boundary_state(), amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], collateral in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
             let mut s = s;
-            prop_assume!(!((amount > 0) && (collateral > 0)));
+            prop_assume!(!(amount > 0 && collateral > 0));
             prop_assert!(!borrow(&mut s, amount, collateral),
                 "borrow must reject when guard is violated");
         }
@@ -356,7 +356,7 @@ mod loan {
         #[test]
         fn liquidate_rejects_invalid(s in arb_boundary_state()) {
             let mut s = s;
-            prop_assume!(!((s.amount > s.collateral)));
+            prop_assume!(!(s.amount > s.collateral));
             prop_assert!(!liquidate(&mut s),
                 "liquidate must reject when guard is violated");
         }

--- a/crates/qedgen/tests/snapshots/let-bindings-fee-split.kani.rs
+++ b/crates/qedgen/tests/snapshots/let-bindings-fee-split.kani.rs
@@ -39,7 +39,7 @@ struct State {
 // ============================================================================
 
 fn collect(s: &mut State, total: u64) -> bool {
-    if !((total > 0) && (net > 0)) {
+    if !(total > 0 && net > 0) {
         return false;
     }
     let fee =
@@ -71,7 +71,7 @@ fn verify_collect_rejects_invalid() {
         fee_bps: kani::any(),
     };
     let total: u64 = kani::any();
-    kani::assume(!((total > 0) && (net > 0)));
+    kani::assume(!(total > 0 && net > 0));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !collect(&mut s, total),
@@ -97,7 +97,7 @@ fn verify_collect_ensures_0() {
         fee_bps: kani::any(),
     };
     let total: u64 = kani::any();
-    kani::assume((total > 0) && (net > 0));
+    kani::assume(total > 0 && net > 0);
     let pre = s.clone();
     if collect(&mut s, total) {
         let post = &s;

--- a/crates/qedgen/tests/snapshots/let-bindings-fee-split.proptest.rs
+++ b/crates/qedgen/tests/snapshots/let-bindings-fee-split.proptest.rs
@@ -98,7 +98,7 @@ prop_compose! {
 }
 
 fn collect(s: &mut State, total: u64) -> bool {
-    if !((total > 0) && (net > 0)) {
+    if !(total > 0 && net > 0) {
         return false;
     }
     let fee =
@@ -121,7 +121,7 @@ proptest! {
     #[test]
     fn collect_rejects_invalid(s in arb_boundary_state(), total in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((total > 0) && (net > 0)));
+        prop_assume!(!(total > 0 && net > 0));
         prop_assert!(!collect(&mut s, total),
             "collect must reject when guard is violated");
     }

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -666,7 +666,7 @@ pub fn create_vault<'info>(
     member_count: u8,
 ) -> Result<()> {
     // requires: threshold > 0 ∧ threshold ≤ member_count
-    if !((threshold > 0) && (threshold <= member_count)) {
+    if !(threshold > 0 && threshold <= member_count) {
         return Err(MultisigError::InvalidThreshold.into());
     }
     // requires: member_count ≤ 32
@@ -804,7 +804,7 @@ pub fn remove_member<'info>(ctx: &mut RemoveMember<'info>) -> Result<()> {
         return Err(anchor_lang::error::Error::from(ProgramError::Custom(0xFF)));
     }
     // requires: s.approval_count = 0 ∧ s.rejection_count = 0
-    if !((ctx.vault.approval_count == 0) && (ctx.vault.rejection_count == 0)) {
+    if !(ctx.vault.approval_count == 0 && ctx.vault.rejection_count == 0) {
         return Err(anchor_lang::error::Error::from(ProgramError::Custom(0xFF)));
     }
     Ok(())
@@ -1659,7 +1659,7 @@ mod tests {
         apply_create_vault(&mut state, threshold, member_count);
         // Property: threshold bounded must hold after create_vault
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after create_vault"
         );
     }
@@ -1678,7 +1678,7 @@ mod tests {
         apply_propose(&mut state);
         // Property: threshold bounded must hold after propose
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after propose"
         );
     }
@@ -1698,7 +1698,7 @@ mod tests {
         apply_approve(&mut state, member_index);
         // Property: threshold bounded must hold after approve
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after approve"
         );
     }
@@ -1718,7 +1718,7 @@ mod tests {
         apply_reject(&mut state, member_index);
         // Property: threshold bounded must hold after reject
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after reject"
         );
     }
@@ -1738,7 +1738,7 @@ mod tests {
         apply_execute(&mut state, member_index);
         // Property: threshold bounded must hold after execute
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after execute"
         );
     }
@@ -1757,7 +1757,7 @@ mod tests {
         apply_cancel_proposal(&mut state);
         // Property: threshold bounded must hold after cancel_proposal
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after cancel_proposal"
         );
     }
@@ -1778,7 +1778,7 @@ mod tests {
         apply_add_member(&mut state, member_index, member_pubkey);
         // Property: threshold bounded must hold after add_member
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after add_member"
         );
     }
@@ -1797,7 +1797,7 @@ mod tests {
         apply_remove_member(&mut state);
         // Property: threshold bounded must hold after remove_member
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after remove_member"
         );
     }
@@ -2381,7 +2381,7 @@ struct State {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -2397,7 +2397,7 @@ fn votes_bounded(s: &State) -> bool {
 // ============================================================================
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -2424,8 +2424,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -2444,8 +2444,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -2463,8 +2463,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -2508,7 +2508,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -2543,7 +2543,7 @@ fn verify_create_vault_rejects_invalid() {
     kani::assume(s.status == Status::Uninitialized);
     let threshold: u8 = kani::any();
     let member_count: u8 = kani::any();
-    kani::assume(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+    kani::assume(!(threshold > 0 && threshold <= member_count && member_count <= 32));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !create_vault(&mut s, threshold, member_count),
@@ -2570,8 +2570,8 @@ fn verify_approve_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -2599,8 +2599,8 @@ fn verify_reject_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -2627,8 +2627,8 @@ fn verify_execute_rejects_invalid() {
     let member_index: u8 = kani::any();
     kani::assume(
         !(((member_index) as usize) < s.members.len()
-            && (member_index < s.member_count)
-            && (s.approval_count >= s.threshold)),
+            && member_index < s.member_count
+            && s.approval_count >= s.threshold),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -2704,7 +2704,7 @@ fn verify_remove_member_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     kani::assume(
-        !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)),
+        !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -3962,7 +3962,7 @@ prop_compose! {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -3971,7 +3971,7 @@ fn votes_bounded(s: &State) -> bool {
 }
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -3998,8 +3998,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -4018,8 +4018,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -4037,8 +4037,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -4082,7 +4082,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -4311,7 +4311,7 @@ proptest! {
     #[test]
     fn create_vault_rejects_invalid(s in arb_boundary_state(), threshold in prop_oneof![0u8..=3u8, 252u8..=255u8], member_count in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+        prop_assume!(!(threshold > 0 && threshold <= member_count && member_count <= 32));
         prop_assert!(!create_vault(&mut s, threshold, member_count),
             "create_vault must reject when guard is violated");
     }
@@ -4322,7 +4322,7 @@ proptest! {
     #[test]
     fn approve_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!approve(&mut s, member_index),
             "approve must reject when guard is violated");
     }
@@ -4333,7 +4333,7 @@ proptest! {
     #[test]
     fn reject_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!reject(&mut s, member_index),
             "reject must reject when guard is violated");
     }
@@ -4344,7 +4344,7 @@ proptest! {
     #[test]
     fn execute_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && (member_index < s.member_count) && (s.approval_count >= s.threshold)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && member_index < s.member_count && s.approval_count >= s.threshold));
         prop_assert!(!execute(&mut s, member_index),
             "execute must reject when guard is violated");
     }
@@ -4355,7 +4355,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!(((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128))));
+        prop_assume!(!((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }
@@ -4366,7 +4366,7 @@ proptest! {
     #[test]
     fn add_member_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8], member_pubkey in prop::array::uniform32(0u8..1u8)) {
         let mut s = s;
-        prop_assume!(!((member_index < s.member_count)));
+        prop_assume!(!(member_index < s.member_count));
         prop_assert!(!add_member(&mut s, member_index, member_pubkey),
             "add_member must reject when guard is violated");
     }
@@ -4377,7 +4377,7 @@ proptest! {
     #[test]
     fn remove_member_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)));
+        prop_assume!(!(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0));
         prop_assert!(!remove_member(&mut s),
             "remove_member must reject when guard is violated");
     }

--- a/crates/qedgen/tests/snapshots/multisig.kani.rs
+++ b/crates/qedgen/tests/snapshots/multisig.kani.rs
@@ -86,7 +86,7 @@ struct State {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -102,7 +102,7 @@ fn votes_bounded(s: &State) -> bool {
 // ============================================================================
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -129,8 +129,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -149,8 +149,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -168,8 +168,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -213,7 +213,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -248,7 +248,7 @@ fn verify_create_vault_rejects_invalid() {
     kani::assume(s.status == Status::Uninitialized);
     let threshold: u8 = kani::any();
     let member_count: u8 = kani::any();
-    kani::assume(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+    kani::assume(!(threshold > 0 && threshold <= member_count && member_count <= 32));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !create_vault(&mut s, threshold, member_count),
@@ -275,8 +275,8 @@ fn verify_approve_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -304,8 +304,8 @@ fn verify_reject_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -332,8 +332,8 @@ fn verify_execute_rejects_invalid() {
     let member_index: u8 = kani::any();
     kani::assume(
         !(((member_index) as usize) < s.members.len()
-            && (member_index < s.member_count)
-            && (s.approval_count >= s.threshold)),
+            && member_index < s.member_count
+            && s.approval_count >= s.threshold),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -409,7 +409,7 @@ fn verify_remove_member_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     kani::assume(
-        !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)),
+        !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(

--- a/crates/qedgen/tests/snapshots/multisig.proptest.rs
+++ b/crates/qedgen/tests/snapshots/multisig.proptest.rs
@@ -86,7 +86,7 @@ prop_compose! {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -95,7 +95,7 @@ fn votes_bounded(s: &State) -> bool {
 }
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -122,8 +122,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -142,8 +142,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -161,8 +161,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -206,7 +206,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -435,7 +435,7 @@ proptest! {
     #[test]
     fn create_vault_rejects_invalid(s in arb_boundary_state(), threshold in prop_oneof![0u8..=3u8, 252u8..=255u8], member_count in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+        prop_assume!(!(threshold > 0 && threshold <= member_count && member_count <= 32));
         prop_assert!(!create_vault(&mut s, threshold, member_count),
             "create_vault must reject when guard is violated");
     }
@@ -446,7 +446,7 @@ proptest! {
     #[test]
     fn approve_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!approve(&mut s, member_index),
             "approve must reject when guard is violated");
     }
@@ -457,7 +457,7 @@ proptest! {
     #[test]
     fn reject_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!reject(&mut s, member_index),
             "reject must reject when guard is violated");
     }
@@ -468,7 +468,7 @@ proptest! {
     #[test]
     fn execute_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && (member_index < s.member_count) && (s.approval_count >= s.threshold)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && member_index < s.member_count && s.approval_count >= s.threshold));
         prop_assert!(!execute(&mut s, member_index),
             "execute must reject when guard is violated");
     }
@@ -479,7 +479,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!(((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128))));
+        prop_assume!(!((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }
@@ -490,7 +490,7 @@ proptest! {
     #[test]
     fn add_member_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8], member_pubkey in prop::array::uniform32(0u8..1u8)) {
         let mut s = s;
-        prop_assume!(!((member_index < s.member_count)));
+        prop_assume!(!(member_index < s.member_count));
         prop_assert!(!add_member(&mut s, member_index, member_pubkey),
             "add_member must reject when guard is violated");
     }
@@ -501,7 +501,7 @@ proptest! {
     #[test]
     fn remove_member_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)));
+        prop_assume!(!(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0));
         prop_assert!(!remove_member(&mut s),
             "remove_member must reject when guard is violated");
     }

--- a/examples/rust/escrow/programs/src/guards.rs
+++ b/examples/rust/escrow/programs/src/guards.rs
@@ -27,7 +27,7 @@ pub fn initialize<'info>(
         return Err(ProgramError::from(EscrowError::Unauthorized));
     }
     // requires: deposit_amount > 0 ∧ receive_amount > 0
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return Err(ProgramError::from(EscrowError::InvalidAmount));
     }
     // lifecycle: status := Open

--- a/examples/rust/escrow/src/guards.rs
+++ b/examples/rust/escrow/src/guards.rs
@@ -27,7 +27,7 @@ pub fn initialize<'info>(
         return Err(ProgramError::from(EscrowError::Unauthorized));
     }
     // requires: deposit_amount > 0 ∧ receive_amount > 0
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return Err(ProgramError::from(EscrowError::InvalidAmount));
     }
     // lifecycle: status := Open

--- a/examples/rust/escrow/tests/kani.rs
+++ b/examples/rust/escrow/tests/kani.rs
@@ -125,7 +125,7 @@ fn initialize(
     deposit_amount: u64,
     receive_amount: u64,
 ) -> bool {
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -209,7 +209,7 @@ fn verify_initialize_rejects_invalid() {
             pubkey: kani::any(),
         },
     };
-    kani::assume(!((deposit_amount > 0) && (receive_amount > 0)));
+    kani::assume(!(deposit_amount > 0 && receive_amount > 0));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !initialize(&mut s, &accounts, deposit_amount, receive_amount),

--- a/examples/rust/escrow/tests/proptest.rs
+++ b/examples/rust/escrow/tests/proptest.rs
@@ -78,7 +78,7 @@ prop_compose! {
 }
 
 fn initialize(s: &mut State, deposit_amount: u64, receive_amount: u64) -> bool {
-    if !((deposit_amount > 0) && (receive_amount > 0)) {
+    if !(deposit_amount > 0 && receive_amount > 0) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -111,7 +111,7 @@ proptest! {
     #[test]
     fn initialize_rejects_invalid(s in arb_boundary_state(), deposit_amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], receive_amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
         let mut s = s;
-        prop_assume!(!((deposit_amount > 0) && (receive_amount > 0)));
+        prop_assume!(!(deposit_amount > 0 && receive_amount > 0));
         prop_assert!(!initialize(&mut s, deposit_amount, receive_amount),
             "initialize must reject when guard is violated");
     }

--- a/examples/rust/lending/programs/src/guards.rs
+++ b/examples/rust/lending/programs/src/guards.rs
@@ -85,7 +85,7 @@ pub fn borrow<'info>(
         return Err(ProgramError::from(LendingError::Unauthorized));
     }
     // requires: amount > 0 ∧ collateral > 0
-    if !((amount > 0) && (collateral > 0)) {
+    if !(amount > 0 && collateral > 0) {
         return Err(ProgramError::from(LendingError::InvalidAmount));
     }
     // lifecycle: status := Active

--- a/examples/rust/lending/src/guards.rs
+++ b/examples/rust/lending/src/guards.rs
@@ -85,7 +85,7 @@ pub fn borrow<'info>(
         return Err(ProgramError::from(LendingError::Unauthorized));
     }
     // requires: amount > 0 ∧ collateral > 0
-    if !((amount > 0) && (collateral > 0)) {
+    if !(amount > 0 && collateral > 0) {
         return Err(ProgramError::from(LendingError::InvalidAmount));
     }
     // lifecycle: status := Active

--- a/examples/rust/lending/tests/kani.rs
+++ b/examples/rust/lending/tests/kani.rs
@@ -381,7 +381,7 @@ mod loan {
     // ============================================================================
 
     fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
-        if !((amount > 0) && (collateral > 0)) {
+        if !(amount > 0 && collateral > 0) {
             return false;
         }
         if s.status != Status::Empty {
@@ -433,7 +433,7 @@ mod loan {
         kani::assume(s.status == Status::Empty);
         let amount: u64 = kani::any();
         let collateral: u64 = kani::any();
-        kani::assume(!((amount > 0) && (collateral > 0)));
+        kani::assume(!(amount > 0 && collateral > 0));
         kani::cover!(true, "guard-violation domain is satisfiable");
         assert!(
             !borrow(&mut s, amount, collateral),

--- a/examples/rust/lending/tests/proptest.rs
+++ b/examples/rust/lending/tests/proptest.rs
@@ -142,7 +142,7 @@ mod pool {
         #[test]
         fn init_pool_rejects_invalid(s in arb_boundary_state(), rate in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
             let mut s = s;
-            prop_assume!(!((rate > 0)));
+            prop_assume!(!(rate > 0));
             prop_assert!(!init_pool(&mut s, rate),
                 "init_pool must reject when guard is violated");
         }
@@ -153,7 +153,7 @@ mod pool {
         #[test]
         fn deposit_rejects_invalid(s in arb_boundary_state(), amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
             let mut s = s;
-            prop_assume!(!((amount > 0)));
+            prop_assume!(!(amount > 0));
             prop_assert!(!deposit(&mut s, amount),
                 "deposit must reject when guard is violated");
         }
@@ -306,7 +306,7 @@ mod loan {
     }
 
     fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
-        if !((amount > 0) && (collateral > 0)) {
+        if !(amount > 0 && collateral > 0) {
             return false;
         }
         if s.status != Status::Empty {
@@ -345,7 +345,7 @@ mod loan {
         #[test]
         fn borrow_rejects_invalid(s in arb_boundary_state(), amount in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX], collateral in prop_oneof![0u64..=3u64, (u64::MAX - 3)..=u64::MAX]) {
             let mut s = s;
-            prop_assume!(!((amount > 0) && (collateral > 0)));
+            prop_assume!(!(amount > 0 && collateral > 0));
             prop_assert!(!borrow(&mut s, amount, collateral),
                 "borrow must reject when guard is violated");
         }
@@ -356,7 +356,7 @@ mod loan {
         #[test]
         fn liquidate_rejects_invalid(s in arb_boundary_state()) {
             let mut s = s;
-            prop_assume!(!((s.amount > s.collateral)));
+            prop_assume!(!(s.amount > s.collateral));
             prop_assert!(!liquidate(&mut s),
                 "liquidate must reject when guard is violated");
         }

--- a/examples/rust/multisig/programs/src/guards.rs
+++ b/examples/rust/multisig/programs/src/guards.rs
@@ -23,7 +23,7 @@ pub fn create_vault<'info>(
     member_count: u8,
 ) -> Result<(), ProgramError> {
     // requires: threshold > 0 ∧ threshold ≤ member_count
-    if !((threshold > 0) && (threshold <= member_count)) {
+    if !(threshold > 0 && threshold <= member_count) {
         return Err(ProgramError::from(MultisigError::InvalidThreshold));
     }
     // requires: member_count ≤ 32
@@ -230,7 +230,7 @@ pub fn remove_member<'info>(ctx: &mut RemoveMember<'info>) -> Result<(), Program
         return Err(ProgramError::Custom(0xFF));
     }
     // requires: s.approval_count = 0 ∧ s.rejection_count = 0
-    if !((ctx.vault.approval_count == 0) && (ctx.vault.rejection_count == 0)) {
+    if !(ctx.vault.approval_count == 0 && ctx.vault.rejection_count == 0) {
         return Err(ProgramError::Custom(0xFF));
     }
     Ok(())

--- a/examples/rust/multisig/programs/src/tests.rs
+++ b/examples/rust/multisig/programs/src/tests.rs
@@ -455,7 +455,7 @@ mod tests {
         apply_create_vault(&mut state, threshold, member_count);
         // Property: threshold bounded must hold after create_vault
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after create_vault"
         );
     }
@@ -474,7 +474,7 @@ mod tests {
         apply_propose(&mut state);
         // Property: threshold bounded must hold after propose
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after propose"
         );
     }
@@ -494,7 +494,7 @@ mod tests {
         apply_approve(&mut state, member_index);
         // Property: threshold bounded must hold after approve
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after approve"
         );
     }
@@ -514,7 +514,7 @@ mod tests {
         apply_reject(&mut state, member_index);
         // Property: threshold bounded must hold after reject
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after reject"
         );
     }
@@ -534,7 +534,7 @@ mod tests {
         apply_execute(&mut state, member_index);
         // Property: threshold bounded must hold after execute
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after execute"
         );
     }
@@ -553,7 +553,7 @@ mod tests {
         apply_cancel_proposal(&mut state);
         // Property: threshold bounded must hold after cancel_proposal
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after cancel_proposal"
         );
     }
@@ -574,7 +574,7 @@ mod tests {
         apply_add_member(&mut state, member_index, member_pubkey);
         // Property: threshold bounded must hold after add_member
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after add_member"
         );
     }
@@ -593,7 +593,7 @@ mod tests {
         apply_remove_member(&mut state);
         // Property: threshold bounded must hold after remove_member
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after remove_member"
         );
     }

--- a/examples/rust/multisig/programs/tests/kani.rs
+++ b/examples/rust/multisig/programs/tests/kani.rs
@@ -86,7 +86,7 @@ struct State {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -102,7 +102,7 @@ fn votes_bounded(s: &State) -> bool {
 // ============================================================================
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -129,8 +129,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -149,8 +149,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -168,8 +168,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -213,7 +213,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -248,7 +248,7 @@ fn verify_create_vault_rejects_invalid() {
     kani::assume(s.status == Status::Uninitialized);
     let threshold: u8 = kani::any();
     let member_count: u8 = kani::any();
-    kani::assume(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+    kani::assume(!(threshold > 0 && threshold <= member_count && member_count <= 32));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !create_vault(&mut s, threshold, member_count),
@@ -275,8 +275,8 @@ fn verify_approve_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -304,8 +304,8 @@ fn verify_reject_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -332,8 +332,8 @@ fn verify_execute_rejects_invalid() {
     let member_index: u8 = kani::any();
     kani::assume(
         !(((member_index) as usize) < s.members.len()
-            && (member_index < s.member_count)
-            && (s.approval_count >= s.threshold)),
+            && member_index < s.member_count
+            && s.approval_count >= s.threshold),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -409,7 +409,7 @@ fn verify_remove_member_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     kani::assume(
-        !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)),
+        !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(

--- a/examples/rust/multisig/programs/tests/proptest.rs
+++ b/examples/rust/multisig/programs/tests/proptest.rs
@@ -86,7 +86,7 @@ prop_compose! {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -95,7 +95,7 @@ fn votes_bounded(s: &State) -> bool {
 }
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -122,8 +122,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -142,8 +142,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -161,8 +161,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -206,7 +206,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -435,7 +435,7 @@ proptest! {
     #[test]
     fn create_vault_rejects_invalid(s in arb_boundary_state(), threshold in prop_oneof![0u8..=3u8, 252u8..=255u8], member_count in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+        prop_assume!(!(threshold > 0 && threshold <= member_count && member_count <= 32));
         prop_assert!(!create_vault(&mut s, threshold, member_count),
             "create_vault must reject when guard is violated");
     }
@@ -446,7 +446,7 @@ proptest! {
     #[test]
     fn approve_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!approve(&mut s, member_index),
             "approve must reject when guard is violated");
     }
@@ -457,7 +457,7 @@ proptest! {
     #[test]
     fn reject_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!reject(&mut s, member_index),
             "reject must reject when guard is violated");
     }
@@ -468,7 +468,7 @@ proptest! {
     #[test]
     fn execute_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && (member_index < s.member_count) && (s.approval_count >= s.threshold)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && member_index < s.member_count && s.approval_count >= s.threshold));
         prop_assert!(!execute(&mut s, member_index),
             "execute must reject when guard is violated");
     }
@@ -479,7 +479,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!(((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128))));
+        prop_assume!(!((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }
@@ -490,7 +490,7 @@ proptest! {
     #[test]
     fn add_member_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8], member_pubkey in prop::array::uniform32(0u8..1u8)) {
         let mut s = s;
-        prop_assume!(!((member_index < s.member_count)));
+        prop_assume!(!(member_index < s.member_count));
         prop_assert!(!add_member(&mut s, member_index, member_pubkey),
             "add_member must reject when guard is violated");
     }
@@ -501,7 +501,7 @@ proptest! {
     #[test]
     fn remove_member_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)));
+        prop_assume!(!(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0));
         prop_assert!(!remove_member(&mut s),
             "remove_member must reject when guard is violated");
     }

--- a/examples/rust/multisig/src/guards.rs
+++ b/examples/rust/multisig/src/guards.rs
@@ -23,7 +23,7 @@ pub fn create_vault<'info>(
     member_count: u8,
 ) -> Result<(), ProgramError> {
     // requires: threshold > 0 ∧ threshold ≤ member_count
-    if !((threshold > 0) && (threshold <= member_count)) {
+    if !(threshold > 0 && threshold <= member_count) {
         return Err(ProgramError::from(MultisigError::InvalidThreshold));
     }
     // requires: member_count ≤ 32
@@ -230,7 +230,7 @@ pub fn remove_member<'info>(ctx: &mut RemoveMember<'info>) -> Result<(), Program
         return Err(ProgramError::Custom(0xFF));
     }
     // requires: s.approval_count = 0 ∧ s.rejection_count = 0
-    if !((ctx.vault.approval_count == 0) && (ctx.vault.rejection_count == 0)) {
+    if !(ctx.vault.approval_count == 0 && ctx.vault.rejection_count == 0) {
         return Err(ProgramError::Custom(0xFF));
     }
     Ok(())

--- a/examples/rust/multisig/src/tests.rs
+++ b/examples/rust/multisig/src/tests.rs
@@ -455,7 +455,7 @@ mod tests {
         apply_create_vault(&mut state, threshold, member_count);
         // Property: threshold bounded must hold after create_vault
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after create_vault"
         );
     }
@@ -474,7 +474,7 @@ mod tests {
         apply_propose(&mut state);
         // Property: threshold bounded must hold after propose
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after propose"
         );
     }
@@ -494,7 +494,7 @@ mod tests {
         apply_approve(&mut state, member_index);
         // Property: threshold bounded must hold after approve
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after approve"
         );
     }
@@ -514,7 +514,7 @@ mod tests {
         apply_reject(&mut state, member_index);
         // Property: threshold bounded must hold after reject
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after reject"
         );
     }
@@ -534,7 +534,7 @@ mod tests {
         apply_execute(&mut state, member_index);
         // Property: threshold bounded must hold after execute
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after execute"
         );
     }
@@ -553,7 +553,7 @@ mod tests {
         apply_cancel_proposal(&mut state);
         // Property: threshold bounded must hold after cancel_proposal
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after cancel_proposal"
         );
     }
@@ -574,7 +574,7 @@ mod tests {
         apply_add_member(&mut state, member_index, member_pubkey);
         // Property: threshold bounded must hold after add_member
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after add_member"
         );
     }
@@ -593,7 +593,7 @@ mod tests {
         apply_remove_member(&mut state);
         // Property: threshold bounded must hold after remove_member
         assert!(
-            (state.threshold <= state.member_count) && (state.threshold > 0),
+            state.threshold <= state.member_count && state.threshold > 0,
             "threshold_bounded must hold after remove_member"
         );
     }

--- a/examples/rust/multisig/tests/kani.rs
+++ b/examples/rust/multisig/tests/kani.rs
@@ -86,7 +86,7 @@ struct State {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -102,7 +102,7 @@ fn votes_bounded(s: &State) -> bool {
 // ============================================================================
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -129,8 +129,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -149,8 +149,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -168,8 +168,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -213,7 +213,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -248,7 +248,7 @@ fn verify_create_vault_rejects_invalid() {
     kani::assume(s.status == Status::Uninitialized);
     let threshold: u8 = kani::any();
     let member_count: u8 = kani::any();
-    kani::assume(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+    kani::assume(!(threshold > 0 && threshold <= member_count && member_count <= 32));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !create_vault(&mut s, threshold, member_count),
@@ -275,8 +275,8 @@ fn verify_approve_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -304,8 +304,8 @@ fn verify_reject_rejects_invalid() {
     kani::assume(
         !(((member_index) as usize) < s.members.len()
             && ((member_index) as usize) < s.voted.len()
-            && (member_index < s.member_count)
-            && (s.voted[(member_index) as usize] == 0)),
+            && member_index < s.member_count
+            && s.voted[(member_index) as usize] == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -332,8 +332,8 @@ fn verify_execute_rejects_invalid() {
     let member_index: u8 = kani::any();
     kani::assume(
         !(((member_index) as usize) < s.members.len()
-            && (member_index < s.member_count)
-            && (s.approval_count >= s.threshold)),
+            && member_index < s.member_count
+            && s.approval_count >= s.threshold),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
@@ -409,7 +409,7 @@ fn verify_remove_member_rejects_invalid() {
     };
     kani::assume(s.status == Status::Active);
     kani::assume(
-        !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)),
+        !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0),
     );
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(

--- a/examples/rust/multisig/tests/proptest.rs
+++ b/examples/rust/multisig/tests/proptest.rs
@@ -86,7 +86,7 @@ prop_compose! {
 
 /// threshold_bounded: s.threshold ≤ s.member_count ∧ s.threshold > 0
 fn threshold_bounded(s: &State) -> bool {
-    (s.threshold <= s.member_count) && (s.threshold > 0)
+    s.threshold <= s.member_count && s.threshold > 0
 }
 
 /// votes_bounded: s.approval_count + s.rejection_count ≤ s.member_count
@@ -95,7 +95,7 @@ fn votes_bounded(s: &State) -> bool {
 }
 
 fn create_vault(s: &mut State, threshold: u8, member_count: u8) -> bool {
-    if !((threshold > 0) && (threshold <= member_count) && (member_count <= 32)) {
+    if !(threshold > 0 && threshold <= member_count && member_count <= 32) {
         return false;
     }
     if s.status != Status::Uninitialized {
@@ -122,8 +122,8 @@ fn propose(s: &mut State) -> bool {
 fn approve(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -142,8 +142,8 @@ fn approve(s: &mut State, member_index: u8) -> bool {
 fn reject(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
         && ((member_index) as usize) < s.voted.len()
-        && (member_index < s.member_count)
-        && (s.voted[(member_index) as usize] == 0))
+        && member_index < s.member_count
+        && s.voted[(member_index) as usize] == 0)
     {
         return false;
     }
@@ -161,8 +161,8 @@ fn reject(s: &mut State, member_index: u8) -> bool {
 
 fn execute(s: &mut State, member_index: u8) -> bool {
     if !(((member_index) as usize) < s.members.len()
-        && (member_index < s.member_count)
-        && (s.approval_count >= s.threshold))
+        && member_index < s.member_count
+        && s.approval_count >= s.threshold)
     {
         return false;
     }
@@ -206,7 +206,7 @@ fn add_member(s: &mut State, member_index: u8, member_pubkey: [u8; 32]) -> bool 
 }
 
 fn remove_member(s: &mut State) -> bool {
-    if !((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)) {
+    if !(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0) {
         return false;
     }
     if s.status != Status::Active {
@@ -435,7 +435,7 @@ proptest! {
     #[test]
     fn create_vault_rejects_invalid(s in arb_boundary_state(), threshold in prop_oneof![0u8..=3u8, 252u8..=255u8], member_count in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!((threshold > 0) && (threshold <= member_count) && (member_count <= 32)));
+        prop_assume!(!(threshold > 0 && threshold <= member_count && member_count <= 32));
         prop_assert!(!create_vault(&mut s, threshold, member_count),
             "create_vault must reject when guard is violated");
     }
@@ -446,7 +446,7 @@ proptest! {
     #[test]
     fn approve_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!approve(&mut s, member_index),
             "approve must reject when guard is violated");
     }
@@ -457,7 +457,7 @@ proptest! {
     #[test]
     fn reject_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && (member_index < s.member_count) && (s.voted[(member_index) as usize] == 0)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && ((member_index) as usize) < s.voted.len() && member_index < s.member_count && s.voted[(member_index) as usize] == 0));
         prop_assert!(!reject(&mut s, member_index),
             "reject must reject when guard is violated");
     }
@@ -468,7 +468,7 @@ proptest! {
     #[test]
     fn execute_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8]) {
         let mut s = s;
-        prop_assume!(!(((member_index) as usize) < s.members.len() && (member_index < s.member_count) && (s.approval_count >= s.threshold)));
+        prop_assume!(!(((member_index) as usize) < s.members.len() && member_index < s.member_count && s.approval_count >= s.threshold));
         prop_assert!(!execute(&mut s, member_index),
             "execute must reject when guard is violated");
     }
@@ -479,7 +479,7 @@ proptest! {
     #[test]
     fn cancel_proposal_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!(((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128))));
+        prop_assume!(!((((s.member_count) as u128)).saturating_sub(((s.rejection_count) as u128)) < ((s.threshold) as u128)));
         prop_assert!(!cancel_proposal(&mut s),
             "cancel_proposal must reject when guard is violated");
     }
@@ -490,7 +490,7 @@ proptest! {
     #[test]
     fn add_member_rejects_invalid(s in arb_boundary_state(), member_index in prop_oneof![0u8..=3u8, 252u8..=255u8], member_pubkey in prop::array::uniform32(0u8..1u8)) {
         let mut s = s;
-        prop_assume!(!((member_index < s.member_count)));
+        prop_assume!(!(member_index < s.member_count));
         prop_assert!(!add_member(&mut s, member_index, member_pubkey),
             "add_member must reject when guard is violated");
     }
@@ -501,7 +501,7 @@ proptest! {
     #[test]
     fn remove_member_rejects_invalid(s in arb_boundary_state()) {
         let mut s = s;
-        prop_assume!(!((s.member_count > s.threshold) && (s.approval_count == 0) && (s.rejection_count == 0)));
+        prop_assume!(!(s.member_count > s.threshold && s.approval_count == 0 && s.rejection_count == 0));
         prop_assert!(!remove_member(&mut s),
             "remove_member must reject when guard is violated");
     }


### PR DESCRIPTION
## Summary
- make boolean and guard composition precedence-aware in the canonical Rust renderer
- represent proptest strategy calls, ranges, alternatives, and method chains as typed syntax before rendering
- remove redundant guard parentheses and refresh the affected generated snapshots

## Stack
- follows #320, which keeps effect targets typed through MIR and codegen
- this slice completes the remaining guard and strategy-expression work

Closes #313

## Verification
- cargo test --manifest-path crates/qedgen/Cargo.toml
- cargo clippy --manifest-path crates/qedgen/Cargo.toml --all-targets -- -D warnings
- cargo fmt --manifest-path crates/qedgen/Cargo.toml -- --check