### PR TITLE
feat(mir): nominal types on constructor ExprTree forms — no more /* ty */ placeholders (#325)

### DIFF
--- a/crates/qedgen/src/check/lints/ctor_types.rs
+++ b/crates/qedgen/src/check/lints/ctor_types.rs
@@ -1,0 +1,152 @@
+//! `unresolved_constructor_type` — every `.Variant` constructor, record
+//! literal, and record update in an expression position must carry its
+//! resolved nominal type (#325).
+//!
+//! The types are resolved at tree-build time (`chumsky_adapter::tree`):
+//! constructors by unique-variant search, record literals by unique
+//! field-set match, record updates from the base path's type. When
+//! resolution fails (ambiguous variant name, partial or ambiguous field
+//! set, non-path update base), the Rust renderer would have to emit a
+//! placeholder — so the gap fails `check` here instead, and the renderer's
+//! poison identifier (`__QEDGEN_UNRESOLVED_TYPE`) is only a backstop for
+//! codegen runs that skipped check.
+//!
+//! Lean is unaffected: it renders these forms anonymously and lets the
+//! elaborator infer the type.
+
+use super::*;
+use crate::mir::ExprTree;
+
+pub(super) fn check_ctor_types(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
+    let mut warnings = Vec::new();
+    let mut lint = |site: &str, tree: &ExprTree| {
+        let mut problems: Vec<String> = Vec::new();
+        tree.for_each_node(&mut |node| match node {
+            ExprTree::Ctor {
+                variant, ty: None, ..
+            } => problems.push(format!(
+                "constructor `.{}` does not resolve to a unique sum type",
+                variant
+            )),
+            ExprTree::RecordLit { fields, ty: None } => problems.push(format!(
+                "record literal {{ {} }} does not match a unique declared record's field set",
+                fields
+                    .iter()
+                    .map(|(n, _)| n.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )),
+            ExprTree::RecordUpdate { ty: None, .. } => problems.push(
+                "record update base has no resolvable record type".to_string(),
+            ),
+            _ => {}
+        });
+        for problem in problems {
+            warnings.push(
+                warn(
+                    "unresolved_constructor_type",
+                    Severity::Error,
+                    1,
+                    format!("{}: {}", site, problem),
+                )
+                .fix(
+                    "Rust codegen needs a concrete type name here. Disambiguate the \
+                     variant / field set, or declare the record the literal constructs.",
+                ),
+            );
+        }
+    };
+
+    for prop in &spec.properties {
+        if let Some(tree) = &prop.tree {
+            lint(&format!("property `{}`", prop.name), tree);
+        }
+    }
+    for inv in &spec.invariants {
+        if let Some(tree) = &inv.tree {
+            lint(&format!("invariant `{}`", inv.name), tree);
+        }
+    }
+    for handler in &spec.handlers {
+        for (idx, req) in handler.requires.iter().enumerate() {
+            if let Some(tree) = &req.tree {
+                lint(
+                    &format!("handler `{}` requires #{}", handler.name, idx),
+                    tree,
+                );
+            }
+        }
+        for (idx, ens) in handler.ensures.iter().enumerate() {
+            if let Some(tree) = &ens.tree {
+                lint(
+                    &format!("handler `{}` ensures #{}", handler.name, idx),
+                    tree,
+                );
+            }
+        }
+        for effect in &handler.effects {
+            if let Some(tree) = &effect.tree {
+                lint(
+                    &format!("handler `{}` effect `{}`", handler.name, effect.field),
+                    tree,
+                );
+            }
+        }
+    }
+
+    warnings
+}
+
+#[cfg(test)]
+mod tests {
+    fn findings(src: &str) -> Vec<String> {
+        let spec = crate::chumsky_adapter::parse_str(src).expect("spec parses");
+        super::check_ctor_types(&spec)
+            .into_iter()
+            .map(|w| w.message)
+            .collect()
+    }
+
+    #[test]
+    fn resolved_ctor_and_record_lit_pass() {
+        let findings = findings(
+            r#"spec T
+type Entry = { who : Pubkey, amount : U64 }
+state { total : U64, best : Entry }
+handler set_best (who : Pubkey) (amount : U64) {
+  permissionless
+  accounts {
+    caller : signer
+  }
+  effect {
+    best := { who := who, amount := amount }
+  }
+}
+"#,
+        );
+        assert!(findings.is_empty(), "{:#?}", findings);
+    }
+
+    #[test]
+    fn ambiguous_record_literal_fails() {
+        // Two records with the same field set: the literal cannot resolve.
+        let findings = findings(
+            r#"spec T
+type EntryA = { who : Pubkey, amount : U64 }
+type EntryB = { who : Pubkey, amount : U64 }
+state { total : U64, best : EntryA }
+handler set_best (who : Pubkey) (amount : U64) {
+  permissionless
+  accounts {
+    caller : signer
+  }
+  effect {
+    best := { who := who, amount := amount }
+  }
+}
+"#,
+        );
+        assert_eq!(findings.len(), 1, "{:#?}", findings);
+        assert!(findings[0].contains("does not match a unique declared record"));
+    }
+}

--- a/crates/qedgen/src/check/lints/ctor_types.rs
+++ b/crates/qedgen/src/check/lints/ctor_types.rs
@@ -36,9 +36,9 @@ pub(super) fn check_ctor_types(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
                     .collect::<Vec<_>>()
                     .join(", ")
             )),
-            ExprTree::RecordUpdate { ty: None, .. } => problems.push(
-                "record update base has no resolvable record type".to_string(),
-            ),
+            ExprTree::RecordUpdate { ty: None, .. } => {
+                problems.push("record update base has no resolvable record type".to_string())
+            }
             _ => {}
         });
         for problem in problems {

--- a/crates/qedgen/src/check/lints/mod.rs
+++ b/crates/qedgen/src/check/lints/mod.rs
@@ -8,6 +8,7 @@ use super::*;
 mod arithmetic;
 mod auth;
 mod cpi;
+mod ctor_types;
 mod known_types;
 mod shared;
 mod state;
@@ -40,6 +41,10 @@ pub fn check_completeness(spec: &ParsedSpec) -> Vec<CompletenessWarning> {
     // instead of surfacing as invalid Lean or a silent u64 proptest
     // strategy at codegen time.
     warnings.extend(known_types::check_known_types(spec));
+
+    // Constructor / record-literal / record-update expressions must carry
+    // a resolved nominal type for Rust rendering (#325).
+    warnings.extend(ctor_types::check_ctor_types(spec));
 
     // ADT-state `WrongState` compile gate.
     warnings.extend(check_adt_state_missing_wrong_state(spec));

--- a/crates/qedgen/src/codegen/codegen_shared/effect.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/effect.rs
@@ -159,7 +159,7 @@ pub(crate) fn tree_bare_rhs(tree: &crate::mir::ExprTree) -> Option<String> {
         | ExprTree::MulDivRoundHalfUp { .. }
         | ExprTree::Match { .. }
         | ExprTree::Ctor { .. }
-        | ExprTree::RecordLit(_)
+        | ExprTree::RecordLit { .. }
         | ExprTree::RecordUpdate { .. }
         | ExprTree::IsVariant { .. }
         | ExprTree::App { .. }

--- a/crates/qedgen/src/codegen/lean_gen_mir/transitions.rs
+++ b/crates/qedgen/src/codegen/lean_gen_mir/transitions.rs
@@ -1086,14 +1086,14 @@ fn collect_tree_bound_guards(
             Some(p) => walk(p, conds),
             None => false,
         },
-        ExprTree::RecordLit(fields) => {
+        ExprTree::RecordLit { fields, .. } => {
             let mut growth = false;
             for (_, v) in fields {
                 growth |= walk(v, conds);
             }
             growth
         }
-        ExprTree::RecordUpdate { base, updates } => {
+        ExprTree::RecordUpdate { base, updates, .. } => {
             let mut growth = walk(base, conds);
             for (_, v) in updates {
                 growth |= walk(v, conds);

--- a/crates/qedgen/src/codegen/lean_gen_mir/tree_render.rs
+++ b/crates/qedgen/src/codegen/lean_gen_mir/tree_render.rs
@@ -292,7 +292,9 @@ fn render(e: &ExprTree, cx: LeanCx, inside_old: bool) -> (String, Prec) {
             out.push(')');
             (out, Prec::Atom)
         }
-        ExprTree::Ctor { variant, payload, .. } => (
+        ExprTree::Ctor {
+            variant, payload, ..
+        } => (
             match payload {
                 None => format!(".{}", variant),
                 Some(p) => format!(".{} {}", variant, render(p, cx, inside_old).0),
@@ -634,7 +636,9 @@ pub fn tree_mentions_ident(e: &ExprTree, name: &str) -> bool {
         ExprTree::Ctor { payload, .. } => payload
             .as_ref()
             .is_some_and(|p| tree_mentions_ident(p, name)),
-        ExprTree::RecordLit { fields, .. } => fields.iter().any(|(_, v)| tree_mentions_ident(v, name)),
+        ExprTree::RecordLit { fields, .. } => {
+            fields.iter().any(|(_, v)| tree_mentions_ident(v, name))
+        }
         ExprTree::RecordUpdate { base, updates, .. } => {
             tree_mentions_ident(base, name)
                 || updates.iter().any(|(_, v)| tree_mentions_ident(v, name))

--- a/crates/qedgen/src/codegen/lean_gen_mir/tree_render.rs
+++ b/crates/qedgen/src/codegen/lean_gen_mir/tree_render.rs
@@ -292,7 +292,7 @@ fn render(e: &ExprTree, cx: LeanCx, inside_old: bool) -> (String, Prec) {
             out.push(')');
             (out, Prec::Atom)
         }
-        ExprTree::Ctor { variant, payload } => (
+        ExprTree::Ctor { variant, payload, .. } => (
             match payload {
                 None => format!(".{}", variant),
                 Some(p) => format!(".{} {}", variant, render(p, cx, inside_old).0),
@@ -301,7 +301,7 @@ fn render(e: &ExprTree, cx: LeanCx, inside_old: bool) -> (String, Prec) {
             // but is context-elaborated; parents should parenthesize.
             Prec::Implies,
         ),
-        ExprTree::RecordLit(fields) => {
+        ExprTree::RecordLit { fields, .. } => {
             let body = fields
                 .iter()
                 .map(|(n, v)| format!("{} := {}", n, render(v, cx, inside_old).0))
@@ -309,7 +309,7 @@ fn render(e: &ExprTree, cx: LeanCx, inside_old: bool) -> (String, Prec) {
                 .join(", ");
             (format!("{{ {} }}", body), Prec::Atom)
         }
-        ExprTree::RecordUpdate { base, updates } => {
+        ExprTree::RecordUpdate { base, updates, .. } => {
             let base_str = render(base, cx, inside_old).0;
             let body = updates
                 .iter()
@@ -431,7 +431,7 @@ fn render_old(inner: &ExprTree, cx: LeanCx) -> (String, Prec) {
         | ExprTree::MulDivRoundHalfUp { .. }
         | ExprTree::Match { .. }
         | ExprTree::Ctor { .. }
-        | ExprTree::RecordLit(_)
+        | ExprTree::RecordLit { .. }
         | ExprTree::RecordUpdate { .. }
         | ExprTree::IsVariant { .. }
         | ExprTree::App { .. }
@@ -634,8 +634,8 @@ pub fn tree_mentions_ident(e: &ExprTree, name: &str) -> bool {
         ExprTree::Ctor { payload, .. } => payload
             .as_ref()
             .is_some_and(|p| tree_mentions_ident(p, name)),
-        ExprTree::RecordLit(fields) => fields.iter().any(|(_, v)| tree_mentions_ident(v, name)),
-        ExprTree::RecordUpdate { base, updates } => {
+        ExprTree::RecordLit { fields, .. } => fields.iter().any(|(_, v)| tree_mentions_ident(v, name)),
+        ExprTree::RecordUpdate { base, updates, .. } => {
             tree_mentions_ident(base, name)
                 || updates.iter().any(|(_, v)| tree_mentions_ident(v, name))
         }

--- a/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
@@ -1370,7 +1370,9 @@ pub fn contains_fallible_arith(e: &ExprTree) -> bool {
         ExprTree::Ctor { payload, .. } => {
             payload.as_ref().is_some_and(|p| contains_fallible_arith(p))
         }
-        ExprTree::RecordLit { fields, .. } => fields.iter().any(|(_, v)| contains_fallible_arith(v)),
+        ExprTree::RecordLit { fields, .. } => {
+            fields.iter().any(|(_, v)| contains_fallible_arith(v))
+        }
         ExprTree::RecordUpdate { base, updates, .. } => {
             contains_fallible_arith(base) || updates.iter().any(|(_, v)| contains_fallible_arith(v))
         }

--- a/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
@@ -380,27 +380,40 @@ fn render(e: &ExprTree, cx: RustCx, inside_old: bool) -> (String, Prec) {
             out.push_str("\n}");
             (out, Prec::Atom)
         }
-        ExprTree::Ctor { variant, payload } => (
+        // #325 — the three constructor forms carry their nominal type,
+        // resolved at build time. `unresolved_ctor_ty` is the None
+        // backstop: a poison identifier that fails rustc loudly with a
+        // searchable name — never a comment placeholder that pretends to
+        // be code. The `unresolved_constructor_type` check lint reports
+        // the same gap before codegen runs.
+        ExprTree::Ctor {
+            variant,
+            payload,
+            ty,
+        } => (
             match payload {
-                None => format!("{}::{}", "/* ty */", variant),
+                None => format!("{}::{}", unresolved_ctor_ty(ty), variant),
                 Some(p) => format!(
                     "{}::{}({})",
-                    "/* ty */",
+                    unresolved_ctor_ty(ty),
                     variant,
                     render(p, cx, inside_old).0
                 ),
             },
             Prec::Atom,
         ),
-        ExprTree::RecordLit(fields) => {
+        ExprTree::RecordLit { fields, ty } => {
             let body = fields
                 .iter()
                 .map(|(n, v)| format!("{}: {}", n, render(v, cx, inside_old).0))
                 .collect::<Vec<_>>()
                 .join(", ");
-            (format!("{} {{ {} }}", "/* ty */", body), Prec::Atom)
+            (
+                format!("{} {{ {} }}", unresolved_ctor_ty(ty), body),
+                Prec::Atom,
+            )
         }
-        ExprTree::RecordUpdate { base, updates } => {
+        ExprTree::RecordUpdate { base, updates, ty } => {
             let base_str = render(base, cx, inside_old).0;
             let body = updates
                 .iter()
@@ -408,7 +421,7 @@ fn render(e: &ExprTree, cx: RustCx, inside_old: bool) -> (String, Prec) {
                 .collect::<Vec<_>>()
                 .join(", ");
             (
-                format!("{} {{ {}, ..{} }}", "/* ty */", body, base_str),
+                format!("{} {{ {}, ..{} }}", unresolved_ctor_ty(ty), body, base_str),
                 Prec::Atom,
             )
         }
@@ -662,6 +675,16 @@ fn render_path(p: &TreePath, cx: RustCx, inside_old: bool) -> String {
     out
 }
 
+/// The resolved nominal type of a constructor form, or the poison
+/// identifier for the unresolved case (#325). The poison is a guaranteed
+/// unresolved-ident rustc error with a greppable name — the check lint
+/// (`unresolved_constructor_type`) reports the same gap with a sited
+/// diagnostic before codegen, so reaching the poison means check was
+/// skipped.
+fn unresolved_ctor_ty(ty: &Option<crate::mir::Symbol>) -> &str {
+    ty.as_deref().unwrap_or("__QEDGEN_UNRESOLVED_TYPE")
+}
+
 /// Pod companion gate, per [`PodStyle`]. Tree-native replacement for
 /// `TypeEnv::path_is_pod_field` (Quasar) and `bind_pinocchio_expr`'s
 /// `.get()` dispatch (Zeropod).
@@ -790,7 +813,7 @@ fn rust_num_kind(e: &ExprTree) -> NumKind {
         | ExprTree::Arith { .. }
         | ExprTree::Match { .. }
         | ExprTree::Ctor { .. }
-        | ExprTree::RecordLit(_)
+        | ExprTree::RecordLit { .. }
         | ExprTree::RecordUpdate { .. }
         | ExprTree::IsVariant { .. }
         | ExprTree::App { .. }
@@ -826,7 +849,7 @@ fn spine_has_arith(e: &ExprTree) -> bool {
         | ExprTree::MulDivRoundHalfUp { .. }
         | ExprTree::Match { .. }
         | ExprTree::Ctor { .. }
-        | ExprTree::RecordLit(_)
+        | ExprTree::RecordLit { .. }
         | ExprTree::RecordUpdate { .. }
         | ExprTree::IsVariant { .. }
         | ExprTree::App { .. }
@@ -969,7 +992,7 @@ fn render_pred_wrapped_term(e: &ExprTree, cx: RustCx, inside_old: bool, wide: &s
         | ExprTree::MulDivRoundHalfUp { .. }
         | ExprTree::Match { .. }
         | ExprTree::Ctor { .. }
-        | ExprTree::RecordLit(_)
+        | ExprTree::RecordLit { .. }
         | ExprTree::RecordUpdate { .. }
         | ExprTree::IsVariant { .. }
         | ExprTree::App { .. }
@@ -1133,7 +1156,7 @@ fn render_widened_term(e: &ExprTree, cx: RustCx, inside_old: bool, wide: &str) -
         | ExprTree::Cmp { .. }
         | ExprTree::Match { .. }
         | ExprTree::Ctor { .. }
-        | ExprTree::RecordLit(_)
+        | ExprTree::RecordLit { .. }
         | ExprTree::RecordUpdate { .. }
         | ExprTree::IsVariant { .. }
         | ExprTree::App { .. }
@@ -1252,12 +1275,12 @@ pub fn for_each_path(e: &ExprTree, f: &mut impl FnMut(&TreePath)) {
                 for_each_path(p, f);
             }
         }
-        ExprTree::RecordLit(fields) => {
+        ExprTree::RecordLit { fields, .. } => {
             for (_, v) in fields {
                 for_each_path(v, f);
             }
         }
-        ExprTree::RecordUpdate { base, updates } => {
+        ExprTree::RecordUpdate { base, updates, .. } => {
             for_each_path(base, f);
             for (_, v) in updates {
                 for_each_path(v, f);
@@ -1347,8 +1370,8 @@ pub fn contains_fallible_arith(e: &ExprTree) -> bool {
         ExprTree::Ctor { payload, .. } => {
             payload.as_ref().is_some_and(|p| contains_fallible_arith(p))
         }
-        ExprTree::RecordLit(fields) => fields.iter().any(|(_, v)| contains_fallible_arith(v)),
-        ExprTree::RecordUpdate { base, updates } => {
+        ExprTree::RecordLit { fields, .. } => fields.iter().any(|(_, v)| contains_fallible_arith(v)),
+        ExprTree::RecordUpdate { base, updates, .. } => {
             contains_fallible_arith(base) || updates.iter().any(|(_, v)| contains_fallible_arith(v))
         }
         ExprTree::IsVariant { scrutinee, .. } => contains_fallible_arith(scrutinee),
@@ -1372,6 +1395,55 @@ pub fn contains_fallible_arith(e: &ExprTree) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ------------------------------------------------------------------
+    // #325 — constructor forms render their resolved nominal type; no
+    // `/* ty */` placeholder survives in any production arm.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn ctor_forms_render_resolved_nominal_types() {
+        use crate::mir::ExprTree;
+        let entry_lit = ExprTree::RecordLit {
+            fields: vec![
+                ("who".to_string(), ExprTree::Int(1)),
+                ("amount".to_string(), ExprTree::Int(2)),
+            ],
+            ty: Some("Entry".to_string()),
+        };
+        let (rendered, _) = render(&entry_lit, RustCx::native(), false);
+        assert_eq!(rendered, "Entry { who: 1, amount: 2 }");
+
+        let ctor = ExprTree::Ctor {
+            variant: "Fast".to_string(),
+            payload: None,
+            ty: Some("Mode".to_string()),
+        };
+        let (rendered, _) = render(&ctor, RustCx::native(), false);
+        assert_eq!(rendered, "Mode::Fast");
+
+        let update = ExprTree::RecordUpdate {
+            base: Box::new(entry_lit.clone()),
+            updates: vec![("amount".to_string(), ExprTree::Int(3))],
+            ty: Some("Entry".to_string()),
+        };
+        let (rendered, _) = render(&update, RustCx::native(), false);
+        assert_eq!(
+            rendered,
+            "Entry { amount: 3, ..Entry { who: 1, amount: 2 } }"
+        );
+
+        // Unresolved backstop: a poison identifier (guaranteed rustc
+        // error, greppable), never a comment placeholder.
+        let unresolved = ExprTree::Ctor {
+            variant: "Fast".to_string(),
+            payload: None,
+            ty: None,
+        };
+        let (rendered, _) = render(&unresolved, RustCx::native(), false);
+        assert_eq!(rendered, "__QEDGEN_UNRESOLVED_TYPE::Fast");
+        assert!(!rendered.contains("/* ty */"));
+    }
 
     // ------------------------------------------------------------------
     // Corpus parity: for every expression the adapter carried a tree for,

--- a/crates/qedgen/src/mir/expr_tree.rs
+++ b/crates/qedgen/src/mir/expr_tree.rs
@@ -235,9 +235,9 @@ impl ExprTree {
         f(self);
         match self {
             ExprTree::Int(_) | ExprTree::Bool(_) | ExprTree::Path(_) => {}
-            ExprTree::Old(inner)
-            | ExprTree::Not(inner)
-            | ExprTree::Len(inner) => inner.for_each_node(f),
+            ExprTree::Old(inner) | ExprTree::Not(inner) | ExprTree::Len(inner) => {
+                inner.for_each_node(f)
+            }
             ExprTree::Sum { body, .. } | ExprTree::Quant { body, .. } => body.for_each_node(f),
             ExprTree::QuantIn { coll, body, .. } => {
                 coll.for_each_node(f);

--- a/crates/qedgen/src/mir/expr_tree.rs
+++ b/crates/qedgen/src/mir/expr_tree.rs
@@ -162,13 +162,29 @@ pub enum ExprTree {
     Ctor {
         variant: Symbol,
         payload: Option<Box<ExprTree>>,
+        /// Resolved owning enum type name (#325) — resolved once at build
+        /// time (unique-variant search, like `IsVariant`) so the env-less
+        /// Rust renderer can emit `Enum::Variant` instead of a
+        /// placeholder. `None` when unresolvable; the
+        /// `unresolved_constructor_type` check lint gates that before
+        /// codegen.
+        ty: Option<Symbol>,
     },
-    /// `{ field := expr, … }` — anonymous record literal.
-    RecordLit(Vec<(Symbol, ExprTree)>),
+    /// `{ field := expr, … }` — record literal.
+    RecordLit {
+        fields: Vec<(Symbol, ExprTree)>,
+        /// Resolved nominal record type (#325), inferred at build time by
+        /// unique field-name match against the declared records. Lean
+        /// renders anonymously and ignores it; Rust requires it.
+        ty: Option<Symbol>,
+    },
     /// `{ base with field := expr, … }` — functional record update.
     RecordUpdate {
         base: Box<ExprTree>,
         updates: Vec<(Symbol, ExprTree)>,
+        /// Resolved nominal record type of `base` (#325), from the base
+        /// path's type when it is a path.
+        ty: Option<Symbol>,
     },
     /// `x is .Variant` — constructor test.
     IsVariant {
@@ -208,6 +224,88 @@ pub enum ExprTree {
         then_branch: Box<ExprTree>,
         else_branch: Box<ExprTree>,
     },
+}
+
+impl ExprTree {
+    /// Pre-order visit of this node and every sub-expression. Exhaustive
+    /// over the closed enum (no `_` arm) so a new variant is a compile
+    /// error here, not a silently unvisited subtree. Used by the
+    /// `unresolved_constructor_type` check lint (#325).
+    pub fn for_each_node<'a>(&'a self, f: &mut dyn FnMut(&'a ExprTree)) {
+        f(self);
+        match self {
+            ExprTree::Int(_) | ExprTree::Bool(_) | ExprTree::Path(_) => {}
+            ExprTree::Old(inner)
+            | ExprTree::Not(inner)
+            | ExprTree::Len(inner) => inner.for_each_node(f),
+            ExprTree::Sum { body, .. } | ExprTree::Quant { body, .. } => body.for_each_node(f),
+            ExprTree::QuantIn { coll, body, .. } => {
+                coll.for_each_node(f);
+                body.for_each_node(f);
+            }
+            ExprTree::BoolOp { lhs, rhs, .. }
+            | ExprTree::Cmp { lhs, rhs, .. }
+            | ExprTree::Arith { lhs, rhs, .. } => {
+                lhs.for_each_node(f);
+                rhs.for_each_node(f);
+            }
+            ExprTree::MulDivFloor { a, b, d }
+            | ExprTree::MulDivCeil { a, b, d }
+            | ExprTree::MulDivRoundHalfUp { a, b, d } => {
+                a.for_each_node(f);
+                b.for_each_node(f);
+                d.for_each_node(f);
+            }
+            ExprTree::Contains { coll, elem } => {
+                coll.for_each_node(f);
+                elem.for_each_node(f);
+            }
+            ExprTree::Match {
+                scrutinee, arms, ..
+            } => {
+                scrutinee.for_each_node(f);
+                for arm in arms {
+                    arm.body.for_each_node(f);
+                }
+            }
+            ExprTree::Ctor { payload, .. } => {
+                if let Some(payload) = payload {
+                    payload.for_each_node(f);
+                }
+            }
+            ExprTree::RecordLit { fields, .. } => {
+                for (_, v) in fields {
+                    v.for_each_node(f);
+                }
+            }
+            ExprTree::RecordUpdate { base, updates, .. } => {
+                base.for_each_node(f);
+                for (_, v) in updates {
+                    v.for_each_node(f);
+                }
+            }
+            ExprTree::IsVariant { scrutinee, .. } => scrutinee.for_each_node(f),
+            ExprTree::App { args, .. } => {
+                for a in args {
+                    a.for_each_node(f);
+                }
+            }
+            ExprTree::Field { base, .. } => base.for_each_node(f),
+            ExprTree::Let { value, body, .. } => {
+                value.for_each_node(f);
+                body.for_each_node(f);
+            }
+            ExprTree::IfThenElse {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                cond.for_each_node(f);
+                then_branch.for_each_node(f);
+                else_branch.for_each_node(f);
+            }
+        }
+    }
 }
 
 /// A name-resolved path. `root` preserves the source spelling of the head
@@ -485,20 +583,27 @@ fn map_paths_inner(
                 .collect(),
             enum_ty: enum_ty.clone(),
         },
-        ExprTree::Ctor { variant, payload } => ExprTree::Ctor {
+        ExprTree::Ctor {
+            variant,
+            payload,
+            ty,
+        } => ExprTree::Ctor {
             variant: variant.clone(),
             payload: payload
                 .as_ref()
                 .map(|p| Box::new(map_paths_inner(p, f, in_old))),
+            ty: ty.clone(),
         },
-        ExprTree::RecordLit(fields) => ExprTree::RecordLit(
-            fields
+        ExprTree::RecordLit { fields, ty } => ExprTree::RecordLit {
+            fields: fields
                 .iter()
                 .map(|(n, v)| (n.clone(), map_paths_inner(v, f, in_old)))
                 .collect(),
-        ),
-        ExprTree::RecordUpdate { base, updates } => ExprTree::RecordUpdate {
+            ty: ty.clone(),
+        },
+        ExprTree::RecordUpdate { base, updates, ty } => ExprTree::RecordUpdate {
             base: Box::new(map_paths_inner(base, f, in_old)),
+            ty: ty.clone(),
             updates: updates
                 .iter()
                 .map(|(n, v)| (n.clone(), map_paths_inner(v, f, in_old)))
@@ -590,7 +695,7 @@ impl ExprTree {
                 .map(|arm| arm.body.num_kind())
                 .unwrap_or(NumKind::Other),
             ExprTree::Ctor { .. } => NumKind::Other,
-            ExprTree::RecordLit(_) => NumKind::Other,
+            ExprTree::RecordLit { .. } => NumKind::Other,
             ExprTree::RecordUpdate { base, .. } => base.num_kind(),
             ExprTree::IsVariant { .. } => NumKind::Bool,
             ExprTree::App { .. } => NumKind::Other,

--- a/crates/qedgen/src/spec/chumsky_adapter/mod.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/mod.rs
@@ -382,6 +382,31 @@ impl<'a> TypeEnv<'a> {
         Some(first)
     }
 
+    /// Infer the nominal record a `{ field := …, … }` literal constructs
+    /// (#325): the unique declared record whose field-name set exactly
+    /// matches the literal's. Exact-set matching keeps inference honest —
+    /// a partial literal is a spec error the `unresolved_constructor_type`
+    /// lint reports, not something to guess through. Ambiguity (two
+    /// records with identical field sets) declines rather than guessing.
+    /// The flat-state `State` mirror record is excluded — a literal is a
+    /// value expression, not a state constructor.
+    fn record_for_fields(&self, field_names: &[&str]) -> Option<String> {
+        let want: std::collections::BTreeSet<&str> = field_names.iter().copied().collect();
+        let mut hits = self.records.iter().filter_map(|(name, fields)| {
+            if name == "State" {
+                return None;
+            }
+            let have: std::collections::BTreeSet<&str> =
+                fields.keys().map(|k| k.as_str()).collect();
+            (have == want).then(|| name.clone())
+        });
+        let first = hits.next()?;
+        if hits.next().is_some() {
+            return None;
+        }
+        Some(first)
+    }
+
     /// Infer the kind of an Expr.
     fn infer(&self, e: &Expr) -> Kind {
         match e {

--- a/crates/qedgen/src/spec/chumsky_adapter/tree.rs
+++ b/crates/qedgen/src/spec/chumsky_adapter/tree.rs
@@ -287,17 +287,33 @@ fn build(e: &Expr, cx: &TreeCx, shadow: &mut Vec<String>) -> ExprTree {
                 enum_ty: enum_hint,
             }
         }
+        // #325 — the three constructor forms resolve their nominal type
+        // HERE, while the TypeEnv is in scope (mirroring `IsVariant` /
+        // `Match` below): the env-less Rust renderer needs a concrete
+        // type name, never a placeholder.
         Expr::Ctor { variant, payload } => ExprTree::Ctor {
             variant: variant.clone(),
             payload: payload.as_ref().map(|p| boxed(p, cx, shadow)),
+            ty: cx
+                .env
+                .resolve_variant(None, variant)
+                .map(|(enum_name, _)| enum_name),
         },
-        Expr::RecordLit(fields) => ExprTree::RecordLit(
-            fields
-                .iter()
-                .map(|(n, v)| (n.clone(), build(&v.node, cx, shadow)))
-                .collect(),
-        ),
+        Expr::RecordLit(fields) => {
+            let field_names: Vec<&str> = fields.iter().map(|(n, _)| n.as_str()).collect();
+            ExprTree::RecordLit {
+                fields: fields
+                    .iter()
+                    .map(|(n, v)| (n.clone(), build(&v.node, cx, shadow)))
+                    .collect(),
+                ty: cx.env.record_for_fields(&field_names),
+            }
+        }
         Expr::RecordUpdate { base, updates } => ExprTree::RecordUpdate {
+            ty: match &base.node {
+                Expr::Path(p) => cx.env.path_type_name(p),
+                _ => None,
+            },
             base: boxed(base, cx, shadow),
             updates: updates
                 .iter()


### PR DESCRIPTION
Implements #325: `ExprTree::Ctor` / `RecordLit` / `RecordUpdate` carry their resolved nominal type, and the Rust renderer emits it instead of the `/* ty */` placeholder. Stacked on #334 (which is stacked on #333) — merge order: #333 → #334 → this.

## Design

Type identity is resolved once at tree-build time, while the `TypeEnv` is in scope — the same pattern `Match.enum_ty` and `IsVariant.enum_ty` already used; these three variants were the only constructor forms missing it:

- **`Ctor`** — unique-variant search across registered sum types (shared with `IsVariant`'s fallback path).
- **`RecordLit`** — new `TypeEnv::record_for_fields`: the unique declared record whose field-name set exactly matches the literal's. Exact-set matching keeps inference honest (a partial literal is a spec error, not something to guess through); ambiguity declines rather than guessing.
- **`RecordUpdate`** — the base path's resolved type.

The Rust renderer emits the concrete name (`Entry { who: w, amount: a }`, `Mode::Fast`). The `None` backstop is a poison identifier (`__QEDGEN_UNRESOLVED_TYPE`) — a guaranteed, greppable rustc error — never a comment placeholder intended to become valid later.

## Check gate

New `unresolved_constructor_type` lint (Error severity): walks every carried expression tree (properties, invariants, requires, ensures, effects) via the new exhaustive `ExprTree::for_each_node` (closed-enum discipline — a new variant is a compile error in the walker, not an unvisited subtree) and reports each unresolved constructor form with a sited diagnostic. Unresolvable forms fail `check` before codegen, per the issue's acceptance criteria.

Lean is unaffected: it renders these forms anonymously (`.Fast`, `{ who := …, … }`) and lets the elaborator infer the type — the asymmetry the issue documented.

## Tests

- Renderer regression: all three forms render the resolved type; the unresolved case renders the poison ident and contains no `/* ty */`.
- Lint tests: resolved literal in an effect passes; two records with identical field sets make the literal ambiguous and fail check.
- Zero lint findings across every bundled spec and fixture; all snapshot suites byte-identical; full suite green (35 targets); clippy clean.

With this, the #325/#327/#330 cluster is complete: types are structured from parse to every backend, and no production renderer emits a placeholder token.

Closes #325
