### PR TITLE
fix(probe): resolve Crucible deploy .so from the workspace root (#342)

### DIFF
--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -696,14 +696,10 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 }
                 // Absolute path to the built program so the harness loads it
                 // from any location (a `--harness-dir` outside the project
-                // can't reach it with the layout-relative fallback). The `.so`
-                // need not exist yet (budget-0 emit), so anchor on the project
-                // root — which does — rather than canonicalizing the `.so`.
-                let deploy_so = std::fs::canonicalize(&project_root_for_idl)
-                    .unwrap_or_else(|_| project_root_for_idl.clone())
-                    .join("target")
-                    .join("deploy")
-                    .join(format!("{prog}.so"));
+                // can't reach it with the layout-relative fallback).
+                // `cargo build-sbf` writes to the WORKSPACE target dir, so
+                // the resolver walks up from the program crate (#342).
+                let deploy_so = run_helpers::resolve_deploy_so(&project_root_for_idl, &prog);
                 if generate_harness {
                     std::fs::create_dir_all(&harness_parent)?;
                     crucible_gen::generate_with_account_overlay(

--- a/crates/qedgen/src/run_helpers.rs
+++ b/crates/qedgen/src/run_helpers.rs
@@ -61,6 +61,50 @@ pub(crate) fn resolve_output_against_spec(spec_dir: &Path, p: PathBuf) -> PathBu
     }
 }
 
