### PR TITLE
feat(kani): product-state module lowers multi-account file-level features (#324)

### DIFF
--- a/crates/qedgen/src/codegen/kani_mir/account.rs
+++ b/crates/qedgen/src/codegen/kani_mir/account.rs
@@ -12,6 +12,7 @@ pub(crate) fn emit_account_section_structural(
     out: &mut String,
     mir: &Mir,
     parsed: &ParsedSpec,
+    vis: &str,
 ) -> Result<()> {
     use crate::codegen_shared::map_type;
     use crate::rust_codegen_util as util;
@@ -31,16 +32,22 @@ pub(crate) fn emit_account_section_structural(
     let mutable = util::field_refs(state_fields);
     let has_lifecycle = lifecycle.len() >= 2;
 
-    util::emit_record_structs(out, parsed, "Clone, Copy, kani::Arbitrary", |t| {
+    util::emit_record_structs(out, parsed, "Clone, Copy, kani::Arbitrary", vis, |t| {
         map_type(t, parsed)
     })?;
 
-    util::emit_unit_enum_sums(out, parsed, "Clone, Copy, PartialEq, Eq, kani::Arbitrary")?;
+    util::emit_unit_enum_sums(
+        out,
+        parsed,
+        "Clone, Copy, PartialEq, Eq, kani::Arbitrary",
+        vis,
+    )?;
 
     util::emit_lifecycle_status_enum_from(
         out,
         lifecycle,
         "Clone, Copy, PartialEq, Eq, kani::Arbitrary",
+        vis,
     );
 
     util::emit_state_struct_with_lifecycle(
@@ -49,6 +56,7 @@ pub(crate) fn emit_account_section_structural(
         "Clone, Copy",
         |t| map_type(t, parsed),
         has_lifecycle,
+        vis,
     )?;
     // #326 — ADT specs get the `state_repr_valid` invariant alongside the
     // flat struct; harness preambles assume it and transitions preserve it.
@@ -71,7 +79,7 @@ pub(crate) fn emit_account_section_structural(
         // `&[&_]` — rebuild an owned Vec.
         let owned: Vec<crate::check::ParsedProperty> =
             properties.iter().map(|p| (*p).clone()).collect();
-        util::emit_property_predicates_with(out, &owned, |t| map_type(t, parsed));
+        util::emit_property_predicates_with(out, &owned, vis, |t| map_type(t, parsed));
     }
 
     // Invariant predicates — only those linked from a handler in this section.
@@ -96,7 +104,7 @@ pub(crate) fn emit_account_section_structural(
         out.push_str(
             "// ============================================================================\n\n",
         );
-        util::emit_invariant_predicates(out, &linked_invs);
+        util::emit_invariant_predicates(out, &linked_invs, vis);
     }
 
     out.push_str(
@@ -110,7 +118,9 @@ pub(crate) fn emit_account_section_structural(
         "// ============================================================================\n\n",
     );
     for op in &handlers {
-        util::emit_transition_fn_for_kani(out, mir, op, parsed, false, |t| map_type(t, parsed))?;
+        util::emit_transition_fn_for_kani(out, mir, op, parsed, false, vis, |t| {
+            map_type(t, parsed)
+        })?;
     }
 
     // Reference implementations — pure-expression fns callable from

--- a/crates/qedgen/src/codegen/kani_mir/conformance.rs
+++ b/crates/qedgen/src/codegen/kani_mir/conformance.rs
@@ -840,7 +840,7 @@ pub(crate) fn emit_file_level_features(
 /// constraint over `state.x` once the environment has external fields, which
 /// forces the two-state (`PrePost`) binder. The caller must emit exactly the
 /// bindings the constraints reference, or the harness fails to compile.
-fn render_environment_constraints(
+pub(crate) fn render_environment_constraints(
     mir_env: Option<&crate::mir::EnvironmentMir>,
     has_external_fields: bool,
 ) -> (Vec<String>, bool, bool) {

--- a/crates/qedgen/src/codegen/kani_mir/driver.rs
+++ b/crates/qedgen/src/codegen/kani_mir/driver.rs
@@ -101,7 +101,7 @@ pub(crate) fn render_inner(
 
     if parsed.account_types.len() > 1 {
         // Multi-account: per-account `mod <lowercase>` blocks; file-level
-        // features (covers / liveness / env) emit in single mode only.
+        // features lower once over the product-state module (#324).
         if let Err(e) =
             emit_multi_account_sections(&mut out, mir, parsed, progress, skip_guard_proofs, rec)
         {
@@ -143,7 +143,7 @@ pub(crate) fn emit_single_account_sections(
     if progress {
         eprintln!("Rendering Kani section: state model");
     }
-    emit_account_section_structural(out, mir, parsed)?;
+    emit_account_section_structural(out, mir, parsed, crate::rust_codegen_util::VIS_PRIVATE)?;
     if skip_guard_proofs {
         if progress {
             eprintln!(
@@ -178,8 +178,8 @@ pub(crate) fn emit_single_account_sections(
         eprintln!("Rendering Kani section: overflow proofs");
     }
     emit_overflow_detection_harnesses(out, mir, parsed, rec)?;
-    // File-level features (covers / liveness / environment) —
-    // single-mode only; multi-account specs skip these entirely.
+    // File-level features (covers / liveness / environment) — the
+    // multi-account path lowers these over the product module instead.
     if progress {
         eprintln!("Rendering Kani section: cover/liveness/environment proofs");
     }
@@ -190,8 +190,9 @@ pub(crate) fn emit_single_account_sections(
 /// Multi-account dispatch — one `mod <lowercase> { use super::*; ... }`
 /// per account_type, each driven by a per-account scoped `ParsedSpec`
 /// (see `scope_parsed_to_account`). Sections follow the same order as
-/// single-mode; file-level features (covers / liveness / environment)
-/// are not emitted in multi-mode at all.
+/// single-mode. File-level features (covers / liveness / environment)
+/// are lowered once, over the product-state module (#324); shapes the
+/// product lowering cannot resolve stay `unsupported` in the manifest.
 pub(crate) fn emit_multi_account_sections(
     out: &mut String,
     mir: &Mir,
@@ -201,6 +202,8 @@ pub(crate) fn emit_multi_account_sections(
     rec: &mut ObligationRecorder,
 ) -> Result<()> {
     use crate::rust_codegen_util as util;
+
+    let mut components: Vec<product::ProductComponent> = Vec::new();
 
     for acct in &parsed.account_types {
         let acct_fields_view = util::field_refs(&acct.fields);
@@ -233,7 +236,7 @@ pub(crate) fn emit_multi_account_sections(
         out.push_str(&format!("mod {} {{\n", mod_name));
         out.push_str("    use super::*;\n\n");
 
-        emit_account_section_structural(out, mir, &scoped)?;
+        emit_account_section_structural(out, mir, &scoped, util::VIS_PUB)?;
         if skip_guard_proofs {
             if progress {
                 eprintln!(
@@ -250,44 +253,20 @@ pub(crate) fn emit_multi_account_sections(
         emit_overflow_detection_harnesses(out, mir, &scoped, rec)?;
 
         out.push_str(&format!("}} // mod {}\n\n", mod_name));
+
+        components.push(product::ProductComponent {
+            acct: acct.clone(),
+            mod_name,
+            scoped_handlers: scoped.handlers.clone(),
+        });
     }
 
-    // #324 — file-level features (covers / liveness / environment) are
-    // never lowered in multi-account mode: a trace may span accounts and
-    // per-account duplication would change its semantics. Report every
-    // requested file-level obligation as unsupported instead of letting
-    // it disappear.
-    for cover in &parsed.covers {
-        for i in 0..cover.traces.len() {
-            rec.unsupported(
-                ObligationKind::Cover,
-                "file",
-                &format!("{}::{}", cover.name, i),
-                UnsupportedReason::KaniMultiAccountFileLevel,
-            );
-        }
-    }
-    for liveness in &parsed.liveness_props {
-        rec.unsupported(
-            ObligationKind::Liveness,
-            "file",
-            &liveness.name,
-            UnsupportedReason::KaniMultiAccountFileLevel,
-        );
-    }
-    for env in &parsed.environments {
-        for prop in &parsed.properties {
-            if prop.expression.is_none() {
-                continue;
-            }
-            rec.unsupported(
-                ObligationKind::Environment,
-                "file",
-                &format!("{}::{}", prop.name, env.name),
-                UnsupportedReason::KaniMultiAccountFileLevel,
-            );
-        }
-    }
+    // #324 — file-level features (covers / liveness / environment) lower
+    // once, over the product-state module: per-account duplication would
+    // change trace semantics. Obligations the product lowering cannot
+    // resolve to modeled components are recorded unsupported there — a
+    // requested obligation never disappears silently.
+    product::emit_product_module(out, mir, parsed, &components, progress, rec)?;
 
     Ok(())
 }

--- a/crates/qedgen/src/codegen/kani_mir/mod.rs
+++ b/crates/qedgen/src/codegen/kani_mir/mod.rs
@@ -4,9 +4,10 @@
 //!
 //! `generate` emits: structural prefix (banner / math helpers / state-model
 //! header / file-scoped constants), per-account sections (multi-account wraps
-//! each in `mod <lowercase>`; covers/liveness/env emit in single mode only),
-//! then the `DO NOT EDIT BELOW` footer. sBPF specs never reach this module —
-//! `qedgen codegen --kani` skips assembly targets (Lean + client tests instead).
+//! each in `mod <lowercase>` and lowers covers/liveness/env once over the
+//! `mod product` state, #324), then the `DO NOT EDIT BELOW` footer. sBPF
+//! specs never reach this module — `qedgen codegen --kani` skips assembly
+//! targets (Lean + client tests instead).
 
 use anyhow::Result;
 use std::path::Path;
@@ -26,6 +27,7 @@ mod driver;
 mod guards;
 mod prefix;
 mod preservation;
+mod product;
 
 pub(crate) use account::*;
 pub(crate) use conformance::*;

--- a/crates/qedgen/src/codegen/kani_mir/product.rs
+++ b/crates/qedgen/src/codegen/kani_mir/product.rs
@@ -1,0 +1,779 @@
+//! #324 — product-state lowering for multi-account file-level features.
+//!
+//! Covers, liveness, and environment obligations are spec-global: a trace
+//! may step handlers routed to different accounts, so per-account
+//! duplication would change its semantics. This module lowers them ONCE,
+//! over a `ProductState` that holds one component per emitted account
+//! module and delegates every transition to the per-account transition
+//! fn — the product model adds no second copy of transition semantics.
+//!
+//! Shapes the lowering cannot resolve to modeled components stay
+//! `unsupported(kani_multi_account_file_level)` in the obligation
+//! manifest, with a structured comment in the artifact — a requested
+//! obligation never disappears silently (#332 contract).
+//!
+//! Deliberate scope limits (each records unsupported, never guesses):
+//!   * handlers needing a symbolic account env (their env structs live
+//!     inside the account module and the binding emitter is unqualified);
+//!   * handler params typed as spec records / sums (those types are
+//!     emitted per account module and are not nameable here);
+//!   * properties that resolve to zero or multiple account components;
+//!   * ghost-reading properties and ghost-mutating environments — the
+//!     product ghost component lands with #331.
+
+use super::*;
+use crate::obligations::{ObligationKind, ObligationRecorder, UnsupportedReason};
+
+/// One emitted per-account module, as seen by the product lowering.
+/// `scoped_handlers` is captured from the scoped spec the account module
+/// was ACTUALLY emitted from, so routing here can never drift from what
+/// `scope_parsed_to_account` decided.
+pub(crate) struct ProductComponent {
+    pub acct: crate::check::ParsedAccountType,
+    pub mod_name: String,
+    pub scoped_handlers: Vec<crate::check::ParsedHandler>,
+}
+
+impl ProductComponent {
+    /// Component state fields as the account module's `State` declares
+    /// them: account fields plus spec ghosts (the structural emitter
+    /// chains ghosts into every per-account State).
+    fn state_fields(&self, parsed: &ParsedSpec) -> Vec<(String, String)> {
+        self.acct
+            .fields
+            .iter()
+            .cloned()
+            .chain(parsed.ghosts.iter().map(|g| (g.name.clone(), g.ty.clone())))
+            .collect()
+    }
+
+    fn has_lifecycle(&self) -> bool {
+        self.acct.lifecycle.len() >= 2
+    }
+}
+
+/// A handler the product module can wrap: routed to an emitted component
+/// and free of the shapes listed in the module doc.
+struct WrappedHandler<'a> {
+    op: &'a crate::check::ParsedHandler,
+    component_mod: &'a str,
+}
+
+pub(crate) fn emit_product_module(
+    out: &mut String,
+    mir: &Mir,
+    parsed: &ParsedSpec,
+    components: &[ProductComponent],
+    progress: bool,
+    rec: &mut ObligationRecorder,
+) -> Result<()> {
+    if parsed.covers.is_empty()
+        && parsed.liveness_props.is_empty()
+        && parsed.environments.is_empty()
+    {
+        return Ok(());
+    }
+    if progress {
+        eprintln!("Rendering Kani product-state module (file-level features)");
+    }
+
+    let wrappable = resolve_wrappable(parsed, components);
+    let cover_plans = plan_covers(parsed, &wrappable);
+    let liveness_plans = plan_liveness(parsed, components, &wrappable);
+    let env_plans = plan_environments(parsed, components);
+
+    // Wrappers are emitted only for handlers a lowered harness calls.
+    let mut wrapper_names: Vec<&str> = Vec::new();
+    for plan in &cover_plans {
+        if let CoverPlan::Lower { trace_ops, .. } = plan {
+            wrapper_names.extend(trace_ops.iter().map(|w| w.op.name.as_str()));
+        }
+    }
+    for plan in &liveness_plans {
+        if let LivenessPlan::Lower { via, .. } = plan {
+            wrapper_names.extend(via.iter().map(|w| w.op.name.as_str()));
+        }
+    }
+    wrapper_names.sort_unstable();
+    wrapper_names.dedup();
+
+    let any_product_harness = !wrapper_names.is_empty();
+    let any_env_harness = env_plans.iter().any(|p| p.owner.is_ok());
+    let any_lowered = any_product_harness || any_env_harness;
+
+    out.push_str(
+        "// ============================================================================\n",
+    );
+    out.push_str("// Product state (#324) — file-level covers / liveness / environment\n");
+    out.push_str("// lowered once over the per-account components; transitions delegate\n");
+    out.push_str("// to the account modules so there is no second copy of the semantics.\n");
+    out.push_str(
+        "// ============================================================================\n\n",
+    );
+    out.push_str("mod product {\n");
+    if any_lowered {
+        out.push_str("    use super::*;\n\n");
+    }
+
+    if any_product_harness {
+        emit_product_state_struct(out, components);
+        emit_wrappers(out, parsed, &wrapper_names, &wrappable)?;
+    }
+
+    emit_covers(out, parsed, components, &cover_plans, rec)?;
+    emit_liveness(out, parsed, components, &liveness_plans, rec)?;
+    emit_environments(out, mir, parsed, components, &env_plans, rec)?;
+
+    out.push_str("} // mod product\n\n");
+    Ok(())
+}
+
+// ── Resolution ──────────────────────────────────────────────────────
+
+/// Collect the wrappable handlers. A handler is wrappable when it is
+/// routed to an emitted component, needs no symbolic account env, and
+/// every param type renders without naming a module-scoped record / sum.
+fn resolve_wrappable<'a>(
+    parsed: &'a ParsedSpec,
+    components: &'a [ProductComponent],
+) -> Vec<WrappedHandler<'a>> {
+    use crate::rust_codegen_util as util;
+
+    let module_scoped_types: Vec<&str> = parsed
+        .records
+        .iter()
+        .map(|r| r.name.as_str())
+        .chain(parsed.sum_types.iter().map(|s| s.name.as_str()))
+        .collect();
+
+    let mut out = Vec::new();
+    for comp in components {
+        for op in &comp.scoped_handlers {
+            if util::handler_needs_account_env(op) {
+                continue;
+            }
+            let param_types_ok = op
+                .takes_params
+                .iter()
+                .chain(op.abstract_binders.iter())
+                .all(|(_, t)| !module_scoped_types.contains(&t.as_str()));
+            if !param_types_ok {
+                continue;
+            }
+            out.push(WrappedHandler {
+                op,
+                component_mod: &comp.mod_name,
+            });
+        }
+    }
+    out
+}
+
+fn wrapped<'a, 'b>(
+    wrappable: &'b [WrappedHandler<'a>],
+    name: &str,
+) -> Option<&'b WrappedHandler<'a>> {
+    wrappable.iter().find(|w| w.op.name == name)
+}
+
+enum CoverPlan<'a> {
+    Lower {
+        cover_name: &'a str,
+        trace_index: usize,
+        trace_ops: Vec<&'a WrappedHandler<'a>>,
+        multi_trace: bool,
+    },
+    Unsupported {
+        cover_name: &'a str,
+        trace_index: usize,
+        why: String,
+    },
+}
+
+fn plan_covers<'a>(
+    parsed: &'a ParsedSpec,
+    wrappable: &'a [WrappedHandler<'a>],
+) -> Vec<CoverPlan<'a>> {
+    let mut plans = Vec::new();
+    for cover in &parsed.covers {
+        for (i, trace) in cover.traces.iter().enumerate() {
+            let mut ops = Vec::with_capacity(trace.len());
+            let mut missing: Option<String> = None;
+            for op_name in trace {
+                match wrapped(wrappable, op_name) {
+                    Some(w) => ops.push(w),
+                    None => {
+                        missing = Some(op_name.clone());
+                        break;
+                    }
+                }
+            }
+            plans.push(match missing {
+                None => CoverPlan::Lower {
+                    cover_name: &cover.name,
+                    trace_index: i,
+                    trace_ops: ops,
+                    multi_trace: cover.traces.len() > 1,
+                },
+                Some(op_name) => CoverPlan::Unsupported {
+                    cover_name: &cover.name,
+                    trace_index: i,
+                    why: format!("trace op `{}` has no product wrapper", op_name),
+                },
+            });
+        }
+    }
+    plans
+}
+
+enum LivenessPlan<'a> {
+    Lower {
+        liveness: &'a crate::check::ParsedLiveness,
+        owner_index: usize,
+        via: Vec<&'a WrappedHandler<'a>>,
+    },
+    Unsupported {
+        liveness: &'a crate::check::ParsedLiveness,
+        why: String,
+    },
+}
+
+fn plan_liveness<'a>(
+    parsed: &'a ParsedSpec,
+    components: &'a [ProductComponent],
+    wrappable: &'a [WrappedHandler<'a>],
+) -> Vec<LivenessPlan<'a>> {
+    let mut plans = Vec::new();
+    for liveness in &parsed.liveness_props {
+        // Owner = the unique component whose lifecycle declares BOTH
+        // endpoint states. The adapter strips `Loan.Active` to `Active`,
+        // so ambiguity across components is detectable, not resolvable.
+        let owners: Vec<usize> = components
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| {
+                c.has_lifecycle()
+                    && c.acct.lifecycle.contains(&liveness.from_state)
+                    && c.acct.lifecycle.contains(&liveness.leads_to_state)
+            })
+            .map(|(i, _)| i)
+            .collect();
+        let plan = match owners.as_slice() {
+            [owner_index] => {
+                let mut via = Vec::with_capacity(liveness.via_ops.len());
+                let mut missing: Option<String> = None;
+                for op_name in &liveness.via_ops {
+                    match wrapped(wrappable, op_name) {
+                        Some(w) => via.push(w),
+                        None => {
+                            missing = Some(op_name.clone());
+                            break;
+                        }
+                    }
+                }
+                match missing {
+                    None => LivenessPlan::Lower {
+                        liveness,
+                        owner_index: *owner_index,
+                        via,
+                    },
+                    Some(op_name) => LivenessPlan::Unsupported {
+                        liveness,
+                        why: format!("via op `{}` has no product wrapper", op_name),
+                    },
+                }
+            }
+            [] => LivenessPlan::Unsupported {
+                liveness,
+                why: format!(
+                    "no modeled account lifecycle declares both `{}` and `{}`",
+                    liveness.from_state, liveness.leads_to_state
+                ),
+            },
+            _ => LivenessPlan::Unsupported {
+                liveness,
+                why: format!(
+                    "states `{}` ~> `{}` are ambiguous across account lifecycles",
+                    liveness.from_state, liveness.leads_to_state
+                ),
+            },
+        };
+        plans.push(plan);
+    }
+    plans
+}
+
+struct EnvPlan<'a> {
+    env: &'a crate::check::ParsedEnvironment,
+    prop: &'a crate::check::ParsedProperty,
+    owner: std::result::Result<usize, String>,
+}
+
+fn plan_environments<'a>(
+    parsed: &'a ParsedSpec,
+    components: &'a [ProductComponent],
+) -> Vec<EnvPlan<'a>> {
+    let mut plans = Vec::new();
+    for env in &parsed.environments {
+        for prop in &parsed.properties {
+            if prop.expression.is_none() {
+                continue;
+            }
+            plans.push(EnvPlan {
+                env,
+                prop,
+                owner: resolve_env_owner(parsed, components, env, prop),
+            });
+        }
+    }
+    plans
+}
+
+/// The environment harness runs over ONE component: the property and every
+/// mutated field must resolve to the same account, and nothing may touch a
+/// ghost (#331 owns the product ghost component).
+fn resolve_env_owner(
+    parsed: &ParsedSpec,
+    components: &[ProductComponent],
+    env: &crate::check::ParsedEnvironment,
+    prop: &crate::check::ParsedProperty,
+) -> std::result::Result<usize, String> {
+    if prop.class == crate::check::PropertyClass::Binary {
+        return Err("binary (old/new) properties are not lowered over a component".into());
+    }
+    let Some(rust) = prop.rust_expression.as_deref() else {
+        return Err("property has no Rust-renderable body".into());
+    };
+    if parsed
+        .ghosts
+        .iter()
+        .any(|g| references_state_field(rust, &g.name))
+    {
+        return Err("property reads a spec-global ghost (#331)".into());
+    }
+
+    let owners: Vec<usize> = components
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| {
+            c.acct
+                .fields
+                .iter()
+                .any(|(f, _)| references_state_field(rust, f))
+        })
+        .map(|(i, _)| i)
+        .collect();
+    let [owner_index] = owners.as_slice() else {
+        return Err(if owners.is_empty() {
+            "property references no modeled account field".to_string()
+        } else {
+            "property references fields of more than one account".to_string()
+        });
+    };
+    let owner = &components[*owner_index];
+
+    // The per-account module only emits predicates for properties its
+    // scoping filter kept — require membership so `<mod>::<prop>` exists.
+    let scoped_has_prop = prop
+        .expression
+        .as_deref()
+        .map(|expr| {
+            owner
+                .acct
+                .fields
+                .iter()
+                .any(|(f, _)| expr.contains(f.as_str()))
+        })
+        .unwrap_or(false);
+    if !scoped_has_prop {
+        return Err(format!(
+            "property predicate is not emitted in mod {}",
+            owner.mod_name
+        ));
+    }
+
+    for (field, _) in &env.mutates {
+        if parsed.ghosts.iter().any(|g| &g.name == field) {
+            return Err("environment mutates a spec-global ghost (#331)".into());
+        }
+        if !owner.acct.fields.iter().any(|(f, _)| f == field) {
+            return Err(format!(
+                "environment mutates `{}`, which is not a field of the property's account",
+                field
+            ));
+        }
+    }
+    Ok(*owner_index)
+}
+
+// ── Structural emission ─────────────────────────────────────────────
+
+fn emit_product_state_struct(out: &mut String, components: &[ProductComponent]) {
+    out.push_str("    struct ProductState {\n");
+    for comp in components {
+        out.push_str(&format!(
+            "        {}: {}::State,\n",
+            comp.mod_name, comp.mod_name
+        ));
+    }
+    out.push_str("    }\n\n");
+}
+
+fn emit_wrappers(
+    out: &mut String,
+    parsed: &ParsedSpec,
+    wrapper_names: &[&str],
+    wrappable: &[WrappedHandler],
+) -> Result<()> {
+    use crate::codegen_shared::map_type;
+
+    out.push_str("    // Transition wrappers — delegate to the owning account module.\n");
+    for name in wrapper_names {
+        let w = wrapped(wrappable, name).expect("wrapper_names built from wrappable");
+        let mut params = String::new();
+        let mut args = String::new();
+        for (n, t) in w.op.takes_params.iter().chain(w.op.abstract_binders.iter()) {
+            params.push_str(&format!(", {}: {}", n, map_type(t, parsed)?));
+            args.push_str(&format!(", {}", n));
+        }
+        out.push_str(&format!(
+            "    fn {}(s: &mut ProductState{}) -> bool {{\n",
+            w.op.name, params
+        ));
+        out.push_str(&format!(
+            "        {}::{}(&mut s.{}{})\n",
+            w.component_mod, w.op.name, w.component_mod, args
+        ));
+        out.push_str("    }\n\n");
+    }
+    Ok(())
+}
+
+/// `let mut s = ProductState { <comp>: <comp>::State { … kani::any() … }, … };`
+fn emit_product_state_init_symbolic(
+    out: &mut String,
+    parsed: &ParsedSpec,
+    components: &[ProductComponent],
+) {
+    use crate::rust_codegen_util as util;
+
+    out.push_str("        let mut s = ProductState {\n");
+    for comp in components {
+        out.push_str(&format!(
+            "            {}: {}::State {{\n",
+            comp.mod_name, comp.mod_name
+        ));
+        let fields = comp.state_fields(parsed);
+        for (fname, _) in util::field_refs(&fields) {
+            out.push_str(&format!("                {}: kani::any(),\n", fname));
+        }
+        if comp.has_lifecycle() && !fields.iter().any(|(n, _)| n == "status") {
+            out.push_str("                status: kani::any(),\n");
+        }
+        out.push_str("            },\n");
+    }
+    out.push_str("        };\n");
+}
+
+/// `let mut s = <mod>::State { … kani::any() … };` — the single-component
+/// symbolic init used by environment harnesses, whose property + mutated
+/// fields all resolve to one account.
+fn emit_component_state_init_symbolic(
+    out: &mut String,
+    parsed: &ParsedSpec,
+    comp: &ProductComponent,
+) {
+    use crate::rust_codegen_util as util;
+
+    out.push_str(&format!(
+        "        let mut s = {}::State {{\n",
+        comp.mod_name
+    ));
+    let fields = comp.state_fields(parsed);
+    for (fname, _) in util::field_refs(&fields) {
+        out.push_str(&format!("            {}: kani::any(),\n", fname));
+    }
+    if comp.has_lifecycle() && !fields.iter().any(|(n, _)| n == "status") {
+        out.push_str("            status: kani::any(),\n");
+    }
+    out.push_str("        };\n");
+}
+
+fn emit_harness_attrs(out: &mut String, name: &str, unwind: usize) {
+    out.push_str("    #[kani::proof]\n");
+    out.push_str(&format!("    #[kani::unwind({})]\n", unwind));
+    out.push_str("    #[kani::solver(cadical)]\n");
+    out.push_str(&format!("    fn {}() {{\n", name));
+}
+
+// ── Covers ──────────────────────────────────────────────────────────
+
+fn emit_covers(
+    out: &mut String,
+    parsed: &ParsedSpec,
+    components: &[ProductComponent],
+    plans: &[CoverPlan],
+    rec: &mut ObligationRecorder,
+) -> Result<()> {
+    use crate::codegen_shared::map_type;
+
+    for plan in plans {
+        match plan {
+            CoverPlan::Unsupported {
+                cover_name,
+                trace_index,
+                why,
+            } => {
+                rec.unsupported(
+                    ObligationKind::Cover,
+                    "file",
+                    &format!("{}::{}", cover_name, trace_index),
+                    UnsupportedReason::KaniMultiAccountFileLevel,
+                );
+                out.push_str(&format!(
+                    "    // cover {} trace {}: not lowered — {}\n\n",
+                    cover_name, trace_index, why
+                ));
+            }
+            CoverPlan::Lower {
+                cover_name,
+                trace_index,
+                trace_ops,
+                multi_trace,
+            } => {
+                let suffix = if *multi_trace {
+                    format!("_{}", trace_index)
+                } else {
+                    String::new()
+                };
+                let harness = format!("cover_{}{}", cover_name, suffix);
+                rec.emitted(
+                    ObligationKind::Cover,
+                    "file",
+                    &format!("{}::{}", cover_name, trace_index),
+                    &harness,
+                );
+                emit_harness_attrs(out, &harness, trace_ops.len() + 1);
+                emit_product_state_init_symbolic(out, parsed, components);
+
+                let mut indent = "        ".to_string();
+                for (j, w) in trace_ops.iter().enumerate() {
+                    for (pname, ptype) in &w.op.takes_params {
+                        out.push_str(&format!(
+                            "{}let {}_{}: {} = kani::any();\n",
+                            indent,
+                            pname,
+                            j,
+                            map_type(ptype, parsed)?
+                        ));
+                    }
+                    let args: String =
+                        w.op.takes_params
+                            .iter()
+                            .map(|(n, _)| format!(", {}_{}", n, j))
+                            .collect();
+                    if j < trace_ops.len() - 1 {
+                        out.push_str(&format!("{}if {}(&mut s{}) {{\n", indent, w.op.name, args));
+                        indent.push_str("    ");
+                    } else {
+                        out.push_str(&format!(
+                            "{}kani::cover!({}(&mut s{}), \"{} trace is reachable\");\n",
+                            indent, w.op.name, args, cover_name
+                        ));
+                    }
+                }
+                for _ in 0..trace_ops.len().saturating_sub(1) {
+                    indent = indent[..indent.len() - 4].to_string();
+                    out.push_str(&format!("{}}}\n", indent));
+                }
+                out.push_str("    }\n\n");
+            }
+        }
+    }
+    Ok(())
+}
+
+// ── Liveness ────────────────────────────────────────────────────────
+
+fn emit_liveness(
+    out: &mut String,
+    parsed: &ParsedSpec,
+    components: &[ProductComponent],
+    plans: &[LivenessPlan],
+    rec: &mut ObligationRecorder,
+) -> Result<()> {
+    use crate::codegen_shared::map_type;
+
+    for plan in plans {
+        match plan {
+            LivenessPlan::Unsupported { liveness, why } => {
+                rec.unsupported(
+                    ObligationKind::Liveness,
+                    "file",
+                    &liveness.name,
+                    UnsupportedReason::KaniMultiAccountFileLevel,
+                );
+                out.push_str(&format!(
+                    "    // liveness {}: not lowered — {}\n\n",
+                    liveness.name, why
+                ));
+            }
+            LivenessPlan::Lower {
+                liveness,
+                owner_index,
+                via,
+            } => {
+                let owner = &components[*owner_index];
+                let bound = liveness.within_steps.unwrap_or(10) as usize;
+                let harness = format!("verify_liveness_{}", liveness.name);
+                rec.emitted(ObligationKind::Liveness, "file", &liveness.name, &harness);
+                emit_harness_attrs(out, &harness, bound + 1);
+                emit_product_state_init_symbolic(out, parsed, components);
+                out.push_str(&format!(
+                    "        kani::assume(s.{}.status == {}::Status::{});\n",
+                    owner.mod_name, owner.mod_name, liveness.from_state
+                ));
+                out.push_str(&format!("        for _ in 0..{} {{\n", bound));
+                out.push_str("            let op: u8 = kani::any();\n");
+                out.push_str("            match op {\n");
+                for (i, w) in via.iter().enumerate() {
+                    out.push_str(&format!("                {} => {{\n", i));
+                    for (n, t) in &w.op.takes_params {
+                        out.push_str(&format!(
+                            "                    let {}: {} = kani::any();\n",
+                            n,
+                            map_type(t, parsed)?
+                        ));
+                    }
+                    let args: String =
+                        w.op.takes_params
+                            .iter()
+                            .chain(w.op.abstract_binders.iter())
+                            .map(|(n, _)| format!(", {}", n))
+                            .collect();
+                    out.push_str(&format!(
+                        "                    {}(&mut s{});\n",
+                        w.op.name, args
+                    ));
+                    out.push_str("                }\n");
+                }
+                out.push_str("                _ => {}\n");
+                out.push_str("            }\n");
+                out.push_str("        }\n");
+                out.push_str(&format!(
+                    "        kani::cover!(s.{}.status == {}::Status::{}, \"{} reaches {} within {} steps\");\n",
+                    owner.mod_name,
+                    owner.mod_name,
+                    liveness.leads_to_state,
+                    liveness.name,
+                    liveness.leads_to_state,
+                    bound
+                ));
+                out.push_str("    }\n\n");
+            }
+        }
+    }
+    Ok(())
+}
+
+// ── Environments ────────────────────────────────────────────────────
+
+fn emit_environments(
+    out: &mut String,
+    mir: &Mir,
+    parsed: &ParsedSpec,
+    components: &[ProductComponent],
+    plans: &[EnvPlan],
+    rec: &mut ObligationRecorder,
+) -> Result<()> {
+    for plan in plans {
+        let key = format!("{}::{}", plan.prop.name, plan.env.name);
+        match &plan.owner {
+            Err(why) => {
+                rec.unsupported(
+                    ObligationKind::Environment,
+                    "file",
+                    &key,
+                    UnsupportedReason::KaniMultiAccountFileLevel,
+                );
+                out.push_str(&format!(
+                    "    // environment {} × property {}: not lowered — {}\n\n",
+                    plan.env.name, plan.prop.name, why
+                ));
+            }
+            Ok(owner_index) => {
+                let owner = &components[*owner_index];
+                let mir_env = mir
+                    .environments
+                    .iter()
+                    .find(|candidate| candidate.name == plan.env.name);
+                let (rust_constraints, needs_pre, needs_post) =
+                    super::render_environment_constraints(
+                        mir_env,
+                        !plan.env.external_fields.is_empty(),
+                    );
+                let harness = format!("verify_{}_under_{}", plan.prop.name, plan.env.name);
+                rec.emitted(ObligationKind::Environment, "file", &key, &harness);
+                emit_harness_attrs(out, &harness, 2);
+                emit_component_state_init_symbolic(out, parsed, owner);
+                out.push_str(&format!(
+                    "        kani::assume({}::{}(&s));\n",
+                    owner.mod_name, plan.prop.name
+                ));
+                if needs_pre {
+                    out.push_str("        let pre = s.clone();\n");
+                }
+                for (object, field, field_type) in &plan.env.external_fields {
+                    let rust_type = crate::codegen_shared::map_type(field_type, parsed)?;
+                    out.push_str(&format!(
+                        "        let pre_{}_{}: {} = kani::any();\n",
+                        object, field, rust_type
+                    ));
+                    out.push_str(&format!(
+                        "        let post_{}_{}: {} = kani::any();\n",
+                        object, field, rust_type
+                    ));
+                }
+                for (field, _ftype) in &plan.env.mutates {
+                    out.push_str(&format!("        s.{} = kani::any();\n", field));
+                }
+                if needs_post {
+                    out.push_str("        let post = &s;\n");
+                }
+                for constraint in &rust_constraints {
+                    out.push_str(&format!("        kani::assume({});\n", constraint));
+                }
+                out.push_str(&format!(
+                    "        assert!({}::{}(&s),\n",
+                    owner.mod_name, plan.prop.name
+                ));
+                out.push_str(&format!(
+                    "            \"{} must hold after {}\");\n",
+                    plan.prop.name, plan.env.name
+                ));
+                out.push_str("    }\n\n");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Word-bounded `s.<name>` reference check (mirrors the proptest-side
+/// helper): `s.total` must not match `s.total_supply`.
+fn references_state_field(rust: &str, name: &str) -> bool {
+    let needle = format!("s.{}", name);
+    let mut start = 0;
+    while let Some(pos) = rust[start..].find(&needle) {
+        let end = start + pos + needle.len();
+        let boundary = rust[end..]
+            .chars()
+            .next()
+            .map(|c| !c.is_alphanumeric() && c != '_')
+            .unwrap_or(true);
+        if boundary {
+            return true;
+        }
+        start = end;
+    }
+    false
+}

--- a/crates/qedgen/src/codegen/kani_mir/product.rs
+++ b/crates/qedgen/src/codegen/kani_mir/product.rs
@@ -137,6 +137,7 @@ fn resolve_wrappable<'a>(
     parsed: &'a ParsedSpec,
     components: &'a [ProductComponent],
 ) -> Vec<WrappedHandler<'a>> {
+    use crate::codegen_shared::map_type;
     use crate::rust_codegen_util as util;
 
     let module_scoped_types: Vec<&str> = parsed
@@ -156,7 +157,13 @@ fn resolve_wrappable<'a>(
                 .takes_params
                 .iter()
                 .chain(op.abstract_binders.iter())
-                .all(|(_, t)| !module_scoped_types.contains(&t.as_str()));
+                .all(|(_, t)| {
+                    map_type(t, parsed).is_ok_and(|rust_ty| {
+                        !module_scoped_types
+                            .iter()
+                            .any(|name| rust_type_mentions(&rust_ty, name))
+                    })
+                });
             if !param_types_ok {
                 continue;
             }
@@ -167,6 +174,16 @@ fn resolve_wrappable<'a>(
         }
     }
     out
+}
+
+/// Whether a rendered Rust type contains `name` as an identifier. The
+/// product module is a sibling of each account module, so record/sum names
+/// nested under `Option`, `Vec`, arrays, or aliases are still unavailable
+/// unless qualified through their owning module.
+fn rust_type_mentions(rust_ty: &str, name: &str) -> bool {
+    rust_ty
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .any(|ident| ident == name)
 }
 
 fn wrapped<'a, 'b>(
@@ -558,7 +575,9 @@ fn emit_covers(
 
                 let mut indent = "        ".to_string();
                 for (j, w) in trace_ops.iter().enumerate() {
-                    for (pname, ptype) in &w.op.takes_params {
+                    for (pname, ptype) in
+                        w.op.takes_params.iter().chain(w.op.abstract_binders.iter())
+                    {
                         out.push_str(&format!(
                             "{}let {}_{}: {} = kani::any();\n",
                             indent,
@@ -570,6 +589,7 @@ fn emit_covers(
                     let args: String =
                         w.op.takes_params
                             .iter()
+                            .chain(w.op.abstract_binders.iter())
                             .map(|(n, _)| format!(", {}_{}", n, j))
                             .collect();
                     if j < trace_ops.len() - 1 {
@@ -638,7 +658,7 @@ fn emit_liveness(
                 out.push_str("            match op {\n");
                 for (i, w) in via.iter().enumerate() {
                     out.push_str(&format!("                {} => {{\n", i));
-                    for (n, t) in &w.op.takes_params {
+                    for (n, t) in w.op.takes_params.iter().chain(w.op.abstract_binders.iter()) {
                         out.push_str(&format!(
                             "                    let {}: {} = kani::any();\n",
                             n,

--- a/crates/qedgen/src/codegen/kani_mir/tests.rs
+++ b/crates/qedgen/src/codegen/kani_mir/tests.rs
@@ -1056,3 +1056,107 @@ liveness ambiguous_states : Alpha.Idle ~> Alpha.Running via [start_alpha] within
         panic!("emitted Kani harness fails to parse as Rust: {e}\n{out}");
     }
 }
+
+/// Product harness calls must bind the same complete parameter list as
+/// their delegating wrappers. In particular, `abstract` binders are model
+/// inputs even though they are not deployed instruction parameters.
+#[test]
+fn product_state_binds_abstract_params_in_cover_and_liveness() {
+    let (mir, parsed) = lower_inline(
+        r#"
+spec ProductAbstract
+
+type Pool
+  | Idle
+  | Active of { total : U64 }
+
+type Loan
+  | Empty
+  | Open of { debt : U64 }
+
+type Error
+  | InvalidAmount
+
+handler activate : Pool.Idle -> Pool.Active {
+  takes amount : U64
+  abstract observed : U64
+  requires amount > 0 else InvalidAmount
+  requires observed > 0 else InvalidAmount
+  effect { total := amount }
+}
+
+handler open_loan : Loan.Empty -> Loan.Open {
+  takes amount : U64
+  requires amount > 0 else InvalidAmount
+  effect { debt := amount }
+}
+
+cover activated [activate]
+liveness activation_progress : Pool.Idle ~> Pool.Active via [activate] within 1
+"#,
+    );
+    let out = render(&mir, &parsed);
+
+    assert!(
+        out.contains("let observed_0: u64 = kani::any();"),
+        "cover must bind the abstract value:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "kani::cover!(activate(&mut s, amount_0, observed_0), \"activated trace is reachable\");"
+        ),
+        "cover must pass the abstract value:\n{out}"
+    );
+    assert!(
+        out.contains("let observed: u64 = kani::any();"),
+        "liveness must bind the abstract value:\n{out}"
+    );
+    assert!(
+        out.contains("activate(&mut s, amount, observed);"),
+        "liveness must pass the abstract value:\n{out}"
+    );
+}
+
+/// Record/sum declarations live inside the account modules. A product
+/// wrapper must not accept a parameter whose rendered type mentions one,
+/// including through a compound wrapper or a type alias.
+#[test]
+fn product_state_rejects_nested_module_scoped_param_types() {
+    let (mir, parsed) = lower_inline(
+        r#"
+spec ProductRecordParam
+
+type Payload = { amount : U64 }
+type MaybePayload = Option Payload
+
+type Pool
+  | Idle
+  | Active of { total : U64 }
+
+type Loan
+  | Empty
+  | Open of { debt : U64 }
+
+handler activate : Pool.Idle -> Pool.Active {
+  takes payload : MaybePayload
+  effect { total := 1 }
+}
+
+handler open_loan : Loan.Empty -> Loan.Open {
+  effect { debt := 1 }
+}
+
+cover activated [activate]
+"#,
+    );
+    let out = render(&mir, &parsed);
+
+    assert!(
+        out.contains("// cover activated trace 0: not lowered —"),
+        "compound record parameter must stay reported unsupported:\n{out}"
+    );
+    assert!(
+        !out.contains("fn activate(s: &mut ProductState"),
+        "product module must not name a sibling module's record type:\n{out}"
+    );
+}

--- a/crates/qedgen/src/codegen/kani_mir/tests.rs
+++ b/crates/qedgen/src/codegen/kani_mir/tests.rs
@@ -971,3 +971,88 @@ fn environment_constraints_bind_mutated_fields_to_state() {
         panic!("emitted Kani harness fails to parse as Rust: {e}\n{out}");
     }
 }
+
+/// #324 — multi-account file-level features lower over the product-state
+/// module: a cross-account cover trace steps both components through
+/// delegating wrappers, while a liveness whose endpoint states appear in
+/// more than one account lifecycle is unresolvable (the adapter strips
+/// the `Type.` qualifier) and must stay a reported unsupported, with a
+/// structured comment in the artifact.
+#[test]
+fn product_state_lowers_cross_account_cover_and_reports_ambiguous_liveness() {
+    let (mir, parsed) = lower_inline(
+        r#"
+spec Duo
+
+type Alpha
+  | Idle
+  | Running of { alpha_total : U64 }
+
+type Beta
+  | Idle
+  | Running of { beta_total : U64 }
+
+type Error
+  | InvalidAmount
+
+handler start_alpha : Alpha.Idle -> Alpha.Running {
+  takes amount : U64
+  requires amount > 0 else Err
+  effect { alpha_total := amount }
+}
+
+handler start_beta : Beta.Idle -> Beta.Running {
+  takes amount : U64
+  requires amount > 0 else Err
+  effect { beta_total := amount }
+}
+
+cover both_start [start_alpha, start_beta]
+
+liveness ambiguous_states : Alpha.Idle ~> Alpha.Running via [start_alpha] within 1
+"#,
+    );
+    assert!(parsed.account_types.len() > 1, "fixture is multi-account");
+    let out = render(&mir, &parsed);
+
+    // Cross-account cover: wrappers delegate into both account modules,
+    // the trace composes them over ProductState.
+    assert!(
+        out.contains("mod product {"),
+        "product module missing:\n{out}"
+    );
+    assert!(
+        out.contains("alpha::start_alpha(&mut s.alpha, amount)"),
+        "alpha wrapper must delegate:\n{out}"
+    );
+    assert!(
+        out.contains("beta::start_beta(&mut s.beta, amount)"),
+        "beta wrapper must delegate:\n{out}"
+    );
+    assert!(
+        out.contains("fn cover_both_start()"),
+        "cross-account cover harness missing:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "kani::cover!(start_beta(&mut s, amount_1), \"both_start trace is reachable\");"
+        ),
+        "cover trace must cap with the last op:\n{out}"
+    );
+
+    // Ambiguous liveness (Idle/Running exist in BOTH lifecycles): no
+    // harness, a structured comment, and per-account items stay pub so
+    // the product module compiles.
+    assert!(
+        !out.contains("fn verify_liveness_ambiguous_states()"),
+        "ambiguous liveness must not guess an owner:\n{out}"
+    );
+    assert!(
+        out.contains("// liveness ambiguous_states: not lowered —"),
+        "ambiguous liveness needs a structured comment:\n{out}"
+    );
+
+    if let Err(e) = syn::parse_file(&out) {
+        panic!("emitted Kani harness fails to parse as Rust: {e}\n{out}");
+    }
+}

--- a/crates/qedgen/src/codegen/proptest_gen_mir.rs
+++ b/crates/qedgen/src/codegen/proptest_gen_mir.rs
@@ -777,10 +777,19 @@ fn emit_account_section(
     // is required by the seed-state path (`default_value_for_type` emits
     // `<Name>::default()`); a non-Default field type fails at the record
     // struct itself — clearer than a cascading E0599 at the call site.
-    rust_codegen_util::emit_record_structs(out, spec, "Debug, Clone, Copy, Default", |t| {
-        map_type(t, spec)
-    })?;
-    rust_codegen_util::emit_unit_enum_sums(out, spec, "Debug, Clone, Copy, PartialEq, Eq")?;
+    rust_codegen_util::emit_record_structs(
+        out,
+        spec,
+        "Debug, Clone, Copy, Default",
+        rust_codegen_util::VIS_PRIVATE,
+        |t| map_type(t, spec),
+    )?;
+    rust_codegen_util::emit_unit_enum_sums(
+        out,
+        spec,
+        "Debug, Clone, Copy, PartialEq, Eq",
+        rust_codegen_util::VIS_PRIVATE,
+    )?;
     // Per-account `Status` from the `lifecycle_states` param, NOT
     // `spec.lifecycle_states` — in multi-ADT mode the caller passes
     // `&acct.lifecycle` so each module gets its own variants.
@@ -788,6 +797,7 @@ fn emit_account_section(
         out,
         lifecycle_states,
         "Debug, Clone, Copy, PartialEq, Eq",
+        rust_codegen_util::VIS_PRIVATE,
     );
     emit_record_prop_composes(out, spec)?;
     emit_unit_sum_prop_oneofs(out, spec)?;
@@ -803,6 +813,7 @@ fn emit_account_section(
         "Debug, Clone, Copy",
         |t| map_type(t, spec),
         section_has_lifecycle,
+        rust_codegen_util::VIS_PRIVATE,
     )?;
 
     // Extract constant upper bounds from properties to cap arb_state() ranges.
@@ -840,9 +851,12 @@ fn emit_account_section(
         .collect();
     let owned_props_for_predicates: Vec<ParsedProperty> =
         properties.iter().map(|p| (*p).clone()).collect();
-    rust_codegen_util::emit_property_predicates_with(out, &owned_props_for_predicates, |t| {
-        map_type(t, spec)
-    });
+    rust_codegen_util::emit_property_predicates_with(
+        out,
+        &owned_props_for_predicates,
+        rust_codegen_util::VIS_PRIVATE,
+        |t| map_type(t, spec),
+    );
 
     // Invariant predicates — only those referenced by at least one handler
     // AND carrying a rust_expr body (not description-only).
@@ -861,7 +875,7 @@ fn emit_account_section(
                 .any(|h| h.invariants.contains(&i.name) || h.establishes.contains(&i.name))
         })
         .collect();
-    rust_codegen_util::emit_invariant_predicates(out, &linked_invs);
+    rust_codegen_util::emit_invariant_predicates(out, &linked_invs, rust_codegen_util::VIS_PRIVATE);
 
     // Transition functions
     emit_transition_functions_for(out, mir, handlers, spec)?;
@@ -1078,7 +1092,15 @@ fn emit_transition_functions_for(
     spec: &ParsedSpec,
 ) -> Result<()> {
     for op in handlers {
-        rust_codegen_util::emit_transition_fn(out, mir, op, spec, false, |t| map_type(t, spec))?;
+        rust_codegen_util::emit_transition_fn(
+            out,
+            mir,
+            op,
+            spec,
+            false,
+            rust_codegen_util::VIS_PRIVATE,
+            |t| map_type(t, spec),
+        )?;
     }
     Ok(())
 }

--- a/crates/qedgen/src/codegen/rust_codegen_util/emit.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/emit.rs
@@ -209,6 +209,14 @@ pub fn emit_constants(out: &mut String, constants: &[(String, String)]) {
     }
 }
 
+/// Item visibility for the shared struct/enum/fn emitters: `""` at file
+/// scope (single-account artifacts), `"pub "` inside a per-account `mod`
+/// so the sibling `mod product` (#324/#331) can name the items. A plain
+/// prefix, not an enum: the only two values are compile-checked at the
+/// emission sites and anything else fails the generated-artifact gate.
+pub const VIS_PRIVATE: &str = "";
+pub const VIS_PUB: &str = "pub ";
+
 /// Emit struct declarations for user-defined record types. Called before
 /// `emit_state_struct` so records are in scope when State references them.
 /// `derives` is the per-backend `#[derive(...)]` list. Empty records are
@@ -217,6 +225,7 @@ pub fn emit_record_structs(
     out: &mut String,
     spec: &crate::check::ParsedSpec,
     derives: &str,
+    vis: &str,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) -> anyhow::Result<()> {
     for rec in &spec.records {
@@ -230,9 +239,9 @@ pub fn emit_record_structs(
             continue;
         }
         out.push_str(&format!("#[derive({})]\n", derives));
-        out.push_str(&format!("struct {} {{\n", rec.name));
+        out.push_str(&format!("{}struct {} {{\n", vis, rec.name));
         for (fname, ftype) in &rec.fields {
-            out.push_str(&format!("    {}: {},\n", fname, map_type_fn(ftype)?));
+            out.push_str(&format!("    {}{}: {},\n", vis, fname, map_type_fn(ftype)?));
         }
         out.push_str("}\n\n");
     }
@@ -247,6 +256,7 @@ pub fn emit_unit_enum_sums(
     out: &mut String,
     spec: &crate::check::ParsedSpec,
     derives: &str,
+    vis: &str,
 ) -> anyhow::Result<()> {
     for sum in &spec.sum_types {
         let all_unit = sum.variants.iter().all(|v| v.fields.is_empty());
@@ -254,7 +264,7 @@ pub fn emit_unit_enum_sums(
             continue;
         }
         out.push_str(&format!("#[derive({})]\n", derives));
-        out.push_str(&format!("enum {} {{\n", sum.name));
+        out.push_str(&format!("{}enum {} {{\n", vis, sum.name));
         for variant in &sum.variants {
             out.push_str(&format!("    {},\n", variant.name));
         }
@@ -280,12 +290,13 @@ pub fn emit_lifecycle_status_enum_from(
     out: &mut String,
     lifecycle_states: &[String],
     derives: &str,
+    vis: &str,
 ) {
     if lifecycle_states.len() < 2 {
         return;
     }
     out.push_str(&format!("#[derive({})]\n", derives));
-    out.push_str("enum Status {\n");
+    out.push_str(&format!("{}enum Status {{\n", vis));
     for state in lifecycle_states {
         out.push_str(&format!("    {},\n", state));
     }
@@ -303,14 +314,15 @@ pub fn emit_state_struct_with_lifecycle(
     derives: &str,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
     has_lifecycle: bool,
+    vis: &str,
 ) -> anyhow::Result<()> {
     out.push_str(&format!("#[derive({})]\n", derives));
-    out.push_str("struct State {\n");
+    out.push_str(&format!("{}struct State {{\n", vis));
     for (fname, ftype) in fields {
-        out.push_str(&format!("    {}: {},\n", fname, map_type_fn(ftype)?));
+        out.push_str(&format!("    {}{}: {},\n", vis, fname, map_type_fn(ftype)?));
     }
     if has_lifecycle && !fields.iter().any(|(n, _)| n == "status") {
-        out.push_str("    status: Status,\n");
+        out.push_str(&format!("    {}status: Status,\n", vis));
     }
     out.push_str("}\n\n");
     Ok(())
@@ -320,7 +332,11 @@ pub fn emit_state_struct_with_lifecycle(
 /// with a Rust body. Description-only invariants and unsupported
 /// quantifier bodies are skipped silently; callers pre-filter to the
 /// invariants relevant for the current account section / state shape.
-pub fn emit_invariant_predicates(out: &mut String, invariants: &[&crate::check::ParsedInvariant]) {
+pub fn emit_invariant_predicates(
+    out: &mut String,
+    invariants: &[&crate::check::ParsedInvariant],
+    vis: &str,
+) {
     for inv in invariants {
         let Some(rust_expr) = inv.rust_expr.as_deref() else {
             continue;
@@ -334,7 +350,7 @@ pub fn emit_invariant_predicates(out: &mut String, invariants: &[&crate::check::
             .map(|le| format!(" — {}", le))
             .unwrap_or_default();
         out.push_str(&format!("/// Invariant: {}{}\n", inv.name, doc_body));
-        out.push_str(&format!("fn {}(s: &State) -> bool {{\n", inv.name));
+        out.push_str(&format!("{}fn {}(s: &State) -> bool {{\n", vis, inv.name));
         out.push_str(&format!("    {}\n", rust_expr));
         out.push_str("}\n\n");
     }
@@ -354,6 +370,7 @@ pub fn emit_invariant_predicates(out: &mut String, invariants: &[&crate::check::
 pub fn emit_property_predicates_with(
     out: &mut String,
     properties: &[ParsedProperty],
+    vis: &str,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) {
     for prop in properties {
@@ -372,16 +389,19 @@ pub fn emit_property_predicates_with(
         // on `prop.class`.
         let is_binary = prop.class == crate::check::PropertyClass::Binary;
         let sig = if is_binary {
-            format!("fn {}(pre: &State, post: &State) -> bool", prop.name)
+            format!("{}fn {}(pre: &State, post: &State) -> bool", vis, prop.name)
         } else {
-            format!("fn {}(s: &State) -> bool", prop.name)
+            format!("{}fn {}(s: &State) -> bool", vis, prop.name)
         };
         // Stubs underscore the params so the body `true` doesn't trip
         // `unused_variables`.
         let stub_sig = if is_binary {
-            format!("fn {}(_pre: &State, _post: &State) -> bool", prop.name)
+            format!(
+                "{}fn {}(_pre: &State, _post: &State) -> bool",
+                vis, prop.name
+            )
         } else {
-            format!("fn {}(_s: &State) -> bool", prop.name)
+            format!("{}fn {}(_s: &State) -> bool", vis, prop.name)
         };
         if crate::check::rust_expr_is_unsupported(&rust_expr) {
             // Quantifier body: emit a `true` stub; the harness preamble
@@ -410,8 +430,8 @@ pub fn emit_property_predicates_with(
             ));
             out.push_str("#[allow(unused_variables)]\n");
             out.push_str(&format!(
-                "fn {}_at(s: &State, {}: {}) -> bool {{\n",
-                prop.name, slot.binder_name, rust_ty
+                "{}fn {}_at(s: &State, {}: {}) -> bool {{\n",
+                vis, prop.name, slot.binder_name, rust_ty
             ));
             out.push_str(&format!("    {}\n", slot.rust_body));
             out.push_str("}\n\n");
@@ -457,9 +477,10 @@ pub fn emit_transition_fn(
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
+    vis: &str,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) -> anyhow::Result<()> {
-    emit_transition_fn_inner(out, mir, op, spec, wrapping, None, false, map_type_fn)
+    emit_transition_fn_inner(out, mir, op, spec, wrapping, None, false, vis, map_type_fn)
 }
 
 pub fn emit_transition_fn_for_kani(
@@ -468,6 +489,7 @@ pub fn emit_transition_fn_for_kani(
     op: &ParsedHandler,
     spec: &ParsedSpec,
     wrapping: bool,
+    vis: &str,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) -> anyhow::Result<()> {
     let account_env =
@@ -480,6 +502,7 @@ pub fn emit_transition_fn_for_kani(
         wrapping,
         account_env.as_deref(),
         true,
+        vis,
         map_type_fn,
     )
 }
@@ -493,6 +516,7 @@ pub fn emit_transition_fn_inner(
     wrapping: bool,
     account_env_struct: Option<&str>,
     rewrite_pubkey_comparisons: bool,
+    vis: &str,
     map_type_fn: impl Fn(&str) -> anyhow::Result<String>,
 ) -> anyhow::Result<()> {
     let body = mir
@@ -517,8 +541,8 @@ pub fn emit_transition_fn_inner(
     // Abstract binders ride alongside real handler params; callers pass a
     // symbolic / arbitrary value for each.
     out.push_str(&format!(
-        "fn {}(s: &mut State{}) -> bool {{\n",
-        op.name, params
+        "{}fn {}(s: &mut State{}) -> bool {{\n",
+        vis, op.name, params
     ));
 
     // Guard check (requires clauses)

--- a/crates/qedgen/src/codegen/rust_codegen_util/tests.rs
+++ b/crates/qedgen/src/codegen/rust_codegen_util/tests.rs
@@ -114,7 +114,7 @@ handler route (fee_type : U8) (amount : U64) : State.Active -> State.Active {
     let mir = crate::mir::lower(&spec);
     let op = &spec.handlers[0];
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");
@@ -223,7 +223,7 @@ handler buy (amount : U64) { effect { pool += amount } }
     let mir = crate::mir::lower(&spec);
     let op = &spec.handlers[0];
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");
@@ -251,7 +251,7 @@ handler buy (amount : U64) { effect { pool +=! amount } }
     let mir = crate::mir::lower(&spec);
     let op = &spec.handlers[0];
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");
@@ -275,7 +275,7 @@ handler buy (amount : U64) { effect { pool +=? amount } }
     let mir = crate::mir::lower(&spec);
     let op = &spec.handlers[0];
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");
@@ -304,7 +304,7 @@ fn emit_transition_fn_sub_three_tiers() {
         let mir = crate::mir::lower(&spec);
         let op = &spec.handlers[0];
         let mut out = String::new();
-        emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+        emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
             crate::codegen_shared::map_type(t, &spec)
         })
         .expect("emit");
@@ -333,7 +333,7 @@ handler close : State.Open -> State.Closed { effect { x := 0 } }
     let mir = crate::mir::lower(&spec);
     let op = &spec.handlers[0];
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");
@@ -360,7 +360,7 @@ handler deposit (amount : U64) { effect { balance += amount } }
     let mir = crate::mir::lower(&spec);
     let op = &spec.handlers[0];
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");
@@ -387,6 +387,7 @@ handler close : State.Open -> State.Closed { effect { x := 0 } }
         "Clone, Copy",
         |t| Ok(t.to_string()),
         has_lifecycle(&spec),
+        VIS_PRIVATE,
     )
     .expect("emit");
     assert!(
@@ -639,7 +640,7 @@ handler deposit (amount : U64) {
     let mir = crate::mir::lower(&spec);
     let op = spec.handlers.first().expect("handler");
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");
@@ -677,7 +678,7 @@ handler deposit (amount : U64) {
     let mir = crate::mir::lower(&spec);
     let op = spec.handlers.first().expect("handler");
     let mut out = String::new();
-    emit_transition_fn(&mut out, &mir, op, &spec, false, |t| {
+    emit_transition_fn(&mut out, &mir, op, &spec, false, VIS_PRIVATE, |t| {
         crate::codegen_shared::map_type(t, &spec)
     })
     .expect("emit");

--- a/crates/qedgen/src/codegen/unit_test.rs
+++ b/crates/qedgen/src/codegen/unit_test.rs
@@ -62,12 +62,14 @@ pub fn generate(spec_path: &Path, output_path: &Path) -> Result<()> {
         &mut out,
         &spec,
         "Debug, Clone, Copy, PartialEq",
+        crate::rust_codegen_util::VIS_PRIVATE,
         |t| map_type(t, &spec),
     )?;
     crate::rust_codegen_util::emit_unit_enum_sums(
         &mut out,
         &spec,
         "Debug, Clone, Copy, PartialEq, Eq",
+        crate::rust_codegen_util::VIS_PRIVATE,
     )?;
 
     if is_multi {

--- a/crates/qedgen/src/obligations/mod.rs
+++ b/crates/qedgen/src/obligations/mod.rs
@@ -109,7 +109,8 @@ pub enum ObligationKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UnsupportedReason {
-    /// #324 — multi-account Kani emits no file-level features.
+    /// #324 — a file-level feature the product-state lowering cannot
+    /// resolve to modeled account components.
     KaniMultiAccountFileLevel,
     /// #326 — Kani verifies a flat state model for `state_repr = adt`.
     KaniAdtStateRepr,
@@ -148,7 +149,7 @@ impl UnsupportedReason {
     pub fn describe(self) -> &'static str {
         match self {
             UnsupportedReason::KaniMultiAccountFileLevel => {
-                "multi-account Kani does not lower file-level cover/liveness/environment obligations yet (#324)"
+                "file-level obligation does not resolve to modeled account components; the product-state lowering cannot express this shape (#324)"
             }
             UnsupportedReason::KaniAdtStateRepr => {
                 "Kani verifies a flat state model for this shape; ADT parity covers single-account specs with defaultable variant payloads only (#326)"

--- a/crates/qedgen/src/obligations/spec_tests.rs
+++ b/crates/qedgen/src/obligations/spec_tests.rs
@@ -44,12 +44,13 @@ fn failed_entries(entries: &[ObligationEntry]) -> Vec<&ObligationEntry> {
         .collect()
 }
 
-/// #324 — multi-account Kani drops covers / liveness / environment. The
-/// bundled lending example (Pool + Loan accounts, two covers, one
-/// liveness, one environment) must surface every file-level obligation as
-/// `unsupported(kani_multi_account_file_level)`, never absent.
+/// #324 — multi-account Kani lowers covers / liveness / environment over
+/// the product-state module. The bundled lending example (Pool + Loan
+/// accounts, two covers, one liveness, one environment) must record every
+/// file-level obligation as `emitted` — and none may go absent (reconcile
+/// would synthesize a status for a silent drop).
 #[test]
-fn kani_multi_account_file_level_obligations_surface() {
+fn kani_multi_account_file_level_obligations_emit_via_product_state() {
     let (mir, parsed) = lower_fixture("examples/rust/lending/lending.qedspec");
     assert!(parsed.account_types.len() > 1, "lending is multi-account");
     let entries = reconciled(
@@ -60,6 +61,12 @@ fn kani_multi_account_file_level_obligations_surface() {
     );
 
     let dropped = entries_with_reason(&entries, UnsupportedReason::KaniMultiAccountFileLevel);
+    assert!(
+        dropped.is_empty(),
+        "lending's file-level obligations all lower over the product state: {:#?}",
+        dropped
+    );
+
     let expected_file_level = parsed.covers.iter().map(|c| c.traces.len()).sum::<usize>()
         + parsed.liveness_props.len()
         + parsed.environments.len()
@@ -72,10 +79,18 @@ fn kani_multi_account_file_level_obligations_surface() {
         expected_file_level > 0,
         "lending declares file-level obligations"
     );
+    let emitted_file_level = entries
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.kind,
+                ObligationKind::Cover | ObligationKind::Liveness | ObligationKind::Environment
+            ) && matches!(e.status, ObligationStatus::Emitted { .. })
+        })
+        .count();
     assert_eq!(
-        dropped.len(),
-        expected_file_level,
-        "every file-level obligation must be reported: {:#?}",
+        emitted_file_level, expected_file_level,
+        "every file-level obligation must be emitted: {:#?}",
         entries
     );
 }
@@ -381,7 +396,10 @@ fn bundled_multi_account_example_has_no_failed_entries() {
 fn strict_gate_fires_on_known_gaps_only() {
     let (mir, parsed) = lower_fixture("examples/rust/lending/lending.qedspec");
     let counts = StatusCounts::of(&collect_all(&mir, &parsed));
-    assert!(counts.gates_strict(), "lending has known #324 gaps");
+    assert!(
+        counts.gates_strict(),
+        "lending still gates: cross-account property preservation stays unsupported (#331)"
+    );
 
     let (mir, parsed) = lower_inline(
         r#"

--- a/crates/qedgen/tests/snapshots/lending.kani.rs
+++ b/crates/qedgen/tests/snapshots/lending.kani.rs
@@ -63,19 +63,19 @@ mod pool {
     use super::*;
 
     #[derive(Clone, Copy, PartialEq, Eq, kani::Arbitrary)]
-    enum Status {
+    pub enum Status {
         Uninitialized,
         Active,
         Paused,
     }
 
     #[derive(Clone, Copy)]
-    struct State {
-        authority: [u8; 32],
-        total_deposits: u64,
-        total_borrows: u64,
-        interest_rate: u64,
-        status: Status,
+    pub struct State {
+        pub authority: [u8; 32],
+        pub total_deposits: u64,
+        pub total_borrows: u64,
+        pub interest_rate: u64,
+        pub status: Status,
     }
 
     // ============================================================================
@@ -83,7 +83,7 @@ mod pool {
     // ============================================================================
 
     /// pool_solvency: s.total_deposits ≥ s.total_borrows
-    fn pool_solvency(s: &State) -> bool {
+    pub fn pool_solvency(s: &State) -> bool {
         s.total_deposits >= s.total_borrows
     }
 
@@ -94,7 +94,7 @@ mod pool {
     // false if the guard rejects the operation.
     // ============================================================================
 
-    fn init_pool(s: &mut State, rate: u64) -> bool {
+    pub fn init_pool(s: &mut State, rate: u64) -> bool {
         if !(rate > 0) {
             return false;
         }
@@ -108,7 +108,7 @@ mod pool {
         true
     }
 
-    fn deposit(s: &mut State, amount: u64) -> bool {
+    pub fn deposit(s: &mut State, amount: u64) -> bool {
         if !(amount > 0) {
             return false;
         }
@@ -358,19 +358,19 @@ mod loan {
     use super::*;
 
     #[derive(Clone, Copy, PartialEq, Eq, kani::Arbitrary)]
-    enum Status {
+    pub enum Status {
         Empty,
         Active,
         Liquidated,
     }
 
     #[derive(Clone, Copy)]
-    struct State {
-        borrower: [u8; 32],
-        pool: [u8; 32],
-        amount: u64,
-        collateral: u64,
-        status: Status,
+    pub struct State {
+        pub borrower: [u8; 32],
+        pub pool: [u8; 32],
+        pub amount: u64,
+        pub collateral: u64,
+        pub status: Status,
     }
 
     // ============================================================================
@@ -380,7 +380,7 @@ mod loan {
     // false if the guard rejects the operation.
     // ============================================================================
 
-    fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
+    pub fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
         if !(amount > 0 && collateral > 0) {
             return false;
         }
@@ -393,7 +393,7 @@ mod loan {
         true
     }
 
-    fn repay(s: &mut State) -> bool {
+    pub fn repay(s: &mut State) -> bool {
         if s.status != Status::Active {
             return false;
         }
@@ -403,7 +403,7 @@ mod loan {
         true
     }
 
-    fn liquidate(s: &mut State) -> bool {
+    pub fn liquidate(s: &mut State) -> bool {
         if !(s.amount > s.collateral) {
             return false;
         }
@@ -601,5 +601,163 @@ mod loan {
         }
     }
 } // mod loan
+
+// ============================================================================
+// Product state (#324) — file-level covers / liveness / environment
+// lowered once over the per-account components; transitions delegate
+// to the account modules so there is no second copy of the semantics.
+// ============================================================================
+
+mod product {
+    use super::*;
+
+    struct ProductState {
+        pool: pool::State,
+        loan: loan::State,
+    }
+
+    // Transition wrappers — delegate to the owning account module.
+    fn borrow(s: &mut ProductState, amount: u64, collateral: u64) -> bool {
+        loan::borrow(&mut s.loan, amount, collateral)
+    }
+
+    fn deposit(s: &mut ProductState, amount: u64) -> bool {
+        pool::deposit(&mut s.pool, amount)
+    }
+
+    fn init_pool(s: &mut ProductState, rate: u64) -> bool {
+        pool::init_pool(&mut s.pool, rate)
+    }
+
+    fn liquidate(s: &mut ProductState) -> bool {
+        loan::liquidate(&mut s.loan)
+    }
+
+    fn repay(s: &mut ProductState) -> bool {
+        loan::repay(&mut s.loan)
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    #[kani::solver(cadical)]
+    fn cover_borrow_repay_cycle() {
+        let mut s = ProductState {
+            pool: pool::State {
+                authority: kani::any(),
+                total_deposits: kani::any(),
+                total_borrows: kani::any(),
+                interest_rate: kani::any(),
+                status: kani::any(),
+            },
+            loan: loan::State {
+                borrower: kani::any(),
+                pool: kani::any(),
+                amount: kani::any(),
+                collateral: kani::any(),
+                status: kani::any(),
+            },
+        };
+        let rate_0: u64 = kani::any();
+        if init_pool(&mut s, rate_0) {
+            let amount_1: u64 = kani::any();
+            if deposit(&mut s, amount_1) {
+                let amount_2: u64 = kani::any();
+                let collateral_2: u64 = kani::any();
+                if borrow(&mut s, amount_2, collateral_2) {
+                    kani::cover!(repay(&mut s), "borrow_repay_cycle trace is reachable");
+                }
+            }
+        }
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    #[kani::solver(cadical)]
+    fn cover_liquidation_path() {
+        let mut s = ProductState {
+            pool: pool::State {
+                authority: kani::any(),
+                total_deposits: kani::any(),
+                total_borrows: kani::any(),
+                interest_rate: kani::any(),
+                status: kani::any(),
+            },
+            loan: loan::State {
+                borrower: kani::any(),
+                pool: kani::any(),
+                amount: kani::any(),
+                collateral: kani::any(),
+                status: kani::any(),
+            },
+        };
+        let rate_0: u64 = kani::any();
+        if init_pool(&mut s, rate_0) {
+            let amount_1: u64 = kani::any();
+            if deposit(&mut s, amount_1) {
+                let amount_2: u64 = kani::any();
+                let collateral_2: u64 = kani::any();
+                if borrow(&mut s, amount_2, collateral_2) {
+                    kani::cover!(liquidate(&mut s), "liquidation_path trace is reachable");
+                }
+            }
+        }
+    }
+
+    #[kani::proof]
+    #[kani::unwind(2)]
+    #[kani::solver(cadical)]
+    fn verify_liveness_loan_settles() {
+        let mut s = ProductState {
+            pool: pool::State {
+                authority: kani::any(),
+                total_deposits: kani::any(),
+                total_borrows: kani::any(),
+                interest_rate: kani::any(),
+                status: kani::any(),
+            },
+            loan: loan::State {
+                borrower: kani::any(),
+                pool: kani::any(),
+                amount: kani::any(),
+                collateral: kani::any(),
+                status: kani::any(),
+            },
+        };
+        kani::assume(s.loan.status == loan::Status::Active);
+        for _ in 0..1 {
+            let op: u8 = kani::any();
+            match op {
+                0 => {
+                    repay(&mut s);
+                }
+                _ => {}
+            }
+        }
+        kani::cover!(
+            s.loan.status == loan::Status::Empty,
+            "loan_settles reaches Empty within 1 steps"
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(2)]
+    #[kani::solver(cadical)]
+    fn verify_pool_solvency_under_interest_rate_change() {
+        let mut s = pool::State {
+            authority: kani::any(),
+            total_deposits: kani::any(),
+            total_borrows: kani::any(),
+            interest_rate: kani::any(),
+            status: kani::any(),
+        };
+        kani::assume(pool::pool_solvency(&s));
+        s.interest_rate = kani::any();
+        kani::assume(s.interest_rate > 0);
+        assert!(
+            pool::pool_solvency(&s),
+            "pool_solvency must hold after interest_rate_change"
+        );
+    }
+} // mod product
 
 // ---- GENERATED BY QEDGEN — DO NOT EDIT BELOW THIS LINE ----

--- a/docs/framework-support.md
+++ b/docs/framework-support.md
@@ -27,7 +27,7 @@ sBPF assembly is selected by `pragma sbpf` in the spec, not by a `Target`.
 | IDL → brownfield fuzz (`probe/crucible_brownfield`) | ✅ 0.30 | ✅ | ⚠️ needs on-disk Codama/0.30 IDL | ❌ deferred | ❌ parked |
 | Brownfield adapt → spec skeleton (`adapt/`) — *deprecated* | ✅ args + accounts + errors | ❌ no adapter | ⚠️ handlers-only skeleton | ⚠️ loose (no conventions) | ❌ |
 | Greenfield Rust scaffold (`codegen_mir`) | ✅ | ⚠️ generic CPI → `todo!()` | ⚠️ generic CPI → `todo!()`; imported mirrors error | n/a | n/a |
-| Kani spec-model (`kani_mir`) | ✅ ¹ | ✅ ¹ | ✅ ¹ | n/a | skip by design |
+| Kani spec-model (`kani_mir`) | ✅ ¹ ⁴ | ✅ ¹ ⁴ | ✅ ¹ ⁴ | n/a | skip by design |
 | impl-Kani (`kani_impl`) | ✅ greenfield + state-struct (#162) + Context (#169) | ⚠️ greenfield shape only | ⚠️ own `#[repr(C)]` shape; some ix-data field types TODO | ❌ | ❌ |
 | proptest (`proptest_gen_mir`) | ✅ | ✅ | ✅ | n/a | skip by design |
 | Lean (`lean_gen_mir`) | ✅ ² ³ | ✅ ² ³ | ✅ ² ³ | n/a | ✅ dedicated sBPF path |
@@ -60,6 +60,16 @@ user-owned `Proofs.lean`, ideally typed `theorem <name> : <name>_stmt` so
 a restated obligation no longer type-checks. The obligation manifest
 records each statement as emitted — the old blanket
 `lean_indexed_shape_proofs_external` status is gone.
+
+⁴ Multi-account file-level features (#324): covers, liveness, and
+environment obligations lower once over a generated `mod product` whose
+components delegate every transition to the per-account modules — no
+second copy of the semantics, no per-account duplication of a trace.
+Shapes that do not resolve to modeled components (trace ops needing a
+symbolic account env, record/sum-typed params, endpoint states declared
+by more than one lifecycle, cross-account or ghost-reading environment
+properties) stay `unsupported(kani_multi_account_file_level)` in the
+obligation manifest.
 
 ## Codegen ownership contract: CPIs, PDA creation, and events
 

--- a/examples/rust/lending/tests/kani.rs
+++ b/examples/rust/lending/tests/kani.rs
@@ -63,19 +63,19 @@ mod pool {
     use super::*;
 
     #[derive(Clone, Copy, PartialEq, Eq, kani::Arbitrary)]
-    enum Status {
+    pub enum Status {
         Uninitialized,
         Active,
         Paused,
     }
 
     #[derive(Clone, Copy)]
-    struct State {
-        authority: [u8; 32],
-        total_deposits: u64,
-        total_borrows: u64,
-        interest_rate: u64,
-        status: Status,
+    pub struct State {
+        pub authority: [u8; 32],
+        pub total_deposits: u64,
+        pub total_borrows: u64,
+        pub interest_rate: u64,
+        pub status: Status,
     }
 
     // ============================================================================
@@ -83,7 +83,7 @@ mod pool {
     // ============================================================================
 
     /// pool_solvency: s.total_deposits ≥ s.total_borrows
-    fn pool_solvency(s: &State) -> bool {
+    pub fn pool_solvency(s: &State) -> bool {
         s.total_deposits >= s.total_borrows
     }
 
@@ -94,7 +94,7 @@ mod pool {
     // false if the guard rejects the operation.
     // ============================================================================
 
-    fn init_pool(s: &mut State, rate: u64) -> bool {
+    pub fn init_pool(s: &mut State, rate: u64) -> bool {
         if !(rate > 0) {
             return false;
         }
@@ -108,7 +108,7 @@ mod pool {
         true
     }
 
-    fn deposit(s: &mut State, amount: u64) -> bool {
+    pub fn deposit(s: &mut State, amount: u64) -> bool {
         if !(amount > 0) {
             return false;
         }
@@ -358,19 +358,19 @@ mod loan {
     use super::*;
 
     #[derive(Clone, Copy, PartialEq, Eq, kani::Arbitrary)]
-    enum Status {
+    pub enum Status {
         Empty,
         Active,
         Liquidated,
     }
 
     #[derive(Clone, Copy)]
-    struct State {
-        borrower: [u8; 32],
-        pool: [u8; 32],
-        amount: u64,
-        collateral: u64,
-        status: Status,
+    pub struct State {
+        pub borrower: [u8; 32],
+        pub pool: [u8; 32],
+        pub amount: u64,
+        pub collateral: u64,
+        pub status: Status,
     }
 
     // ============================================================================
@@ -380,7 +380,7 @@ mod loan {
     // false if the guard rejects the operation.
     // ============================================================================
 
-    fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
+    pub fn borrow(s: &mut State, amount: u64, collateral: u64) -> bool {
         if !(amount > 0 && collateral > 0) {
             return false;
         }
@@ -393,7 +393,7 @@ mod loan {
         true
     }
 
-    fn repay(s: &mut State) -> bool {
+    pub fn repay(s: &mut State) -> bool {
         if s.status != Status::Active {
             return false;
         }
@@ -403,7 +403,7 @@ mod loan {
         true
     }
 
-    fn liquidate(s: &mut State) -> bool {
+    pub fn liquidate(s: &mut State) -> bool {
         if !(s.amount > s.collateral) {
             return false;
         }
@@ -601,5 +601,163 @@ mod loan {
         }
     }
 } // mod loan
+
+// ============================================================================
+// Product state (#324) — file-level covers / liveness / environment
+// lowered once over the per-account components; transitions delegate
+// to the account modules so there is no second copy of the semantics.
+// ============================================================================
+
+mod product {
+    use super::*;
+
+    struct ProductState {
+        pool: pool::State,
+        loan: loan::State,
+    }
+
+    // Transition wrappers — delegate to the owning account module.
+    fn borrow(s: &mut ProductState, amount: u64, collateral: u64) -> bool {
+        loan::borrow(&mut s.loan, amount, collateral)
+    }
+
+    fn deposit(s: &mut ProductState, amount: u64) -> bool {
+        pool::deposit(&mut s.pool, amount)
+    }
+
+    fn init_pool(s: &mut ProductState, rate: u64) -> bool {
+        pool::init_pool(&mut s.pool, rate)
+    }
+
+    fn liquidate(s: &mut ProductState) -> bool {
+        loan::liquidate(&mut s.loan)
+    }
+
+    fn repay(s: &mut ProductState) -> bool {
+        loan::repay(&mut s.loan)
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    #[kani::solver(cadical)]
+    fn cover_borrow_repay_cycle() {
+        let mut s = ProductState {
+            pool: pool::State {
+                authority: kani::any(),
+                total_deposits: kani::any(),
+                total_borrows: kani::any(),
+                interest_rate: kani::any(),
+                status: kani::any(),
+            },
+            loan: loan::State {
+                borrower: kani::any(),
+                pool: kani::any(),
+                amount: kani::any(),
+                collateral: kani::any(),
+                status: kani::any(),
+            },
+        };
+        let rate_0: u64 = kani::any();
+        if init_pool(&mut s, rate_0) {
+            let amount_1: u64 = kani::any();
+            if deposit(&mut s, amount_1) {
+                let amount_2: u64 = kani::any();
+                let collateral_2: u64 = kani::any();
+                if borrow(&mut s, amount_2, collateral_2) {
+                    kani::cover!(repay(&mut s), "borrow_repay_cycle trace is reachable");
+                }
+            }
+        }
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    #[kani::solver(cadical)]
+    fn cover_liquidation_path() {
+        let mut s = ProductState {
+            pool: pool::State {
+                authority: kani::any(),
+                total_deposits: kani::any(),
+                total_borrows: kani::any(),
+                interest_rate: kani::any(),
+                status: kani::any(),
+            },
+            loan: loan::State {
+                borrower: kani::any(),
+                pool: kani::any(),
+                amount: kani::any(),
+                collateral: kani::any(),
+                status: kani::any(),
+            },
+        };
+        let rate_0: u64 = kani::any();
+        if init_pool(&mut s, rate_0) {
+            let amount_1: u64 = kani::any();
+            if deposit(&mut s, amount_1) {
+                let amount_2: u64 = kani::any();
+                let collateral_2: u64 = kani::any();
+                if borrow(&mut s, amount_2, collateral_2) {
+                    kani::cover!(liquidate(&mut s), "liquidation_path trace is reachable");
+                }
+            }
+        }
+    }
+
+    #[kani::proof]
+    #[kani::unwind(2)]
+    #[kani::solver(cadical)]
+    fn verify_liveness_loan_settles() {
+        let mut s = ProductState {
+            pool: pool::State {
+                authority: kani::any(),
+                total_deposits: kani::any(),
+                total_borrows: kani::any(),
+                interest_rate: kani::any(),
+                status: kani::any(),
+            },
+            loan: loan::State {
+                borrower: kani::any(),
+                pool: kani::any(),
+                amount: kani::any(),
+                collateral: kani::any(),
+                status: kani::any(),
+            },
+        };
+        kani::assume(s.loan.status == loan::Status::Active);
+        for _ in 0..1 {
+            let op: u8 = kani::any();
+            match op {
+                0 => {
+                    repay(&mut s);
+                }
+                _ => {}
+            }
+        }
+        kani::cover!(
+            s.loan.status == loan::Status::Empty,
+            "loan_settles reaches Empty within 1 steps"
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(2)]
+    #[kani::solver(cadical)]
+    fn verify_pool_solvency_under_interest_rate_change() {
+        let mut s = pool::State {
+            authority: kani::any(),
+            total_deposits: kani::any(),
+            total_borrows: kani::any(),
+            interest_rate: kani::any(),
+            status: kani::any(),
+        };
+        kani::assume(pool::pool_solvency(&s));
+        s.interest_rate = kani::any();
+        kani::assume(s.interest_rate > 0);
+        assert!(
+            pool::pool_solvency(&s),
+            "pool_solvency must hold after interest_rate_change"
+        );
+    }
+} // mod product
 
 // ---- GENERATED BY QEDGEN — DO NOT EDIT BELOW THIS LINE ----


### PR DESCRIPTION
Closes #324. Stacked on #346 (the environment-constraint rendering fix this lowering compile-gates).

## What

Multi-account Kani specs no longer drop covers, liveness, and environment obligations. They lower ONCE over a generated `mod product`:

- `ProductState` holds one component per emitted account module (`pool: pool::State`, …).
- Transition wrappers delegate to the per-account transition fns — the product model adds no second copy of the transition semantics, and per-account duplication of a trace (which would change its meaning) never happens.
- Cover traces step components through the wrappers; liveness assumes/covers the owning component's status; environment harnesses run over the single component that owns both the property and every mutated field.

Per-account module items gain `pub` visibility via a `vis` parameter threaded through the shared emitters (`VIS_PRIVATE` at file scope keeps every single-account artifact byte-identical — only `lending.kani.rs` changes).

## Reporting contract (#332)

Every requested file-level obligation ends `emitted` or `unsupported(kani_multi_account_file_level)` with a structured comment in the artifact. Unresolvable shapes (trace ops needing a symbolic account env, record/sum-typed params, endpoint states declared by more than one lifecycle, cross-account or ghost-reading environment properties) never guess — they stay reported. Ghost product semantics land with #331.

Lending: 2 covers + 1 liveness + 1 environment obligation flip unsupported → emitted.

## Verification

- `lending_generated_artifacts_compile_and_run` (artifact gate) passes locally — the product module type-checks against the kani compile stub, unit + proptests run.
- New unit test `product_state_lowers_cross_account_cover_and_reports_ambiguous_liveness` (cross-account trace lowers; ambiguous liveness stays reported; artifact syn-parses).
- `kani_multi_account_file_level_obligations_emit_via_product_state` pins the lending manifest flip.
- Full suite: 1560 passed, 0 failed; snapshots + `--regen-drift --write` clean.