### PR TITLE
feat(check): nudge Proofs.lean theorems that restate machine-owned statements (#349)

### DIFF
--- a/crates/qedgen/src/project/proofs_bootstrap.rs
+++ b/crates/qedgen/src/project/proofs_bootstrap.rs
@@ -31,11 +31,36 @@ pub fn extract_theorem_names(source: &str) -> BTreeSet<String> {
     re.captures_iter(source).map(|c| c[1].to_string()).collect()
 }
 
+/// Extract the base names of the machine-owned obligation statements a
+/// generated `Spec.lean` carries: `def <base>_stmt : Prop` → `<base>`.
+/// Artifact-derived on purpose — reading the generated file cannot drift
+/// from the emitter the way a second copy of its naming logic could.
+pub fn extract_stmt_defs(source: &str) -> BTreeSet<String> {
+    let re = Regex::new(r"(?m)^\s*def\s+([A-Za-z_][A-Za-z0-9_]*)_stmt\s*:\s*Prop\b").unwrap();
+    re.captures_iter(source).map(|c| c[1].to_string()).collect()
+}
+
+/// Does `source` declare `theorem <name>` typed directly against its
+/// machine-owned statement — `theorem <name> : [<Ns>.]<name>_stmt`?
+/// Any other form (inline binders, a hand-restated Prop) is a restatement:
+/// it elaborates fine, but the statement is no longer machine-checked.
+fn theorem_types_against_stmt(source: &str, name: &str) -> bool {
+    let re = Regex::new(&format!(
+        r"theorem\s+{name}\s*:\s*(?:[A-Za-z_][A-Za-z0-9_]*\.)*{name}_stmt\b",
+        name = regex::escape(name)
+    ))
+    .unwrap();
+    re.is_match(source)
+}
+
 /// Render the bootstrap `Proofs.lean` body: `import Spec`, `open` clauses,
-/// and a commented checklist of expected obligations. Intentionally no
+/// and a commented checklist of expected obligations. `stmt_bases` is the
+/// set of machine-owned `_stmt` obligations the sibling `Spec.lean` carries
+/// (empty for flat shapes) — those checklist lines show the typed form and
+/// the full stmt inventory is listed, not just preservation. Intentionally no
 /// `theorem X : True := by trivial` stubs — they type-check but prove
 /// nothing, and a Proofs.lean full of them reads as "everything is proven".
-pub fn render_bootstrap(spec: &ParsedSpec) -> String {
+pub fn render_bootstrap(spec: &ParsedSpec, stmt_bases: &BTreeSet<String>) -> String {
     let mut out = String::new();
     out.push_str("/-\n");
     out.push_str("Proofs.lean — user-owned preservation proofs.\n");
@@ -49,21 +74,38 @@ pub fn render_bootstrap(spec: &ParsedSpec) -> String {
     out.push_str(&format!("namespace {}\n\n", spec.program_name));
     out.push_str("open QEDGen.Solana\n\n");
 
-    let theorems = expected_theorems(spec);
-    if theorems.is_empty() {
+    // Union: spec-declared preservation obligations + every machine-owned
+    // statement Spec.lean carries. Names with a `_stmt` render the typed
+    // form so the statement stays machine-checked.
+    let mut checklist = expected_theorems(spec);
+    checklist.extend(stmt_bases.iter().cloned());
+    if checklist.is_empty() {
         out.push_str("-- No preservation obligations declared by the spec.\n");
         out.push_str("-- Add `property <name> preserved_by [...]` blocks to the `.qedspec`\n");
         out.push_str("-- and `qedgen check` will list the new obligations here.\n");
     } else {
-        out.push_str("-- Preservation obligations the spec expects.\n");
-        out.push_str("-- Write each theorem against the signature generated in Spec.lean\n");
-        out.push_str("-- (the handler's transition + the property predicate). Close with\n");
+        out.push_str("-- Obligations the spec expects.\n");
+        if stmt_bases.is_empty() {
+            out.push_str("-- Write each theorem against the signature generated in Spec.lean\n");
+            out.push_str("-- (the handler's transition + the property predicate). Close with\n");
+        } else {
+            out.push_str("-- Spec.lean owns each statement as `def <name>_stmt : Prop`;\n");
+            out.push_str("-- type the theorem against it (`theorem <name> : <name>_stmt`)\n");
+            out.push_str("-- so the statement cannot drift from the spec. Close with\n");
+        }
         out.push_str("-- tactics like `unfold`, `omega`, or `simp_all` as appropriate, or\n");
         out.push_str("-- `QEDGen.Solana.IndexedState.forall_update_pres` for per-account\n");
         out.push_str("-- invariants in Map-backed specs.\n");
         out.push_str("--\n");
-        for name in &theorems {
-            out.push_str(&format!("--   theorem {}\n", name));
+        for name in &checklist {
+            if stmt_bases.contains(name) {
+                out.push_str(&format!(
+                    "--   theorem {} : {}_stmt := by sorry\n",
+                    name, name
+                ));
+            } else {
+                out.push_str(&format!("--   theorem {}\n", name));
+            }
         }
     }
 
@@ -72,14 +114,20 @@ pub fn render_bootstrap(spec: &ParsedSpec) -> String {
 }
 
 /// Bootstrap `Proofs.lean` if absent. Never overwrites an existing file.
-/// Returns `true` if a new file was written.
+/// Reads the sibling generated `Spec.lean` (written just before this in the
+/// codegen sequence) for machine-owned `_stmt` obligations so the checklist
+/// suggests the typed form. Returns `true` if a new file was written.
 pub fn bootstrap_if_missing(spec: &ParsedSpec, proofs_dir: &Path) -> Result<bool> {
     let path = proofs_dir.join("Proofs.lean");
     if path.exists() {
         return Ok(false);
     }
+    let stmt_bases = match std::fs::read_to_string(proofs_dir.join("Spec.lean")) {
+        Ok(source) => extract_stmt_defs(&source),
+        Err(_) => BTreeSet::new(),
+    };
     std::fs::create_dir_all(proofs_dir)?;
-    std::fs::write(&path, render_bootstrap(spec))?;
+    std::fs::write(&path, render_bootstrap(spec, &stmt_bases))?;
     eprintln!("Bootstrapped {}", path.display());
     Ok(true)
 }
@@ -98,6 +146,14 @@ pub enum OrphanFinding {
     ForeignProofs {
         declared: usize,
         expected: usize,
+    },
+    /// `Spec.lean` carries a machine-owned `def <name>_stmt : Prop` for this
+    /// obligation, but the `Proofs.lean` theorem restates the obligation
+    /// instead of typing against it (#336 follow-up). Informational, like
+    /// `ForeignProofs`: the restated theorem is still a valid proof, but its
+    /// statement can drift from the spec without any gate noticing.
+    RestatedStatement {
+        theorem: String,
     },
 }
 
@@ -123,13 +179,24 @@ impl std::fmt::Display for OrphanFinding {
                  workflows can ignore it.)",
                 declared, expected
             ),
+            OrphanFinding::RestatedStatement { theorem } => write!(
+                f,
+                "theorem `{}` restates its obligation — Spec.lean owns the \
+                 statement as `{}_stmt`. Retype it as\n  theorem {} : {}_stmt := by intro …\n\
+                 so the statement stays machine-checked. (Informational — the \
+                 proof is still valid, but its statement can drift from the spec.)",
+                theorem, theorem, theorem, theorem
+            ),
         }
     }
 }
 
 /// Compare the spec's expected obligations against the theorems in
 /// `Proofs.lean`. Only `<property>_preserved_by_<handler>`-shaped names are
-/// checked — helper lemmas never trigger false orphans.
+/// checked for orphan/missing — helper lemmas never trigger false orphans.
+/// When the sibling `Spec.lean` carries machine-owned `_stmt` statements,
+/// declared theorems that restate instead of typing against them get an
+/// informational nudge (#349).
 pub fn check_orphans(spec: &ParsedSpec, proofs_dir: &Path) -> Result<Vec<OrphanFinding>> {
     let path = proofs_dir.join("Proofs.lean");
     if !path.exists() {
@@ -176,6 +243,22 @@ pub fn check_orphans(spec: &ParsedSpec, proofs_dir: &Path) -> Result<Vec<OrphanF
     for thm in &expected {
         if !declared.contains(thm) {
             findings.push(OrphanFinding::Missing(thm.clone()));
+        }
+    }
+
+    // Restated-statement nudge (#349, the #336 follow-up): when the sibling
+    // generated Spec.lean carries machine-owned `def <name>_stmt : Prop`
+    // obligations, a declared theorem of the same name should type against
+    // its `_stmt` — any other typing re-opens statement drift at the proof
+    // site. Covers the full stmt inventory (preservation, aborts, ensures,
+    // covers, liveness, environments), not just `expected_theorems`.
+    let spec_lean = proofs_dir.join("Spec.lean");
+    if spec_lean.exists() {
+        let spec_source = std::fs::read_to_string(&spec_lean)?;
+        for base in extract_stmt_defs(&spec_source) {
+            if declared.contains(&base) && !theorem_types_against_stmt(&source, &base) {
+                findings.push(OrphanFinding::RestatedStatement { theorem: base });
+            }
         }
     }
 
@@ -277,6 +360,129 @@ end Foo
             )),
             "overlap keeps per-theorem orphan+missing findings; got {findings:?}"
         );
+    }
+
+    #[test]
+    fn extract_stmt_defs_finds_bases() {
+        let src = r#"
+def threshold_bounded (s : State) : Prop := s.threshold > 0
+def solvency_preserved_by_deposit_stmt : Prop :=
+  ∀ (s s' : State), solvency s → depositTransition s = some s' → solvency s'
+def cover_can_execute_stmt : Prop := ∃ s, True
+-- def commented_out_stmt : Prop := True
+"#;
+        let bases = extract_stmt_defs(src);
+        assert!(bases.contains("solvency_preserved_by_deposit"));
+        assert!(bases.contains("cover_can_execute"));
+        assert!(!bases.contains("commented_out"));
+        assert!(
+            !bases.contains("threshold_bounded"),
+            "plain predicate defs are not statements"
+        );
+        assert_eq!(bases.len(), 2);
+    }
+
+    /// #349: a declared theorem that restates its obligation inline while
+    /// Spec.lean owns the statement as `_stmt` gets an informational nudge.
+    /// Covers the full stmt inventory — the cover obligation is not in
+    /// `expected_theorems` and still nudges.
+    #[test]
+    fn restated_theorems_get_stmt_nudge() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Spec.lean"),
+            "def solvency_preserved_by_deposit_stmt : Prop := True\n\
+             def cover_can_execute_stmt : Prop := True\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("Proofs.lean"),
+            "theorem solvency_preserved_by_deposit\n\
+             \x20   (s s' : State) (h : depositTransition s = some s') :\n\
+             \x20   solvency s' := by sorry\n\
+             theorem cover_can_execute : ∃ s, True := by sorry\n",
+        )
+        .unwrap();
+        let spec = spec_with_obligation("solvency", "deposit");
+        let findings = check_orphans(&spec, dir.path()).unwrap();
+        assert!(findings.contains(&OrphanFinding::RestatedStatement {
+            theorem: "solvency_preserved_by_deposit".to_string()
+        }));
+        assert!(
+            findings.contains(&OrphanFinding::RestatedStatement {
+                theorem: "cover_can_execute".to_string()
+            }),
+            "non-preservation stmt obligations nudge too; got {findings:?}"
+        );
+    }
+
+    /// The blessed form — `theorem X : X_stmt` (bare or namespace-qualified)
+    /// — produces no nudge.
+    #[test]
+    fn stmt_typed_theorems_do_not_nudge() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Spec.lean"),
+            "def solvency_preserved_by_deposit_stmt : Prop := True\n\
+             def cover_can_execute_stmt : Prop := True\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("Proofs.lean"),
+            "theorem solvency_preserved_by_deposit :\n\
+             \x20   solvency_preserved_by_deposit_stmt := by sorry\n\
+             theorem cover_can_execute : Vault.cover_can_execute_stmt := by sorry\n",
+        )
+        .unwrap();
+        let spec = spec_with_obligation("solvency", "deposit");
+        let findings = check_orphans(&spec, dir.path()).unwrap();
+        assert!(
+            !findings
+                .iter()
+                .any(|f| matches!(f, OrphanFinding::RestatedStatement { .. })),
+            "stmt-typed theorems must not nudge; got {findings:?}"
+        );
+    }
+
+    /// Flat shapes: no Spec.lean statements → no nudge, whatever the
+    /// theorem's typing.
+    #[test]
+    fn no_stmt_defs_no_nudge() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Spec.lean"),
+            "def solvency (s : State) : Prop := True\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("Proofs.lean"),
+            "theorem solvency_preserved_by_deposit : True := by trivial\n",
+        )
+        .unwrap();
+        let spec = spec_with_obligation("solvency", "deposit");
+        let findings = check_orphans(&spec, dir.path()).unwrap();
+        assert!(findings.is_empty(), "got {findings:?}");
+    }
+
+    /// Bootstrap checklist shows the typed form for stmt-backed obligations
+    /// and lists the full stmt inventory, not just preservation.
+    #[test]
+    fn bootstrap_checklist_uses_stmt_form() {
+        let spec = spec_with_obligation("solvency", "deposit");
+        let stmts: BTreeSet<String> = ["solvency_preserved_by_deposit", "cover_can_execute"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let out = render_bootstrap(&spec, &stmts);
+        assert!(out.contains(
+            "--   theorem solvency_preserved_by_deposit : solvency_preserved_by_deposit_stmt := by sorry"
+        ));
+        assert!(out.contains("--   theorem cover_can_execute : cover_can_execute_stmt := by sorry"));
+
+        // Flat shape unchanged: bare checklist line.
+        let flat = render_bootstrap(&spec, &BTreeSet::new());
+        assert!(flat.contains("--   theorem solvency_preserved_by_deposit\n"));
+        assert!(!flat.contains("_stmt"));
     }
 
     #[test]

--- a/crates/qedgen/src/project/reconcile.rs
+++ b/crates/qedgen/src/project/reconcile.rs
@@ -178,7 +178,10 @@ pub fn reconcile(spec_path: &Path, code_dir: &Path, proofs_dir: &Path) -> Result
                 }
                 // #166: a Proofs.lean from a DIFFERENT spec is a workspace-
                 // hygiene note, not per-theorem drift — surface as a warning.
