### PR TITLE
fix(codegen): type-correct call exprs for compound Crucible fuzz args (#340)

### DIFF
--- a/crates/qedgen/src/codegen/crucible_gen.rs
+++ b/crates/qedgen/src/codegen/crucible_gen.rs
@@ -1051,10 +1051,13 @@ enum FuzzParamKind {
     /// Fuzzable primitive: action param + field shorthand at the call.
     Fuzzed(&'static str),
     /// `Option(<fuzzable primitive>)`: the INNER value is the action
-    /// param; the call site wraps it in `Some(..)`.
+    /// param; a companion bool lets the fuzzer choose `None` or `Some`.
     OptionFuzzed(&'static str),
+    /// `Option(<non-fuzzable payload>)`: a companion bool still fuzzes
+    /// the discriminant, while `Some` carries this type-correct default.
+    OptionInline(String),
     /// Not fuzzable (Pubkey, enum/struct, array, vec, string, unknown):
-    /// no action param; this expression is inlined at the call site.
+    /// no payload action param; this expression is inlined at the call site.
     Inline(String),
 }
 
@@ -1079,14 +1082,15 @@ fn fuzz_param_kind(dsl_type: &str) -> FuzzParamKind {
         return FuzzParamKind::Fuzzed(mapped);
     }
     if let Some(inner) = strip_type_wrap(dsl_type, "Option(") {
-        if inner != "Pubkey" {
-            let inner_mapped = map_simple_type(inner);
-            if !inner_mapped.starts_with("()") {
-                return FuzzParamKind::OptionFuzzed(inner_mapped);
+        return match fuzz_param_kind(inner) {
+            FuzzParamKind::Fuzzed(inner_mapped) => FuzzParamKind::OptionFuzzed(inner_mapped),
+            FuzzParamKind::Inline(expr) => FuzzParamKind::OptionInline(expr),
+            // Nested options: `Default::default()` supplies the inner
+            // option (`None`) without inventing another action-field layer.
+            FuzzParamKind::OptionFuzzed(_) | FuzzParamKind::OptionInline(_) => {
+                FuzzParamKind::OptionInline("Default::default()".to_string())
             }
-        }
-        // Option of a non-fuzzable payload: `None` always type-checks.
-        return FuzzParamKind::Inline("None".to_string());
+        };
     }
     if let Some(body) = strip_type_wrap(dsl_type, "Array(") {
         // `Array(<elem>,<len>)` — the len is the LAST comma field, so
@@ -1125,6 +1129,16 @@ fn fuzz_param_kind(dsl_type: &str) -> FuzzParamKind {
 /// `strip_type_wrap("Option(U64)", "Option(")` → `Some("U64")`.
 fn strip_type_wrap<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
     s.strip_prefix(prefix)?.strip_suffix(')')
+}
+
+/// Collision-free synthetic action parameter controlling an Option's
+/// discriminant. IDL argument names remain untouched at the call site.
+fn option_presence_param(op: &ParsedHandler, pname: &str) -> String {
+    let mut candidate = format!("__qedgen_{pname}_is_some");
+    while op.takes_params.iter().any(|(name, _)| name == &candidate) {
+        candidate.insert(0, '_');
+    }
+    candidate
 }
 
 fn collect_signer_idents(spec: &ParsedSpec) -> Vec<String> {
@@ -1300,12 +1314,12 @@ fn emit_action_fn(
         out.push_str("    /// at the project root to auto-fill it).\n");
     }
 
-    // Only fuzzable primitives are exposed as action params (see
+    // Fuzzable primitives are exposed as action params (see
     // `fuzz_param_kind`): Pubkey breaks the `#[fuzz_fixture]` Arbitrary
     // derive, and compound IDL types (enum/struct/array/vec) have no
     // primitive shadow — both get a type-correct expression inlined at
-    // the `.call(...)` site instead (#340). `Option(<primitive>)` keeps
-    // its inner value fuzzable and wraps it in `Some(..)` at the call.
+    // the `.call(...)` site instead (#340). Every Option gets a fuzzed
+    // presence bool; primitive inners additionally remain fuzzable.
     let mut params = String::new();
     for (pname, ptype) in &op.takes_params {
         match fuzz_param_kind(ptype) {
@@ -1317,7 +1331,13 @@ fn emit_action_fn(
                 params.push_str(&format!("        {pname}: {rust_ty},\n"));
             }
             FuzzParamKind::OptionFuzzed(rust_ty) => {
+                let presence = option_presence_param(op, pname);
+                params.push_str(&format!("        {presence}: bool,\n"));
                 params.push_str(&format!("        {pname}: {rust_ty},\n"));
+            }
+            FuzzParamKind::OptionInline(_) => {
+                let presence = option_presence_param(op, pname);
+                params.push_str(&format!("        {presence}: bool,\n"));
             }
             FuzzParamKind::Inline(_) => {}
         }
@@ -1394,7 +1414,14 @@ fn emit_action_fn(
         .iter()
         .map(|(n, t)| match fuzz_param_kind(t) {
             FuzzParamKind::Fuzzed(_) => format!("{n}, "),
-            FuzzParamKind::OptionFuzzed(_) => format!("{n}: Some({n}), "),
+            FuzzParamKind::OptionFuzzed(_) => {
+                let presence = option_presence_param(op, n);
+                format!("{n}: if {presence} {{ Some({n}) }} else {{ None }}, ")
+            }
+            FuzzParamKind::OptionInline(expr) => {
+                let presence = option_presence_param(op, n);
+                format!("{n}: if {presence} {{ Some({expr}) }} else {{ None }}, ")
+            }
             FuzzParamKind::Inline(expr) => format!("{n}: {expr}, "),
         })
         .collect();
@@ -2054,6 +2081,10 @@ handler resume : State.Inactive -> State.Active {
                 ("memo".into(), "Array(U8,97)".into()),
                 ("payload".into(), "Vec(U8)".into()),
                 ("payment_amount".into(), "Option(U64)".into()),
+                (
+                    "optional_policy".into(),
+                    "Option(Defined(PolicyType))".into(),
+                ),
                 ("label".into(), "String".into()),
                 ("rate".into(), "Opaque".into()),
                 ("recipient".into(), "Pubkey".into()),
@@ -2076,22 +2107,60 @@ handler resume : State.Inactive -> State.Active {
         // is lifted to a plain primitive param).
         let sig_start = out.find("pub fn action_create_policy").expect("action fn");
         let sig = &out[sig_start..out[sig_start..].find(") -> bool").unwrap() + sig_start];
+        assert!(
+            sig.contains("__qedgen_payment_amount_is_some: bool,"),
+            "sig: {sig}"
+        );
         assert!(sig.contains("payment_amount: u64,"), "sig: {sig}");
+        assert!(
+            sig.contains("__qedgen_optional_policy_is_some: bool,"),
+            "sig: {sig}"
+        );
         assert!(sig.contains("count: u32,"), "sig: {sig}");
-        for absent in ["policy_type:", "memo:", "payload:", "label:", "rate:", "recipient:"] {
-            assert!(!sig.contains(absent), "`{absent}` must not be fuzzed: {sig}");
+        for absent in [
+            "policy_type:",
+            "memo:",
+            "payload:",
+            "optional_policy:",
+            "label:",
+            "rate:",
+            "recipient:",
+        ] {
+            assert!(
+                !sig.contains(absent),
+                "`{absent}` must not be fuzzed: {sig}"
+            );
         }
 
         // Call literal: type-correct expression per arg.
-        let call_start = out.find(".call(instruction::CreatePolicy").expect("call literal");
+        let call_start = out
+            .find(".call(instruction::CreatePolicy")
+            .expect("call literal");
         let call = &out[call_start..out[call_start..].find(")\n").unwrap() + call_start];
-        assert!(call.contains("policy_type: Default::default(), "), "call: {call}");
+        assert!(
+            call.contains("policy_type: Default::default(), "),
+            "call: {call}"
+        );
         assert!(call.contains("memo: [0u8; 97], "), "call: {call}");
         assert!(call.contains("payload: Vec::new(), "), "call: {call}");
-        assert!(call.contains("payment_amount: Some(payment_amount), "), "call: {call}");
+        assert!(
+            call.contains(
+                "payment_amount: if __qedgen_payment_amount_is_some { Some(payment_amount) } else { None }, "
+            ),
+            "call: {call}"
+        );
+        assert!(
+            call.contains(
+                "optional_policy: if __qedgen_optional_policy_is_some { Some(Default::default()) } else { None }, "
+            ),
+            "call: {call}"
+        );
         assert!(call.contains("label: String::new(), "), "call: {call}");
         assert!(call.contains("rate: Default::default(), "), "call: {call}");
-        assert!(call.contains("recipient: Pubkey::default(), "), "call: {call}");
+        assert!(
+            call.contains("recipient: Pubkey::default(), "),
+            "call: {call}"
+        );
         // The one fuzzable primitive still uses field shorthand.
         assert!(call.contains(" count, "), "call: {call}");
     }
@@ -2106,6 +2175,7 @@ handler resume : State.Inactive -> State.Active {
             FuzzParamKind::Inline(expr) => expr,
             FuzzParamKind::Fuzzed(t) => format!("<fuzzed {t}>"),
             FuzzParamKind::OptionFuzzed(t) => format!("<option-fuzzed {t}>"),
+            FuzzParamKind::OptionInline(expr) => format!("<option-inline {expr}>"),
         };
         assert_eq!(expr_of("Array(I64,4)"), "[0i64; 4]");
         assert_eq!(expr_of("Array(Bool,8)"), "[false; 8]");
@@ -2114,10 +2184,29 @@ handler resume : State.Inactive -> State.Active {
             expr_of("Array(Defined(Tier),5)"),
             "core::array::from_fn(|_| Default::default())"
         );
-        assert_eq!(expr_of("Option(Pubkey)"), "None");
-        assert_eq!(expr_of("Option(Defined(Tier))"), "None");
+        assert_eq!(
+            expr_of("Option(Pubkey)"),
+            "<option-inline Pubkey::default()>"
+        );
+        assert_eq!(
+            expr_of("Option(Defined(Tier))"),
+            "<option-inline Default::default()>"
+        );
         assert_eq!(expr_of("Option(Bool)"), "<option-fuzzed bool>");
         assert_eq!(expr_of("Vec(Defined(Tier))"), "Vec::new()");
+    }
+
+    #[test]
+    fn option_presence_param_avoids_idl_name_collisions() {
+        let mut op = synthetic_handler();
+        op.takes_params = vec![
+            ("value".into(), "Option(U64)".into()),
+            ("__qedgen_value_is_some".into(), "Bool".into()),
+        ];
+        assert_eq!(
+            option_presence_param(&op, "value"),
+            "___qedgen_value_is_some"
+        );
     }
 
     #[test]

--- a/crates/qedgen/src/codegen/crucible_gen.rs
+++ b/crates/qedgen/src/codegen/crucible_gen.rs
@@ -1044,6 +1044,89 @@ fn map_simple_type(dsl_type: &str) -> &'static str {
     }
 }
 
+/// How one instruction argument reaches the `.call(instruction::X { .. })`
+/// literal (#340: forwarding a bare `u64` into a typed field is an E0308
+/// per non-primitive arg).
+enum FuzzParamKind {
+    /// Fuzzable primitive: action param + field shorthand at the call.
+    Fuzzed(&'static str),
+    /// `Option(<fuzzable primitive>)`: the INNER value is the action
+    /// param; the call site wraps it in `Some(..)`.
+    OptionFuzzed(&'static str),
+    /// Not fuzzable (Pubkey, enum/struct, array, vec, string, unknown):
+    /// no action param; this expression is inlined at the call site.
+    Inline(String),
+}
+
+/// Classify a `takes_params` type. Primitive names are qedspec DSL types
+/// (`U64`, `Bool`, ...); compound shapes arrive from the IDL as the
+/// structured encodings built by `crucible_brownfield::idl_arg_type`
+/// (`Array(U8,97)`, `Vec(U8)`, `Option(U64)`, `Defined(X)`, `String`,
+/// `Opaque`). `Defined` and `Opaque` render `Default::default()` — the
+/// `declare_fuzz_program!` macro derives `Default` for every IDL type
+/// (its derive has its own >32-byte-array limitation, tracked upstream
+/// as issue #341's root cause).
+fn fuzz_param_kind(dsl_type: &str) -> FuzzParamKind {
+    // Pubkey args are deliberately fixed: `#[fuzz_fixture]` cannot derive
+    // Arbitrary for Solana's `Address` wrapper, so one in the action
+    // signature breaks the build. Real PDAs / signer pubkeys belong in
+    // the `.accounts(...)` literal, not the fuzzed payload.
+    if dsl_type == "Pubkey" {
+        return FuzzParamKind::Inline("Pubkey::default()".to_string());
+    }
+    let mapped = map_simple_type(dsl_type);
+    if !mapped.starts_with("()") {
+        return FuzzParamKind::Fuzzed(mapped);
+    }
+    if let Some(inner) = strip_type_wrap(dsl_type, "Option(") {
+        if inner != "Pubkey" {
+            let inner_mapped = map_simple_type(inner);
+            if !inner_mapped.starts_with("()") {
+                return FuzzParamKind::OptionFuzzed(inner_mapped);
+            }
+        }
+        // Option of a non-fuzzable payload: `None` always type-checks.
+        return FuzzParamKind::Inline("None".to_string());
+    }
+    if let Some(body) = strip_type_wrap(dsl_type, "Array(") {
+        // `Array(<elem>,<len>)` — the len is the LAST comma field, so
+        // nested element encodings split correctly.
+        if let Some((elem, len)) = body.rsplit_once(',') {
+            if len.bytes().all(|b| b.is_ascii_digit()) && !len.is_empty() {
+                let elem_mapped = map_simple_type(elem);
+                if elem_mapped.starts_with('u') || elem_mapped.starts_with('i') {
+                    return FuzzParamKind::Inline(format!("[0{elem_mapped}; {len}]"));
+                }
+                if elem == "Bool" {
+                    return FuzzParamKind::Inline(format!("[false; {len}]"));
+                }
+                if elem == "Pubkey" {
+                    return FuzzParamKind::Inline(format!("[Pubkey::default(); {len}]"));
+                }
+                // Non-Copy / defined elements: `from_fn` needs no
+                // `Default` on the ARRAY, only on the element.
+                return FuzzParamKind::Inline(
+                    "core::array::from_fn(|_| Default::default())".to_string(),
+                );
+            }
+        }
+    }
+    if dsl_type.starts_with("Vec(") {
+        return FuzzParamKind::Inline("Vec::new()".to_string());
+    }
+    if dsl_type == "String" {
+        return FuzzParamKind::Inline("String::new()".to_string());
+    }
+    // `Defined(X)`, `Opaque`, and any legacy spec type without a
+    // primitive shadow.
+    FuzzParamKind::Inline("Default::default()".to_string())
+}
+
+/// `strip_type_wrap("Option(U64)", "Option(")` → `Some("U64")`.
+fn strip_type_wrap<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    s.strip_prefix(prefix)?.strip_suffix(')')
+}
+
 fn collect_signer_idents(spec: &ParsedSpec) -> Vec<String> {
     let mut seen = std::collections::BTreeSet::new();
     for h in &spec.handlers {
@@ -1217,22 +1300,27 @@ fn emit_action_fn(
         out.push_str("    /// at the project root to auto-fill it).\n");
     }
 
-    // Pubkey-typed args are NOT exposed as action params: #[fuzz_fixture]
-    // can't derive Arbitrary for Pubkey (no Arbitrary on its `Address`
-    // wrapper), so one in the signature breaks the build. The call literal
-    // inlines `Pubkey::default()`; real PDAs / signer pubkeys belong in the
-    // agent-filled `.accounts(...)` literal, not the fuzzed payload.
+    // Only fuzzable primitives are exposed as action params (see
+    // `fuzz_param_kind`): Pubkey breaks the `#[fuzz_fixture]` Arbitrary
+    // derive, and compound IDL types (enum/struct/array/vec) have no
+    // primitive shadow — both get a type-correct expression inlined at
+    // the `.call(...)` site instead (#340). `Option(<primitive>)` keeps
+    // its inner value fuzzable and wraps it in `Some(..)` at the call.
     let mut params = String::new();
     for (pname, ptype) in &op.takes_params {
-        if ptype == "Pubkey" {
-            continue;
+        match fuzz_param_kind(ptype) {
+            FuzzParamKind::Fuzzed(rust_ty) => {
+                let range_attr = infer_range_attr(spec, ptype);
+                if !range_attr.is_empty() {
+                    params.push_str(&format!("        {range_attr}\n"));
+                }
+                params.push_str(&format!("        {pname}: {rust_ty},\n"));
+            }
+            FuzzParamKind::OptionFuzzed(rust_ty) => {
+                params.push_str(&format!("        {pname}: {rust_ty},\n"));
+            }
+            FuzzParamKind::Inline(_) => {}
         }
-        let rust_ty = map_simple_type(ptype);
-        let range_attr = infer_range_attr(spec, ptype);
-        if !range_attr.is_empty() {
-            params.push_str(&format!("        {range_attr}\n"));
-        }
-        params.push_str(&format!("        {pname}: {rust_ty},\n"));
     }
 
     out.push_str(&format!(
@@ -1299,17 +1387,15 @@ fn emit_action_fn(
     // `Result<TxOutcome, ...>`; both layers collapse into one bool —
     // transport errors count as failed actions, same as program errors.
     let ix_name = pascal_case(&op.name);
-    // Pubkey fields get `Pubkey::default()` (see param-list note above);
-    // other params pass through via field shorthand.
+    // Fuzzed primitives pass through via field shorthand; everything
+    // else gets a type-correct expression (see `fuzz_param_kind`).
     let arg_inits: String = op
         .takes_params
         .iter()
-        .map(|(n, t)| {
-            if t == "Pubkey" {
-                format!("{n}: Pubkey::default(), ")
-            } else {
-                format!("{n}, ")
-            }
+        .map(|(n, t)| match fuzz_param_kind(t) {
+            FuzzParamKind::Fuzzed(_) => format!("{n}, "),
+            FuzzParamKind::OptionFuzzed(_) => format!("{n}: Some({n}), "),
+            FuzzParamKind::Inline(expr) => format!("{n}: {expr}, "),
         })
         .collect();
     // Snapshot wallet lamports before .send() (Protocol / Both only). Tracked
@@ -1948,6 +2034,90 @@ handler resume : State.Inactive -> State.Active {
         assert!(out.contains("pub fn action_increment(\n        &mut self,\n    ) -> bool"));
         // todo!() agent-fill site for the accounts struct literal
         assert!(out.contains("todo!(\"agent-fill: accounts::Increment"));
+    }
+
+    /// #340: compound-typed instruction args (enum/struct, `[u8; N]`,
+    /// `Vec<u8>`, `Option<u64>`, `String`) must reach the
+    /// `.call(instruction::X { .. })` literal as type-correct
+    /// expressions, never as bare `u64` shorthand (E0308 per arg).
+    /// Only fuzzable primitives may appear in the action signature.
+    #[test]
+    fn action_fn_renders_type_correct_call_exprs_for_compound_args() {
+        let mut spec = ParsedSpec {
+            program_name: "PullPayments".into(),
+            ..Default::default()
+        };
+        spec.handlers.push(crate::check::ParsedHandler {
+            name: "create_policy".into(),
+            takes_params: vec![
+                ("policy_type".into(), "Defined(PolicyType)".into()),
+                ("memo".into(), "Array(U8,97)".into()),
+                ("payload".into(), "Vec(U8)".into()),
+                ("payment_amount".into(), "Option(U64)".into()),
+                ("label".into(), "String".into()),
+                ("rate".into(), "Opaque".into()),
+                ("recipient".into(), "Pubkey".into()),
+                ("count".into(), "U32".into()),
+            ],
+            ..synthetic_handler()
+        });
+        let mut out = String::new();
+        emit_fixture_impl(
+            &mut out,
+            &spec,
+            "PullPaymentsFixture",
+            InvariantMode::Spec,
+            None,
+            None,
+        )
+        .expect("emit");
+
+        // Signature: only the fuzzable primitives (Option's inner value
+        // is lifted to a plain primitive param).
+        let sig_start = out.find("pub fn action_create_policy").expect("action fn");
+        let sig = &out[sig_start..out[sig_start..].find(") -> bool").unwrap() + sig_start];
+        assert!(sig.contains("payment_amount: u64,"), "sig: {sig}");
+        assert!(sig.contains("count: u32,"), "sig: {sig}");
+        for absent in ["policy_type:", "memo:", "payload:", "label:", "rate:", "recipient:"] {
+            assert!(!sig.contains(absent), "`{absent}` must not be fuzzed: {sig}");
+        }
+
+        // Call literal: type-correct expression per arg.
+        let call_start = out.find(".call(instruction::CreatePolicy").expect("call literal");
+        let call = &out[call_start..out[call_start..].find(")\n").unwrap() + call_start];
+        assert!(call.contains("policy_type: Default::default(), "), "call: {call}");
+        assert!(call.contains("memo: [0u8; 97], "), "call: {call}");
+        assert!(call.contains("payload: Vec::new(), "), "call: {call}");
+        assert!(call.contains("payment_amount: Some(payment_amount), "), "call: {call}");
+        assert!(call.contains("label: String::new(), "), "call: {call}");
+        assert!(call.contains("rate: Default::default(), "), "call: {call}");
+        assert!(call.contains("recipient: Pubkey::default(), "), "call: {call}");
+        // The one fuzzable primitive still uses field shorthand.
+        assert!(call.contains(" count, "), "call: {call}");
+    }
+
+    /// #340: array-element coverage beyond `u8` — signed ints, bool,
+    /// Pubkey, and defined elements each need a different zero-value
+    /// spelling ([u8; N>32] has no `Default`, so `Default::default()`
+    /// is never an option for arrays).
+    #[test]
+    fn array_and_option_call_exprs_cover_element_kinds() {
+        let expr_of = |ty: &str| match fuzz_param_kind(ty) {
+            FuzzParamKind::Inline(expr) => expr,
+            FuzzParamKind::Fuzzed(t) => format!("<fuzzed {t}>"),
+            FuzzParamKind::OptionFuzzed(t) => format!("<option-fuzzed {t}>"),
+        };
+        assert_eq!(expr_of("Array(I64,4)"), "[0i64; 4]");
+        assert_eq!(expr_of("Array(Bool,8)"), "[false; 8]");
+        assert_eq!(expr_of("Array(Pubkey,3)"), "[Pubkey::default(); 3]");
+        assert_eq!(
+            expr_of("Array(Defined(Tier),5)"),
+            "core::array::from_fn(|_| Default::default())"
+        );
+        assert_eq!(expr_of("Option(Pubkey)"), "None");
+        assert_eq!(expr_of("Option(Defined(Tier))"), "None");
+        assert_eq!(expr_of("Option(Bool)"), "<option-fuzzed bool>");
+        assert_eq!(expr_of("Vec(Defined(Tier))"), "Vec::new()");
     }
 
     #[test]

--- a/crates/qedgen/src/probe/crucible_brownfield.rs
+++ b/crates/qedgen/src/probe/crucible_brownfield.rs
@@ -485,7 +485,17 @@ fn idl_arg_type(ty: &serde_json::Value) -> String {
             .get("item")
             .map(|item| format!("Option({})", idl_arg_type(item)))
             .unwrap_or_else(|| "Opaque".to_string()),
-        "definedTypeLinkNode" => format!("Defined({})", defined_type_name(ty)),
+        "definedTypeLinkNode" => {
+            let name = defined_type_name(ty);
+            // Keep parity with Crucible's Codama converter: these links
+            // are built-in scalar aliases, not generated compound types.
+            // Preserving their primitive shape keeps them fuzzer-mutated.
+            match name.as_str() {
+                "epoch" | "slot" | "lamports" => "U64".to_string(),
+                "unixTimestamp" | "unix_timestamp" => "I64".to_string(),
+                _ => format!("Defined({name})"),
+            }
+        }
         "arrayTypeNode" => {
             let count = ty
                 .get("count")
@@ -982,7 +992,10 @@ version = "0.1.0"
         { "name": "memo", "type": { "kind": "arrayTypeNode", "item": { "kind": "numberTypeNode", "format": "u8" }, "count": { "kind": "fixedCountNode", "value": 97 } } },
         { "name": "paymentAmount", "type": { "kind": "optionTypeNode", "item": { "kind": "numberTypeNode", "format": "u64" } } },
         { "name": "payload", "type": { "kind": "bytesTypeNode" } },
-        { "name": "label", "type": { "kind": "stringTypeNode" } }
+        { "name": "label", "type": { "kind": "stringTypeNode" } },
+        { "name": "epoch", "type": { "kind": "definedTypeLinkNode", "name": "epoch" } },
+        { "name": "timestamp", "type": { "kind": "definedTypeLinkNode", "name": "unixTimestamp" } },
+        { "name": "amount", "type": { "kind": "definedTypeLinkNode", "name": "lamports" } }
       ]
     }]
   }
@@ -998,6 +1011,9 @@ version = "0.1.0"
                 "Option(U64)",
                 "Vec(U8)",
                 "String",
+                "U64",
+                "I64",
+                "U64",
             ]
         );
     }

--- a/crates/qedgen/src/probe/crucible_brownfield.rs
+++ b/crates/qedgen/src/probe/crucible_brownfield.rs
@@ -217,9 +217,12 @@ pub(crate) fn discover_pinocchio_idl(project_root: &Path) -> Result<Option<Strin
 /// `defaultValueStrategy: "omitted"` (e.g. discriminators) are skipped;
 /// the macro doesn't surface them as struct fields.
 ///
-/// Unrecognised types map to a `"u64"` placeholder: it compiles, but a
-/// type-coercion failure in the macro's field is the signal that the type
-/// isn't supported yet (refine the IDL or accept the compile error).
+/// Compound arg types are preserved as structured encodings —
+/// `Array(U8,97)`, `Vec(U8)`, `Option(U64)`, `Defined(PolicyType)`,
+/// `String` — so the emitter can render a type-correct expression at the
+/// `.call(...)` site instead of a bare `u64` shorthand (#340: every
+/// non-primitive arg was an E0308). Types the mapper cannot classify
+/// become `Opaque`, which the emitter fills with `Default::default()`.
 pub(crate) fn handlers_with_args_from_idl(idl_text: &str) -> Vec<(String, Vec<(String, String)>)> {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(idl_text) else {
         return Vec::new();
@@ -450,6 +453,23 @@ fn idl_arg_type(ty: &serde_json::Value) -> String {
     if let Some(s) = ty.as_str() {
         return anchor_str_to_dsl(s);
     }
+    // Anchor JSON compound forms: {"array": [elem, N]}, {"vec": elem},
+    // {"option": inner}, {"defined": "X"} / {"defined": {"name": "X"}}.
+    if let Some(arr) = ty.get("array").and_then(|v| v.as_array()) {
+        if let (Some(elem), Some(n)) = (arr.first(), arr.get(1).and_then(|n| n.as_u64())) {
+            return format!("Array({},{n})", idl_arg_type(elem));
+        }
+    }
+    if let Some(elem) = ty.get("vec") {
+        return format!("Vec({})", idl_arg_type(elem));
+    }
+    if let Some(inner) = ty.get("option") {
+        return format!("Option({})", idl_arg_type(inner));
+    }
+    if let Some(defined) = ty.get("defined") {
+        return format!("Defined({})", defined_type_name(defined));
+    }
+    // Codama IR node kinds.
     let kind = ty.get("kind").and_then(|k| k.as_str()).unwrap_or("");
     match kind {
         "numberTypeNode" => ty
@@ -459,8 +479,40 @@ fn idl_arg_type(ty: &serde_json::Value) -> String {
             .unwrap_or_else(|| "U64".to_string()),
         "publicKeyTypeNode" => "Pubkey".to_string(),
         "booleanTypeNode" => "Bool".to_string(),
-        _ => "U64".to_string(),
+        "stringTypeNode" => "String".to_string(),
+        "bytesTypeNode" => "Vec(U8)".to_string(),
+        "optionTypeNode" => ty
+            .get("item")
+            .map(|item| format!("Option({})", idl_arg_type(item)))
+            .unwrap_or_else(|| "Opaque".to_string()),
+        "definedTypeLinkNode" => format!("Defined({})", defined_type_name(ty)),
+        "arrayTypeNode" => {
+            let count = ty
+                .get("count")
+                .and_then(|c| c.get("value"))
+                .and_then(|v| v.as_u64());
+            match (ty.get("item"), count) {
+                (Some(item), Some(n)) => format!("Array({},{n})", idl_arg_type(item)),
+                (Some(item), None) => format!("Vec({})", idl_arg_type(item)),
+                _ => "Opaque".to_string(),
+            }
+        }
+        // Anything else (structs inlined as struct nodes, tuples, maps,
+        // amounts, ...) is not fuzzable as a primitive — the emitter
+        // renders `Default::default()` for it.
+        _ => "Opaque".to_string(),
     }
+}
+
+/// Type name from an Anchor `defined` value (`"X"` or `{"name": "X"}`)
+/// or a Codama `definedTypeLinkNode` (`{"name": "x"}`). The name is
+/// carried for readability of the encoding only; the emitter renders
+/// `Default::default()` regardless and never uses it in an expression.
+fn defined_type_name(v: &serde_json::Value) -> String {
+    v.as_str()
+        .or_else(|| v.get("name").and_then(|n| n.as_str()))
+        .unwrap_or("?")
+        .to_string()
 }
 
 fn anchor_str_to_dsl(s: &str) -> String {
@@ -477,7 +529,11 @@ fn anchor_str_to_dsl(s: &str) -> String {
         "i128" => "I128".to_string(),
         "pubkey" | "publicKey" => "Pubkey".to_string(),
         "bool" => "Bool".to_string(),
-        _ => "U64".to_string(),
+        "string" => "String".to_string(),
+        "bytes" => "Vec(U8)".to_string(),
+        // f32/f64 and future scalar spellings: not fuzzable as-is, the
+        // emitter renders `Default::default()`.
+        _ => "Opaque".to_string(),
     }
 }
 
@@ -866,6 +922,83 @@ version = "0.1.0"
                 .as_ref()
                 .map(|seeds| seeds.iter().map(String::as_str).collect::<Vec<_>>()),
             Some(vec!["\"vault\"", "authority", "laneId"])
+        );
+    }
+
+    /// #340: compound IDL arg types must survive into `takes_params` as
+    /// structured encodings — collapsing them to a `U64` placeholder
+    /// made the emitter forward a bare `u64` into every typed
+    /// `instruction::X { .. }` field (one E0308 per arg).
+    #[test]
+    fn anchor_idl_compound_arg_types_are_preserved() {
+        let idl = r#"{
+  "metadata": { "name": "pull_payments" },
+  "instructions": [{
+    "name": "createPolicy",
+    "accounts": [],
+    "args": [
+      { "name": "policyType", "type": { "defined": { "name": "PolicyType" } } },
+      { "name": "memo", "type": { "array": ["u8", 97] } },
+      { "name": "forwardConfig", "type": { "defined": "ForwardConfig" } },
+      { "name": "payload", "type": { "vec": "u8" } },
+      { "name": "paymentAmount", "type": { "option": "u64" } },
+      { "name": "label", "type": "string" },
+      { "name": "rate", "type": "f64" },
+      { "name": "count", "type": "u32" }
+    ]
+  }]
+}"#;
+        let handlers = handlers_with_args_from_idl(idl);
+        let (_, args) = handlers.first().expect("one handler");
+        let types: Vec<&str> = args.iter().map(|(_, t)| t.as_str()).collect();
+        assert_eq!(
+            types,
+            vec![
+                "Defined(PolicyType)",
+                "Array(U8,97)",
+                "Defined(ForwardConfig)",
+                "Vec(U8)",
+                "Option(U64)",
+                "String",
+                "Opaque",
+                "U32",
+            ]
+        );
+    }
+
+    /// #340: the Codama IR spellings of the same compound shapes.
+    #[test]
+    fn codama_compound_arg_types_are_preserved() {
+        let idl = r#"{
+  "kind": "rootNode",
+  "program": {
+    "name": "pull_payments",
+    "instructions": [{
+      "kind": "instructionNode",
+      "name": "createPolicy",
+      "accounts": [],
+      "arguments": [
+        { "name": "policyType", "type": { "kind": "definedTypeLinkNode", "name": "policyType" } },
+        { "name": "memo", "type": { "kind": "arrayTypeNode", "item": { "kind": "numberTypeNode", "format": "u8" }, "count": { "kind": "fixedCountNode", "value": 97 } } },
+        { "name": "paymentAmount", "type": { "kind": "optionTypeNode", "item": { "kind": "numberTypeNode", "format": "u64" } } },
+        { "name": "payload", "type": { "kind": "bytesTypeNode" } },
+        { "name": "label", "type": { "kind": "stringTypeNode" } }
+      ]
+    }]
+  }
+}"#;
+        let handlers = handlers_with_args_from_idl(idl);
+        let (_, args) = handlers.first().expect("one handler");
+        let types: Vec<&str> = args.iter().map(|(_, t)| t.as_str()).collect();
+        assert_eq!(
+            types,
+            vec![
+                "Defined(policyType)",
+                "Array(U8,97)",
+                "Option(U64)",
+                "Vec(U8)",
+                "String",
+            ]
         );
     }
 


### PR DESCRIPTION
Closes #340.

## Problem

The brownfield fuzz path collapsed every compound IDL arg type (enum, struct, `[u8; N]`, `Vec<u8>`, `Option<T>`, string) to a `u64` placeholder, and the emitted `action_*` method forwarded the bare `u64` into the typed `instruction::X { .. }` field. Result: one E0308 per non-primitive arg, so the harness never compiled for any program with typed instruction args.

## Fix

Option (b) from the issue — keep primitive fuzz inputs, render a type-correct expression at the `.call(...)` site:

- `crucible_brownfield::idl_arg_type` now preserves compound types as structured encodings (`Defined(X)`, `Array(U8,97)`, `Vec(U8)`, `Option(U64)`, `String`, `Opaque`) for both Anchor JSON and Codama IR spellings, instead of masking them as `U64`.
- A new `fuzz_param_kind` classifier in `crucible_gen` drives both emission sites. The `action_*` signature exposes only fuzzable primitives. The call literal renders per arg type: `Default::default()` for defined enum/struct types, `[0u8; N]` for byte arrays (a literal, so it needs no `Default` impl on the array — independent of the upstream derive limitation in #341), `Vec::new()`, `String::new()`, and `None` / `Some(<fuzzed inner>)` for options, keeping the inner primitive fuzzer-mutated. The old `Pubkey::default()` special case folds into the classifier.
- A compound-typed arg used as a PDA seed now falls to the existing placeholder-derivation path with an explanatory comment instead of generating `to_le_bytes()` on a mistyped value.

Follow-up (not this PR): typed action params via fuzzer-provided strategies — the issue's option (a) — would let libfuzzer mutate each compound field independently. That depends on upstream `Arbitrary` support in the macro-generated types.

## Tests

New tests pin the IDL type carrier (Anchor + Codama spellings), the emitted signature and call literal, and the array element-kind matrix. Spec-mode output for primitive args is unchanged (no snapshot churn). Full suite green.