### PR TITLE
fix(kani): bind imported-state guard reads as symbolic env members (#337)

### DIFF
--- a/crates/qedgen/src/codegen/kani_mir/account.rs
+++ b/crates/qedgen/src/codegen/kani_mir/account.rs
@@ -55,7 +55,7 @@ pub(crate) fn emit_account_section_structural(
     if let Some(acct) = util::kani_adt_view(parsed) {
         util::emit_state_repr_validity_fn(out, parsed, acct);
     }
-    emit_kani_account_env_structs(out, parsed);
+    emit_kani_account_env_structs(out, mir, parsed);
 
     let handlers: Vec<&crate::check::ParsedHandler> = parsed.handlers.iter().collect();
     let properties: Vec<&crate::check::ParsedProperty> = parsed.properties.iter().collect();
@@ -145,7 +145,7 @@ pub(crate) fn emit_account_section_structural(
     Ok(())
 }
 
-pub(crate) fn emit_kani_account_env_structs(out: &mut String, parsed: &ParsedSpec) {
+pub(crate) fn emit_kani_account_env_structs(out: &mut String, mir: &Mir, parsed: &ParsedSpec) {
     use crate::rust_codegen_util as util;
 
     let handlers: Vec<&crate::check::ParsedHandler> = parsed
@@ -171,8 +171,45 @@ pub(crate) fn emit_kani_account_env_structs(out: &mut String, parsed: &ParsedSpe
         for account in &op.accounts {
             out.push_str(&format!("    {}: KaniAccount,\n", account.name));
         }
+        // #337 — flattened symbolic members for account state-field reads
+        // (`admin_config.admin` → `admin_config_admin`): external state the
+        // guard compares against, modeled as an arbitrary value.
+        for (acct, field) in util::collect_account_state_field_reads(op) {
+            let ty = account_state_field_rust_type(mir, parsed, op, &acct, &field);
+            out.push_str(&format!("    {}_{}: {},\n", acct, field, ty));
+        }
         out.push_str("}\n\n");
     }
+}
+
+/// Rust type for a handler-account state-field read (#337), resolved from
+/// the account binding's declared type through the imported spec's
+/// account-type declarations. Falls back to `[u8; 32]` — the guard shape
+/// that motivates these reads is a pubkey comparison.
+fn account_state_field_rust_type(
+    mir: &Mir,
+    parsed: &ParsedSpec,
+    op: &crate::check::ParsedHandler,
+    acct: &str,
+    field: &str,
+) -> String {
+    use crate::codegen_shared::map_type;
+
+    op.accounts
+        .iter()
+        .find(|a| a.name == acct)
+        .and_then(|a| a.account_type.as_deref())
+        .and_then(|ty| {
+            let (ns, tname) = ty.split_once('.')?;
+            let import = mir.imports.get(ns)?;
+            let at = import.account_types.iter().find(|t| t.name == tname)?;
+            at.fields
+                .iter()
+                .find(|(n, _)| n == field)
+                .map(|(_, t)| t.clone())
+        })
+        .and_then(|dsl_ty| map_type(&dsl_ty, parsed).ok())
+        .unwrap_or_else(|| "[u8; 32]".to_string())
 }
 
 pub(crate) fn emit_kani_account_env_binding(
@@ -196,6 +233,10 @@ pub(crate) fn emit_kani_account_env_binding(
             "{indent}    {}: KaniAccount {{ pubkey: kani::any() }},\n",
             account.name
         ));
+    }
+    // #337 — symbolic external-state members, matching the struct emission.
+    for (acct, field) in util::collect_account_state_field_reads(op) {
+        out.push_str(&format!("{indent}    {}_{}: kani::any(),\n", acct, field));
     }
     out.push_str(&format!("{indent}}};\n"));
 }

--- a/crates/qedgen/src/codegen/kani_mir/account.rs
+++ b/crates/qedgen/src/codegen/kani_mir/account.rs
@@ -198,9 +198,9 @@ fn account_state_field_rust_type(
     op.accounts
         .iter()
         .find(|a| a.name == acct)
-        .and_then(|a| a.account_type.as_deref())
-        .and_then(|ty| {
-            let (ns, tname) = ty.split_once('.')?;
+        .and_then(|a| {
+            let ns = a.imported_namespace.as_deref()?;
+            let tname = a.account_type.as_deref()?;
             let import = mir.imports.get(ns)?;
             let at = import.account_types.iter().find(|t| t.name == tname)?;
             at.fields

--- a/crates/qedgen/src/codegen/kani_mir/tests.rs
+++ b/crates/qedgen/src/codegen/kani_mir/tests.rs
@@ -111,6 +111,81 @@ fn imported_state_field_guard_binds_symbolic_env_member() {
     );
 }
 
+/// #337 review follow-up — dotted imported types are split by the parser
+/// into `imported_namespace` + `account_type`. Resolve both fields and use
+/// the binding's declared account type rather than the Pubkey fallback.
+#[test]
+fn imported_numeric_state_field_uses_declared_account_type() {
+    let mut parsed = crate::chumsky_adapter::parse_str(
+        r#"
+spec ImportedCounterGuard
+
+program_id "11111111111111111111111111111111"
+
+type State = {
+  counter : U64,
+}
+
+type Error
+  | CounterMismatch
+
+handler check_counter {
+  permissionless
+  accounts {
+    registry : writable
+  }
+  requires registry.counter == state.counter else CounterMismatch
+}
+"#,
+    )
+    .expect("parse");
+    let registry = parsed.handlers[0]
+        .accounts
+        .iter_mut()
+        .find(|a| a.name == "registry")
+        .expect("registry binding");
+    registry.imported_namespace = Some("Registry".to_string());
+    registry.account_type = Some("CounterConfig".to_string());
+    parsed.imported_namespaces.insert(
+        "Registry".to_string(),
+        crate::check::ImportedNamespace {
+            dep_key: "registry".to_string(),
+            account_types: vec![
+                crate::check::ParsedAccountType {
+                    name: "WrongFirstMatch".to_string(),
+                    fields: vec![("counter".to_string(), "Bool".to_string())],
+                    lifecycle: Vec::new(),
+                    pda_ref: None,
+                    variants: Vec::new(),
+                },
+                crate::check::ParsedAccountType {
+                    name: "CounterConfig".to_string(),
+                    fields: vec![("counter".to_string(), "U64".to_string())],
+                    lifecycle: Vec::new(),
+                    pda_ref: None,
+                    variants: Vec::new(),
+                },
+            ],
+            records: Vec::new(),
+        },
+    );
+    let mir = crate::mir::lower(&parsed);
+    let out = render(&mir, &parsed);
+
+    assert!(
+        out.contains("registry_counter: u64,"),
+        "numeric imported field must use the declared account type:\n{out}"
+    );
+    assert!(
+        out.contains("accounts.registry_counter == s.counter"),
+        "guard must read the typed symbolic env member:\n{out}"
+    );
+    assert!(
+        !out.contains("registry_counter: [u8; 32],"),
+        "numeric imported field must not fall back to Pubkey:\n{out}"
+    );
+}
+
 /// #326 — single-account ADT spec with a variant-dropping transition:
 /// the flat carrier gains the `state_repr_valid` invariant, symbolic
 /// inits assume it, the dropping transition resets the dropped field,

--- a/crates/qedgen/src/codegen/kani_mir/tests.rs
+++ b/crates/qedgen/src/codegen/kani_mir/tests.rs
@@ -81,6 +81,36 @@ fn lower_inline(src: &str) -> (Mir, ParsedSpec) {
     (mir, parsed)
 }
 
+/// #337 — dotted cross-program auth (`auth admin_config.admin`) reads an
+/// imported account's state field. The Kani model must bind it as a
+/// flattened symbolic member on the account-env struct and route the
+/// guard through it — never emit the bare (unbound) identifier.
+#[test]
+fn imported_state_field_guard_binds_symbolic_env_member() {
+    let (mir, parsed) = lower_fixture("examples/rust/cross-program-vault/vault.qedspec");
+    let out = render(&mir, &parsed);
+
+    // Env struct member, typed from the imported AdminConfig.State.admin.
+    assert!(
+        out.contains("admin_config_admin: [u8; 32],"),
+        "flattened env member missing:\n{out}"
+    );
+    // Binding site mirrors the struct.
+    assert!(
+        out.contains("admin_config_admin: kani::any(),"),
+        "symbolic binding missing:\n{out}"
+    );
+    // Guard routes through the env; the bare identifier must be gone.
+    assert!(
+        out.contains("accounts.admin_config_admin == accounts.admin.pubkey"),
+        "guard must read the env member:\n{out}"
+    );
+    assert!(
+        !out.contains("(admin_config.admin"),
+        "bare unbound identifier must not appear:\n{out}"
+    );
+}
+
 /// #326 — single-account ADT spec with a variant-dropping transition:
 /// the flat carrier gains the `state_repr_valid` invariant, symbolic
 /// inits assume it, the dropping transition resets the dropped field,

--- a/crates/qedgen/src/codegen/rust_codegen_util/effect.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/effect.rs
@@ -8,6 +8,7 @@ pub fn handler_needs_account_env(op: &ParsedHandler) -> bool {
     op.requires
         .iter()
         .any(|r| mentions_handler_account_pubkey(&r.rust_expr, &op.accounts))
+        || !collect_account_state_field_reads(op).is_empty()
         || op
             .effects
             .iter()
@@ -19,6 +20,36 @@ pub fn handler_needs_account_env(op: &ParsedHandler) -> bool {
                     .any(|e| is_account_pubkey_ref(e.value.trim(), &op.accounts))
             })
         })
+}
+
+/// Handler-account *state-field* reads in the requires clauses (#337):
+/// `admin_config.admin` reads the imported account's state, not its
+/// address. The Kani model carries each as a flattened symbolic member on
+/// the handler's account-env struct (`accounts.admin_config_admin`) —
+/// external state has no model identity beyond "some value", and without
+/// a binding the identifier is free and the harness cannot compile.
+/// Returns sorted, deduplicated `(account, field)` pairs.
+pub fn collect_account_state_field_reads(op: &ParsedHandler) -> Vec<(String, String)> {
+    use crate::mir::expr_tree::{BindingKind, ExprTree, TreeSeg};
+
+    let mut refs = std::collections::BTreeSet::new();
+    for req in &op.requires {
+        let Some(tree) = req.tree.as_ref() else {
+            continue;
+        };
+        tree.for_each_node(&mut |node| {
+            if let ExprTree::Path(p) = node {
+                if p.binding == BindingKind::Account {
+                    if let [TreeSeg::Field(f)] = p.segments.as_slice() {
+                        if f != "pubkey" {
+                            refs.insert((p.root.clone(), f.clone()));
+                        }
+                    }
+                }
+            }
+        });
+    }
+    refs.into_iter().collect()
 }
 
 pub fn handler_account_env_struct_name(op_name: &str) -> String {

--- a/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tree_render.rs
@@ -625,13 +625,19 @@ fn render_path(p: &TreePath, cx: RustCx, inside_old: bool) -> String {
                 }
             }
             // Pubkey reads route through the generated account env when
-            // one is bound (`owner.pubkey` → `accounts.owner.pubkey`) —
-            // scoped to the exact `.pubkey` shape the legacy string
-            // rewrite handled; other account projections pass through.
+            // one is bound (`owner.pubkey` → `accounts.owner.pubkey`).
+            // Account *state-field* reads (`admin_config.admin` — the
+            // imported account's state, not its address) route to the
+            // flattened symbolic member the env struct carries for them
+            // (#337: `accounts.admin_config_admin`); without the binding
+            // the identifier is free and the harness cannot compile.
+            // Deeper projections pass through unchanged.
             if let (Some(env), [TreeSeg::Field(f)]) = (cx.acct_env, p.segments.as_slice()) {
                 if f == "pubkey" {
                     out.push_str(env);
                     out.push('.');
+                } else {
+                    return format!("{env}.{}_{}", p.root, f);
                 }
             }
             out.push_str(&p.root);

--- a/crates/qedgen/tests/snapshots/cross-program-vault.kani.rs
+++ b/crates/qedgen/tests/snapshots/cross-program-vault.kani.rs
@@ -52,6 +52,7 @@ struct EmergencyCloseAccounts {
     sink_ta: KaniAccount,
     token_program: KaniAccount,
     admin_config: KaniAccount,
+    admin_config_admin: [u8; 32],
 }
 
 // ============================================================================
@@ -86,7 +87,7 @@ fn deposit(s: &mut State, amount: u64) -> bool {
 }
 
 fn emergency_close(s: &mut State, accounts: &EmergencyCloseAccounts) -> bool {
-    if !(admin_config.admin == accounts.admin.pubkey) {
+    if !(accounts.admin_config_admin == accounts.admin.pubkey) {
         return false;
     }
     if s.status != Status::Active {
@@ -149,8 +150,9 @@ fn verify_emergency_close_rejects_invalid() {
         admin_config: KaniAccount {
             pubkey: kani::any(),
         },
+        admin_config_admin: kani::any(),
     };
-    kani::assume(!(admin_config.admin == accounts.admin.pubkey));
+    kani::assume(!(accounts.admin_config_admin == accounts.admin.pubkey));
     kani::cover!(true, "guard-violation domain is satisfiable");
     assert!(
         !emergency_close(&mut s, &accounts),
@@ -214,6 +216,7 @@ fn verify_emergency_close_effect_total_deposits() {
         admin_config: KaniAccount {
             pubkey: kani::any(),
         },
+        admin_config_admin: kani::any(),
     };
     if emergency_close(&mut s, &accounts) {
         assert!(s.total_deposits == 0, "total_deposits must equal 0");


### PR DESCRIPTION
**Stacked on #338** (`feat/326-kani-adt-state`) — merge #338 first; this PR shares the cross-program-vault snapshot #338 introduced. After #338 merges, retarget this to main via `gh api -X PATCH .../pulls/<n> -f base=main`.

## Problem

Dotted cross-program auth (`auth admin_config.admin`) desugars to a requires clause reading an imported account's *state field*. The Kani model rendered the identifier verbatim — unbound — so the generated harness could not compile:

```rust
fn emergency_close(s: &mut State, accounts: &EmergencyCloseAccounts) -> bool {
    if !(admin_config.admin == accounts.admin.pubkey) {  // E0425: unresolved
```

This is why `cross-program-vault` had no Kani snapshot or artifact-gate entry, and guard obligations recorded `emitted` described code that could not build.

## Fix

External state has no model identity beyond "some value", so each read becomes a flattened symbolic member on the handler's account-env struct:

- **`collect_account_state_field_reads`** — structural walk over the requires trees (`ExprTree::for_each_node`, the #325 walker) for Account-rooted single-field reads that are not `.pubkey`.
- **Env struct + binding** — one member per read (`admin_config_admin: [u8; 32]`), typed by resolving the account binding's declared type through `mir.imports` (`AdminConfig.State.admin : Pubkey`), bound to `kani::any()`. Env detection now fires for handlers whose only account reference is a state-field read.
- **Tree renderer** — under an account env, `<acct>.<field>` renders as `accounts.<acct>_<field>`; `.pubkey` reads keep their existing routing; deeper projections pass through unchanged.

The guard now reads `accounts.admin_config_admin == accounts.admin.pubkey` and the vault harness type-checks against the kani compile stub (`cargo rustc --test kani -- --cfg kani`), verified locally.

## Tests

- Unit test pins the env member, the binding, the rewritten guard, and the absence of the bare identifier.
- Snapshot delta is vault-only (+5/−2); all flat-spec output byte-identical.
- Full suite green (35/35); clippy and fmt clean.

The Lean side of the same gap (dropped authorization clauses) is #328, tracked separately.

Closes #337