-                f @ OrphanFinding::ForeignProofs { .. } => {
+                // #349: a theorem restating its machine-owned `_stmt` is the
+                // same class — valid proof, missing statement guard.
+                f @ (OrphanFinding::ForeignProofs { .. }
+                | OrphanFinding::RestatedStatement { .. }) => {
                     warnings.push(f.to_string());
                 }
             }

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -1332,9 +1332,16 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     // A foreign Proofs.lean (generated from a DIFFERENT spec,
                     // #166) is informational — a Kani-first workflow may
                     // legitimately never regenerate Lean — so it must not
-                    // fail the check. Real same-spec drift still does.
-                    let only_foreign = findings.iter().all(|f| {
-                        matches!(f, proofs_bootstrap::OrphanFinding::ForeignProofs { .. })
+                    // fail the check. A restated-statement nudge (#349) is
+                    // likewise informational: the proof is valid, only the
+                    // statement guard is missing. Real same-spec drift
+                    // (orphan/missing) still fails.
+                    let only_informational = findings.iter().all(|f| {
+                        matches!(
+                            f,
+                            proofs_bootstrap::OrphanFinding::ForeignProofs { .. }
+                                | proofs_bootstrap::OrphanFinding::RestatedStatement { .. }
+                        )
                     });
                     if json {
                         let as_json: Vec<serde_json::Value> = findings
@@ -1354,6 +1361,12 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                                     "declared": declared,
                                     "expected": expected,
                                 }),
+                                proofs_bootstrap::OrphanFinding::RestatedStatement { theorem } => {
+                                    serde_json::json!({
+                                        "kind": "restated_statement",
+                                        "theorem": theorem,
+                                    })
+                                }
                             })
                             .collect();
                         println!("{}", serde_json::to_string_pretty(&as_json)?);