+/// Resolve the built program `.so` the Crucible harness loads (#342).
+/// `cargo build-sbf` writes to the WORKSPACE `target/deploy/`, so a
+/// crate-rooted join never exists in the standard Anchor
+/// `programs/<name>/` layout and the harness panics at `setup()`.
+/// Walk the ancestor chain of the program root:
+/// 1. the first `target/deploy/<prog>.so` that already exists wins
+///    (works for any layout once the program is built);
+/// 2. else the nearest ancestor whose `Cargo.toml` declares a
+///    `[workspace]` table (covers the budget-0 emit before any build);
+/// 3. else fall back to the crate root itself (standalone crate — the
+///    pre-#342 behavior, correct there).
+pub(crate) fn resolve_deploy_so(project_root: &Path, prog: &str) -> PathBuf {
+    let root = std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let so_name = format!("{prog}.so");
+    let candidate = |dir: &Path| dir.join("target").join("deploy").join(&so_name);
+    for dir in root.ancestors() {
+        let built = candidate(dir);
+        if built.exists() {
+            return built;
+        }
+    }
+    for dir in root.ancestors() {
+        if manifest_declares_workspace(&dir.join("Cargo.toml")) {
+            return candidate(dir);
+        }
+    }
+    candidate(&root)
+}
+
+/// True when the manifest contains a `[workspace]` or `[workspace.*]`
+/// table header. Member crates never carry these headers (they opt in
+/// via `dependency.workspace = true` keys), so a match identifies the
+/// workspace root without a TOML parse.
+fn manifest_declares_workspace(manifest: &Path) -> bool {
+    std::fs::read_to_string(manifest)
+        .map(|text| {
+            text.lines().any(|line| {
+                let t = line.trim();
+                t == "[workspace]" || t.starts_with("[workspace.")
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// Canonicalize the `--program` root once at the probe entry (#289).
 /// `--program .` is the natural invocation from inside a program root,
 /// but every downstream name — the skeleton `spec` name, the
@@ -1127,6 +1171,72 @@ mod tests {
         assert_eq!(
             missing.file_name().and_then(|n| n.to_str()),
             Some("no-such-dir-289")
+        );
+    }
+
+    /// #342: in the standard Anchor workspace layout (`programs/<name>/`),
+    /// `cargo build-sbf` writes the `.so` to the WORKSPACE `target/deploy/`.
+    /// The resolver must return that path, not the crate-rooted join that
+    /// never exists.
+    #[test]
+    fn deploy_so_resolves_workspace_rooted_built_artifact() {
+        let ws = tempfile::tempdir().unwrap();
+        let crate_root = ws.path().join("programs").join("my-program");
+        std::fs::create_dir_all(&crate_root).unwrap();
+        std::fs::write(ws.path().join("Cargo.toml"), "[workspace]\nmembers = [\"programs/*\"]\n")
+            .unwrap();
+        std::fs::write(crate_root.join("Cargo.toml"), "[package]\nname = \"my-program\"\n")
+            .unwrap();
+        let deploy = ws.path().join("target").join("deploy");
+        std::fs::create_dir_all(&deploy).unwrap();
+        std::fs::write(deploy.join("my_program.so"), b"elf").unwrap();
+
+        let resolved = super::resolve_deploy_so(&crate_root, "my_program");
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(ws.path()).unwrap().join("target/deploy/my_program.so"),
+            "must pick the workspace-rooted built artifact"
+        );
+    }
+
+    /// #342: budget-0 emit — nothing is built yet, so no `.so` exists
+    /// anywhere. The resolver must still anchor on the workspace root
+    /// (the dir whose Cargo.toml declares `[workspace]`), because that
+    /// is where `cargo build-sbf` will write.
+    #[test]
+    fn deploy_so_prefers_workspace_manifest_when_nothing_is_built() {
+        let ws = tempfile::tempdir().unwrap();
+        let crate_root = ws.path().join("programs").join("my-program");
+        std::fs::create_dir_all(&crate_root).unwrap();
+        std::fs::write(
+            ws.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"programs/*\"]\n\n[workspace.dependencies]\nanchor-lang = \"0.31\"\n",
+        )
+        .unwrap();
+        std::fs::write(crate_root.join("Cargo.toml"), "[package]\nname = \"my-program\"\n")
+            .unwrap();
+
+        let resolved = super::resolve_deploy_so(&crate_root, "my_program");
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(ws.path()).unwrap().join("target/deploy/my_program.so"),
+        );
+    }
+
+    /// #342: a standalone crate (no workspace anywhere above) keeps the
+    /// crate-rooted path — the pre-#342 behavior, correct there.
+    #[test]
+    fn deploy_so_falls_back_to_crate_root_for_standalone_crate() {
+        let dir = tempfile::tempdir().unwrap();
+        let crate_root = dir.path().join("standalone");
+        std::fs::create_dir_all(&crate_root).unwrap();
+        std::fs::write(crate_root.join("Cargo.toml"), "[package]\nname = \"standalone\"\n")
+            .unwrap();
+
+        let resolved = super::resolve_deploy_so(&crate_root, "standalone");
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(&crate_root).unwrap().join("target/deploy/standalone.so"),
         );
     }
 

--- a/crates/qedgen/src/run_helpers.rs
+++ b/crates/qedgen/src/run_helpers.rs
@@ -90,19 +90,14 @@ pub(crate) fn resolve_deploy_so(project_root: &Path, prog: &str) -> PathBuf {
     candidate(&root)
 }
 
-/// True when the manifest contains a `[workspace]` or `[workspace.*]`
-/// table header. Member crates never carry these headers (they opt in
-/// via `dependency.workspace = true` keys), so a match identifies the
-/// workspace root without a TOML parse.
+/// True when the manifest declares a Cargo workspace table. Parse TOML
+/// instead of scanning header text so valid formatting such as
+/// `[workspace] # root workspace` and `[ workspace ]` is recognized.
 fn manifest_declares_workspace(manifest: &Path) -> bool {
     std::fs::read_to_string(manifest)
-        .map(|text| {
-            text.lines().any(|line| {
-                let t = line.trim();
-                t == "[workspace]" || t.starts_with("[workspace.")
-            })
-        })
-        .unwrap_or(false)
+        .ok()
+        .and_then(|text| text.parse::<toml::Value>().ok())
+        .is_some_and(|manifest| manifest.get("workspace").is_some())
 }
 
 /// Canonicalize the `--program` root once at the probe entry (#289).
@@ -1183,10 +1178,16 @@ mod tests {
         let ws = tempfile::tempdir().unwrap();
         let crate_root = ws.path().join("programs").join("my-program");
         std::fs::create_dir_all(&crate_root).unwrap();
-        std::fs::write(ws.path().join("Cargo.toml"), "[workspace]\nmembers = [\"programs/*\"]\n")
-            .unwrap();
-        std::fs::write(crate_root.join("Cargo.toml"), "[package]\nname = \"my-program\"\n")
-            .unwrap();
+        std::fs::write(
+            ws.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"programs/*\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            crate_root.join("Cargo.toml"),
+            "[package]\nname = \"my-program\"\n",
+        )
+        .unwrap();
         let deploy = ws.path().join("target").join("deploy");
         std::fs::create_dir_all(&deploy).unwrap();
         std::fs::write(deploy.join("my_program.so"), b"elf").unwrap();
@@ -1194,7 +1195,9 @@ mod tests {
         let resolved = super::resolve_deploy_so(&crate_root, "my_program");
         assert_eq!(
             resolved,
-            std::fs::canonicalize(ws.path()).unwrap().join("target/deploy/my_program.so"),
+            std::fs::canonicalize(ws.path())
+                .unwrap()
+                .join("target/deploy/my_program.so"),
             "must pick the workspace-rooted built artifact"
         );
     }
@@ -1213,13 +1216,46 @@ mod tests {
             "[workspace]\nmembers = [\"programs/*\"]\n\n[workspace.dependencies]\nanchor-lang = \"0.31\"\n",
         )
         .unwrap();
-        std::fs::write(crate_root.join("Cargo.toml"), "[package]\nname = \"my-program\"\n")
-            .unwrap();
+        std::fs::write(
+            crate_root.join("Cargo.toml"),
+            "[package]\nname = \"my-program\"\n",
+        )
+        .unwrap();
 
         let resolved = super::resolve_deploy_so(&crate_root, "my_program");
         assert_eq!(
             resolved,
-            std::fs::canonicalize(ws.path()).unwrap().join("target/deploy/my_program.so"),
+            std::fs::canonicalize(ws.path())
+                .unwrap()
+                .join("target/deploy/my_program.so"),
+        );
+    }
+
+    /// Cargo permits comments after table headers. A textual equality
+    /// check for `[workspace]` misses this valid manifest and sends
+    /// budget-0 harnesses back to the crate-rooted path.
+    #[test]
+    fn deploy_so_recognizes_commented_workspace_header() {
+        let ws = tempfile::tempdir().unwrap();
+        let crate_root = ws.path().join("programs").join("my-program");
+        std::fs::create_dir_all(&crate_root).unwrap();
+        std::fs::write(
+            ws.path().join("Cargo.toml"),
+            "[workspace] # root workspace\nmembers = [\"programs/*\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            crate_root.join("Cargo.toml"),
+            "[package]\nname = \"my-program\"\n",
+        )
+        .unwrap();
+
+        let resolved = super::resolve_deploy_so(&crate_root, "my_program");
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(ws.path())
+                .unwrap()
+                .join("target/deploy/my_program.so"),
         );
     }
 
@@ -1230,13 +1266,18 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let crate_root = dir.path().join("standalone");
         std::fs::create_dir_all(&crate_root).unwrap();
-        std::fs::write(crate_root.join("Cargo.toml"), "[package]\nname = \"standalone\"\n")
-            .unwrap();
+        std::fs::write(
+            crate_root.join("Cargo.toml"),
+            "[package]\nname = \"standalone\"\n",
+        )
+        .unwrap();
 
         let resolved = super::resolve_deploy_so(&crate_root, "standalone");
         assert_eq!(
             resolved,
-            std::fs::canonicalize(&crate_root).unwrap().join("target/deploy/standalone.so"),
+            std::fs::canonicalize(&crate_root)
+                .unwrap()
+                .join("target/deploy/standalone.so"),
         );
     }
 


### PR DESCRIPTION
Closes #342.

## Problem

The `probe --fuzz` harness hardcoded the program `.so` path as `<crate-root>/target/deploy/<name>.so`. In the standard Anchor workspace layout (`programs/<name>/`), `cargo build-sbf` writes to the **workspace** `target/deploy/`. The hardcoded path never existed, so every `crucible run` panicked at fixture `setup()` with "No such file or directory" before any fuzzing happened.

## Fix

New `run_helpers::resolve_deploy_so`, wired into the probe `--fuzz` path. It walks the ancestor chain from the program crate:

1. The first `target/deploy/<name>.so` that already exists wins (correct for any layout once the program is built).
2. Else the nearest ancestor whose `Cargo.toml` declares a `[workspace]` table (covers the budget-0 emit before any build). Member manifests never carry `[workspace.*]` table headers, so the scan identifies the workspace root without a TOML parse.
3. Else the crate root itself — standalone crates keep the old behavior, which was correct there.

## Tests

Unit tests cover the built-workspace, unbuilt-workspace (budget-0), and standalone layouts. Full suite green.