@@ -1363,7 +1376,7 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                             eprintln!("  {}", f);
                         }
                     }
-                    if !only_foreign {
+                    if !only_informational {
                         has_issues = true;
                     }
                 }

--- a/docs/framework-support.md
+++ b/docs/framework-support.md
@@ -56,9 +56,11 @@ manifest.
 ³ Indexed shapes (`Map[N]` fields, #336): `Spec.lean` carries a
 machine-owned `def <name>_stmt : Prop` for every obligation (preservation,
 aborts, ensures, covers, liveness, environments); proof bodies stay in the
-user-owned `Proofs.lean`, ideally typed `theorem <name> : <name>_stmt` so
-a restated obligation no longer type-checks. The obligation manifest
-records each statement as emitted — the old blanket
+user-owned `Proofs.lean`, typed `theorem <name> : <name>_stmt` so
+a restated obligation no longer type-checks. `qedgen check` nudges any
+theorem that restates its obligation instead of typing against the
+`_stmt` (#349, informational). The obligation manifest records each
+statement as emitted — the old blanket
 `lean_indexed_shape_proofs_external` status is gone.
 
 ⁴ Multi-account file-level features (#324): covers, liveness, and

--- a/examples/rust/multisig/formal_verification/Proofs.lean
+++ b/examples/rust/multisig/formal_verification/Proofs.lean
@@ -5,6 +5,10 @@ Proofs.lean — user-owned preservation proofs for Multisig.
 Spec.lean is regenerated; this file is durable. `qedgen check`
 (and `qedgen reconcile`) flag orphan theorems (handler removed from
 spec) and missing obligations (new `preserved_by` declared).
+
+Spec.lean owns each obligation statement as `def <name>_stmt : Prop`;
+every theorem here types against its `_stmt`, so a statement cannot
+drift from the spec — only the proof body is hand-written.
 -/
 import Spec
 
@@ -19,75 +23,71 @@ open QEDGen.Solana
 -- them untouched or only decrements member_count under a guard that proves
 -- the new value still ≥ threshold.
 
-theorem threshold_bounded_preserved_by_create_vault
-    (s s' : State) (signer : Pubkey) (threshold member_count : Nat)
-    (_h_inv : threshold_bounded s)
-    (h : create_vaultTransition s signer threshold member_count = some s') :
-    threshold_bounded s' := by
+theorem threshold_bounded_preserved_by_create_vault :
+    threshold_bounded_preserved_by_create_vault_stmt := by
+  intro s s' signer threshold member_count _h_inv h
   unfold create_vaultTransition at h
   split_ifs at h with hg
   cases h
   unfold threshold_bounded
   exact ⟨hg.2.2.1.2, hg.2.2.1.1⟩
 
-theorem threshold_bounded_preserved_by_propose
-    (s s' : State) (signer : Pubkey)
-    (h_inv : threshold_bounded s)
-    (h : proposeTransition s signer = some s') :
-    threshold_bounded s' := by
+theorem threshold_bounded_preserved_by_propose :
+    threshold_bounded_preserved_by_propose_stmt := by
+  intro s s' signer h_inv h
   unfold proposeTransition at h
   split_ifs at h
   cases h
   exact h_inv
 
-theorem threshold_bounded_preserved_by_approve
-    (s s' : State) (signer : Pubkey) (member_index : Fin MAX_MEMBERS)
-    (h_inv : threshold_bounded s)
-    (h : approveTransition s signer member_index = some s') :
-    threshold_bounded s' := by
+theorem threshold_bounded_preserved_by_approve :
+    threshold_bounded_preserved_by_approve_stmt := by
+  intro s s' signer member_index h_inv h
   unfold approveTransition at h
   simp only at h
   split_ifs at h
   cases h
   exact h_inv
 
-theorem threshold_bounded_preserved_by_reject
-    (s s' : State) (signer : Pubkey) (member_index : Fin MAX_MEMBERS)
-    (h_inv : threshold_bounded s)
-    (h : rejectTransition s signer member_index = some s') :
-    threshold_bounded s' := by
+theorem threshold_bounded_preserved_by_reject :
+    threshold_bounded_preserved_by_reject_stmt := by
+  intro s s' signer member_index h_inv h
   unfold rejectTransition at h
   simp only at h
   split_ifs at h
   cases h
   exact h_inv
 
-theorem threshold_bounded_preserved_by_execute
-    (s s' : State) (signer : Pubkey) (member_index : Fin MAX_MEMBERS)
-    (h_inv : threshold_bounded s)
-    (h : executeTransition s signer member_index = some s') :
-    threshold_bounded s' := by
+theorem threshold_bounded_preserved_by_execute :
+    threshold_bounded_preserved_by_execute_stmt := by
+  intro s s' signer member_index h_inv h
   unfold executeTransition at h
   simp only at h
   split_ifs at h
   cases h
   exact h_inv
 
-theorem threshold_bounded_preserved_by_cancel_proposal
-    (s s' : State) (signer : Pubkey)
-    (h_inv : threshold_bounded s)
-    (h : cancel_proposalTransition s signer = some s') :
-    threshold_bounded s' := by
+theorem threshold_bounded_preserved_by_cancel_proposal :
+    threshold_bounded_preserved_by_cancel_proposal_stmt := by
+  intro s s' signer h_inv h
   unfold cancel_proposalTransition at h
   split_ifs at h
   cases h
   exact h_inv
 
-theorem threshold_bounded_preserved_by_remove_member
-    (s s' : State) (signer : Pubkey)
-    (h_inv : threshold_bounded s)
-    (h : remove_memberTransition s signer = some s') :
-    threshold_bounded s' := by
+theorem threshold_bounded_preserved_by_add_member :
+    threshold_bounded_preserved_by_add_member_stmt := by
+  intro s s' signer member_index member_pubkey h_inv h
+  -- add_member rewrites `members`/`status` only; threshold and member_count
+  -- pass through untouched.
+  unfold add_memberTransition at h
+  split_ifs at h
+  cases h
+  exact h_inv
+
+theorem threshold_bounded_preserved_by_remove_member :
+    threshold_bounded_preserved_by_remove_member_stmt := by
+  intro s s' signer h_inv h
   unfold remove_memberTransition at h
   split_ifs at h with hg
   cases h
@@ -110,11 +110,9 @@ theorem threshold_bounded_preserved_by_remove_member
 -- per-slot `voted` bitmap; see the comment on `votes_bounded` in
 -- multisig.qedspec for why those obligations are excluded.
 
-theorem votes_bounded_preserved_by_create_vault
-    (s s' : State) (signer : Pubkey) (threshold member_count : Nat)
-    (_h_inv : votes_bounded s)
-    (h : create_vaultTransition s signer threshold member_count = some s') :
-    votes_bounded s' := by
+theorem votes_bounded_preserved_by_create_vault :
+    votes_bounded_preserved_by_create_vault_stmt := by
+  intro s s' signer threshold member_count _h_inv h
   unfold create_vaultTransition at h
   split_ifs at h
   cases h
@@ -122,22 +120,18 @@ theorem votes_bounded_preserved_by_create_vault
   -- s'.approval_count = 0, s'.rejection_count = 0 ⇒ 0 ≤ s'.member_count
   dsimp only; omega
 
-theorem votes_bounded_preserved_by_propose
-    (s s' : State) (signer : Pubkey)
-    (_h_inv : votes_bounded s)
-    (h : proposeTransition s signer = some s') :
-    votes_bounded s' := by
+theorem votes_bounded_preserved_by_propose :
+    votes_bounded_preserved_by_propose_stmt := by
+  intro s s' signer _h_inv h
   unfold proposeTransition at h
   split_ifs at h
   cases h
   unfold votes_bounded
   dsimp only; omega
 
-theorem votes_bounded_preserved_by_execute
-    (s s' : State) (signer : Pubkey) (member_index : Fin MAX_MEMBERS)
-    (_h_inv : votes_bounded s)
-    (h : executeTransition s signer member_index = some s') :
-    votes_bounded s' := by
+theorem votes_bounded_preserved_by_execute :
+    votes_bounded_preserved_by_execute_stmt := by
+  intro s s' signer member_index _h_inv h
   unfold executeTransition at h
   simp only at h
   split_ifs at h
@@ -145,22 +139,18 @@ theorem votes_bounded_preserved_by_execute
   unfold votes_bounded
   dsimp only; omega
 
-theorem votes_bounded_preserved_by_cancel_proposal
-    (s s' : State) (signer : Pubkey)
-    (_h_inv : votes_bounded s)
-    (h : cancel_proposalTransition s signer = some s') :
-    votes_bounded s' := by
+theorem votes_bounded_preserved_by_cancel_proposal :
+    votes_bounded_preserved_by_cancel_proposal_stmt := by
+  intro s s' signer _h_inv h
   unfold cancel_proposalTransition at h
   split_ifs at h
   cases h
   unfold votes_bounded
   dsimp only; omega
 
-theorem votes_bounded_preserved_by_remove_member
-    (s s' : State) (signer : Pubkey)
-    (_h_inv : votes_bounded s)
-    (h : remove_memberTransition s signer = some s') :
-    votes_bounded s' := by
+theorem votes_bounded_preserved_by_remove_member :
+    votes_bounded_preserved_by_remove_member_stmt := by
+  intro s s' signer _h_inv h
   unfold remove_memberTransition at h
   split_ifs at h with hg
   cases h


### PR DESCRIPTION
## Problem

#336 (PR #344) made indexed-shape `Spec.lean` emit one machine-owned `def <name>_stmt : Prop` per obligation. Nothing checked that `Proofs.lean` theorems used them. A theorem that restated its obligation inline still elaborated, still passed `check_orphans` (name match only), and still counted as the proof. The statement-drift hole closed at the statement site stayed open at the proof site. This was the named follow-up in PR #344.

## Change

- `check_orphans` reads the sibling generated `Spec.lean` and extracts the `_stmt` names. This is artifact-derived on purpose: reading the generated file cannot drift from the emitter the way a second copy of its naming logic could. A declared theorem whose name has a matching `_stmt` def but whose stated type is not that `_stmt` gets a `RestatedStatement` nudge. The nudge covers the full statement inventory (preservation, aborts, ensures, covers, liveness, environments), not just `expected_theorems`.
- The nudge is informational, same class as the #166 foreign-proofs note: the restated theorem is still a valid proof, only the statement guard is missing. It prints in `check` (text and JSON kind `restated_statement`) and lands in `reconcile` warnings. It does not fail the check on its own. Real orphan/missing drift still does.
- The bootstrap checklist now lists the full statement inventory and shows the typed form (`theorem <name> : <name>_stmt := by sorry`) for statement-backed obligations. Flat shapes render unchanged.
- The bundled multisig example `Proofs.lean` is migrated: every theorem now types against its `_stmt` Prop, so the shipped example demonstrates the blessed pattern and carries zero nudges. The migration also adds the previously missing `threshold_bounded_preserved_by_add_member` proof — `check` had been reporting that as real drift (the spec declares the obligation; the file never carried it).

## Validation

- New unit tests: stmt-def extraction, restated theorem nudges (including a non-preservation cover obligation), stmt-typed and namespace-qualified typings do not nudge, flat shapes unaffected, bootstrap checklist forms.
- `lake build` on the migrated multisig example passes (1154 jobs, `Proofs` rebuilt cleanly).
- `qedgen check --proofs` on the example: zero Proofs.lean drift findings (previously 1 missing + 12 restated).
- Full suite green; clippy and fmt clean.

Closes #349