### PR TITLE
fix(check): --json writes exactly one JSON document (#355)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -277,7 +277,7 @@ Use Leanstral for routine sorry filling and Aristotle for harder long-running pr
 
 Always run `lake build` after editing Lean and run `qedgen check` after proofs compile so orphan or missing obligations are reported.
 
-For a verification summary, run `qedgen check --spec <s> --explain --json` and render the report yourself from the structured payload (`summary` counts + per-`properties` status/intent/suggestion). The bare `--explain` Markdown is a human fallback; the agent owns the narrative.
+For a verification summary, run `qedgen check --spec <s> --explain --json` and render the report yourself from the structured payload under the document's `explain` key (`summary` counts + per-`properties` status/intent/suggestion; the same document carries the lint `findings` array). The bare `--explain` Markdown is a human fallback; the agent owns the narrative.
 
 ## Invariants vs Properties
 

--- a/crates/qedgen/src/check/mod.rs
+++ b/crates/qedgen/src/check/mod.rs
@@ -37,21 +37,24 @@ pub fn lint_with_opts(
 
 /// `qedgen check --anchor-project <path>`: spec handler list vs the
 /// existing Anchor program — catches stale specs and uncovered handlers
-/// as a CI gate. Renders JSON or the human report; returns true when any
-/// finding fired (the caller gates the exit code). Parses the spec with
-/// default opts, as this stage always has — folding it into the caller's
-/// lock/cache-aware parse would change gating under `--frozen`. Moved
-/// out of the dispatch arm (T7c).
+/// as a CI gate. Returns (fired, payload): `fired` is true when any
+/// finding exists (the caller gates the exit code); `payload` is the
+/// JSON section under `--json` (#355: the caller folds it into the
+/// single check document instead of this function printing its own).
+/// Parses the spec with default opts, as this stage always has —
+/// folding it into the caller's lock/cache-aware parse would change
+/// gating under `--frozen`. Moved out of the dispatch arm (T7c).
 pub fn render_anchor_project_report(
     spec_path: &std::path::Path,
     project_path: &std::path::Path,
     json: bool,
-) -> Result<bool> {
+) -> Result<(bool, Option<serde_json::Value>)> {
     let parsed = parse_spec_file(spec_path)?;
     let findings = crate::anchor_check::check_anchor_coverage(&parsed, project_path)?;
     let effect_findings = crate::anchor_check::check_effect_coverage(&parsed, project_path)?;
+    let mut payload = None;
     if json {
-        let payload = serde_json::json!({
+        payload = Some(serde_json::json!({
             "handler_coverage": findings
                 .iter()
                 .map(|f| serde_json::json!({
@@ -68,8 +71,7 @@ pub fn render_anchor_project_report(
                     "message": f.message(),
                 }))
                 .collect::<Vec<_>>(),
-        });
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        }));
     } else {
         if findings.is_empty() {
             eprintln!(
@@ -100,5 +102,5 @@ pub fn render_anchor_project_report(
             }
         }
     }
-    Ok(!findings.is_empty() || !effect_findings.is_empty())
+    Ok((!findings.is_empty() || !effect_findings.is_empty(), payload))
 }

--- a/crates/qedgen/src/check/proof_status.rs
+++ b/crates/qedgen/src/check/proof_status.rs
@@ -39,6 +39,36 @@ pub fn check(spec_path: &Path, proofs_dir: &Path) -> Result<Vec<PropertyStatus>>
     Ok(results)
 }
 
+/// The `--explain` JSON data layer as a value (#355): the check dispatch
+/// folds it into the single `--json` document instead of printing a
+/// second one.
+pub fn explain_report_payload(
+    spec_path: &Path,
+    spec_name: &str,
+    proofs_dir: &Path,
+) -> Result<serde_json::Value> {
+    let results = check(spec_path, proofs_dir)?;
+    let proven = results
+        .iter()
+        .filter(|r| r.status == Status::Proven)
+        .count();
+    let sorry = results.iter().filter(|r| r.status == Status::Sorry).count();
+    let missing = results
+        .iter()
+        .filter(|r| r.status == Status::Missing)
+        .count();
+    Ok(serde_json::json!({
+        "spec": spec_name,
+        "summary": {
+            "proven": proven,
+            "sorry": sorry,
+            "missing": missing,
+            "total": results.len(),
+        },
+        "properties": results,
+    }))
+}
+
 /// `qedgen check --explain`: render the verification-status report.
 /// `--json` emits the data layer for the agent to render; without it the
 /// CLI prints the inline Markdown human fallback. Written to `output`
@@ -63,17 +93,12 @@ pub fn render_explain_report(
     let total = results.len();
 
     let (rendered, what) = if json {
-        let payload = serde_json::json!({
-            "spec": spec_name,
-            "summary": {
-                "proven": proven,
-                "sorry": sorry,
-                "missing": missing,
-                "total": total,
-            },
-            "properties": results,
-        });
-        (serde_json::to_string_pretty(&payload)?, "report (JSON)")
+        (
+            serde_json::to_string_pretty(&explain_report_payload(
+                spec_path, spec_name, proofs_dir,
+            )?)?,
+            "report (JSON)",
+        )
     } else {
         let mut md = format!("# {} Verification Report\n\n", spec_name);
         md.push_str(&format!(

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -1262,20 +1262,48 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 }
             }
 
+            // Single-document JSON accumulator (#355). Under --json every
+            // section below inserts into this map and exactly one JSON
+            // document reaches stdout at the end of the lint block. The one
+            // back-compat exception: when only lint findings print (plain
+            // `qedgen check --json`), the document stays the bare findings
+            // array existing consumers parse.
+            let mut json_sections = serde_json::Map::new();
+
             // Anchor cross-check (--anchor-project) — spec handler list vs
             // the existing program; catches stale specs and uncovered
             // handlers as a CI gate.
             if let Some(ref project_path) = anchor_project {
-                if check::render_anchor_project_report(&spec, project_path, json)? {
+                let (fired, payload) =
+                    check::render_anchor_project_report(&spec, project_path, json)?;
+                if let Some(payload) = payload {
+                    json_sections.insert("anchor_project".to_string(), payload);
+                }
+                if fired {
                     has_issues = true;
                 }
             }
 
             // Verification report (--explain). `--json` emits the
             // verification-status data layer for the agent to render; without
-            // it the CLI prints the inline Markdown human fallback.
+            // it the CLI prints the inline Markdown human fallback. With
+            // --json and no --output the payload joins the single document;
+            // an explicit --output still writes the report to that file.
             if explain {
-                check::render_explain_report(&spec, &spec_name, &proofs, json, output.as_deref())?;
+                if json && output.is_none() {
+                    json_sections.insert(
+                        "explain".to_string(),
+                        check::explain_report_payload(&spec, &spec_name, &proofs)?,
+                    );
+                } else {
+                    check::render_explain_report(
+                        &spec,
+                        &spec_name,
+                        &proofs,
+                        json,
+                        output.as_deref(),
+                    )?;
+                }
             }
 
             // One parse shared by every remaining ParsedSpec consumer
@@ -1306,11 +1334,11 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 let entries = crate::obligations::collect_all(&mir, parsed);
                 let backend_reports = crate::obligations::backend_coverage_reports(&entries);
                 if json {
-                    // Additive JSON shape: the matrix keys stay top-level
-                    // (existing consumers), `backend_coverage` is new.
+                    // Matrix fields plus `backend_coverage`, together under
+                    // the `coverage` key of the single document (#355).
                     let mut value = serde_json::to_value(&matrix)?;
                     value["backend_coverage"] = serde_json::to_value(&backend_reports)?;
-                    println!("{}", serde_json::to_string_pretty(&value)?);
+                    json_sections.insert("coverage".to_string(), value);
                 } else {
                     check::print_coverage_table(&matrix);
                     crate::obligations::print_backend_coverage(&entries);
@@ -1365,7 +1393,10 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                                 }
                             })
                             .collect();
-                        println!("{}", serde_json::to_string_pretty(&as_json)?);
+                        json_sections.insert(
+                            "proofs_drift".to_string(),
+                            serde_json::Value::Array(as_json),
+                        );
                     } else {
                         eprintln!("Proofs.lean drift:");
                         for f in &findings {
@@ -1389,7 +1420,20 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     warnings.extend(check::check_handler_todos(parsed, code_dir)?);
                 }
                 if json {
-                    println!("{}", serde_json::to_string_pretty(&warnings)?);
+                    let findings = serde_json::to_value(&warnings)?;
+                    if json_sections.is_empty() {
+                        // Plain `check --json`: the bare findings array,
+                        // unchanged for existing consumers.
+                        println!("{}", serde_json::to_string_pretty(&findings)?);
+                    } else {
+                        json_sections.insert("findings".to_string(), findings);
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::Value::Object(
+                                json_sections
+                            ))?
+                        );
+                    }
                 } else if warnings.is_empty() {
                     eprintln!("Spec is complete — no issues found.");
                 } else {

--- a/crates/qedgen/tests/check_json_single_doc.rs
+++ b/crates/qedgen/tests/check_json_single_doc.rs
@@ -1,0 +1,60 @@
+//! #355 gate: `qedgen check --json` must write exactly one JSON document
+//! to stdout. Before the fix, `--coverage --json` printed the coverage
+//! object and the findings array as two concatenated documents, so
+//! strict parsers (`serde_json::from_str`, `json.load`) failed with
+//! "trailing characters" and no scripted consumer could reach
+//! `backend_coverage`.
+
+mod common;
+
+use std::process::Command;
+
+fn pool_spec() -> std::path::PathBuf {
+    common::repo_root().join("crates/qedgen/tests/fixtures/regressions/issue-8/pool.qedspec")
+}
+
+fn run_check(extra: &[&str]) -> String {
+    common::ensure_qedgen_built();
+    let out = Command::new(common::qedgen_bin())
+        .arg("check")
+        .arg("--spec")
+        .arg(pool_spec())
+        .args(extra)
+        .output()
+        .expect("run qedgen check");
+    String::from_utf8(out.stdout).expect("stdout utf8")
+}
+
+#[test]
+fn coverage_json_is_one_document_with_sections() {
+    let stdout = run_check(&["--coverage", "--json"]);
+    let doc: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("check --coverage --json stdout must parse as ONE JSON document: {e}\n{stdout}")
+    });
+    let obj = doc
+        .as_object()
+        .expect("with --coverage the single document is an object");
+    let coverage = obj
+        .get("coverage")
+        .expect("document has a `coverage` section");
+    assert!(
+        coverage.get("backend_coverage").is_some(),
+        "coverage section carries the backend_coverage rollup"
+    );
+    assert!(
+        obj.get("findings").is_some_and(|f| f.is_array()),
+        "document has the lint `findings` array"
+    );
+}
+
+#[test]
+fn plain_json_stays_a_bare_findings_array() {
+    let stdout = run_check(&["--json"]);
+    let doc: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("check --json stdout must parse as ONE JSON document: {e}\n{stdout}")
+    });
+    assert!(
+        doc.is_array(),
+        "plain `check --json` keeps the bare findings array for existing consumers"
+    );
+}

--- a/references/cli.md
+++ b/references/cli.md
@@ -274,7 +274,7 @@ $QEDGEN check --regen-drift --examples-root examples/rust
 |---|---|---|---|
 | `--spec` | Path | optional | Spec file or directory. Defaults to `.qed/config.json spec` |
 | `--proofs` | Path | `./formal_verification` | Proofs directory |
-| `--coverage` | bool | false | Show operation × property matrix (spec coverage) plus the per-backend obligation rollup (backend coverage, #332): for each of kani / lean / proptest, how many requested obligations are `emitted` vs `unsupported(reason)` vs `failed`, recomputed in memory from the current spec. `--json` adds a `backend_coverage` key next to the existing matrix fields. |
+| `--coverage` | bool | false | Show operation × property matrix (spec coverage) plus the per-backend obligation rollup (backend coverage, #332): for each of kani / lean / proptest, how many requested obligations are `emitted` vs `unsupported(reason)` vs `failed`, recomputed in memory from the current spec. Under `--json` the matrix fields and the `backend_coverage` key form the `coverage` section of the single check document (#355). |
 | `--explain` | bool | false | Generate Markdown verification report |
 | `--output` | Path | stdout | Output file for --explain |
 | `--drift` | Path | - | Rust source path for #[qed(verified)] drift detection |
@@ -290,7 +290,7 @@ $QEDGEN check --regen-drift --examples-root examples/rust
 | `--regen-drift` | bool | false | Regenerate bundled examples into temporary directories and fail if committed generated support code, harnesses, or `Spec.lean` drift. Also fails when an example has `.qed/` state or generated artifacts but no `qed.toml`. |
 | `--examples-root` | Path | `examples/rust` | Example root scanned by `--regen-drift` |
 | `--write` | bool | false | With `--regen-drift`, also write the regenerated content into the repo so committed example outputs match current codegen. Useful for rebasing PRs across codegen-touching releases. Never touches user-owned files (handler bodies, Spec.lean proofs) — only the codegen-owned set `--regen-drift` already compares. |
-| `--json` | bool | false | Machine-readable output |
+| `--json` | bool | false | Machine-readable output. Stdout is exactly one JSON document (#355). Plain `check --json` prints the bare lint-findings array. When any other section prints (`--coverage`, `--explain` without `--output`, `--anchor-project`, or Proofs.lean drift), the document is one object with a key per section — `coverage` (matrix fields + `backend_coverage`), `explain`, `anchor_project`, `proofs_drift` — plus the `findings` array. |
 
 Lints fired by `check` include `[shape_only_cpi]` for `call
 Interface.handler(...)` sites whose target declares no `ensures` —


### PR DESCRIPTION
Closes #355.

Under --json, check printed each section as its own pretty-printed JSON document: the coverage object, the --explain payload, the --anchor-project report, the Proofs.lean drift array, and the lint findings array. Any combination beyond plain 'check --json' produced concatenated documents that strict parsers reject, so no scripted consumer could reach backend_coverage.

The check dispatch now collects every section into one map and prints one document at the end:

- Plain 'check --json' keeps the bare findings array. It was the only combination that parsed before, so existing consumers are unchanged.
- Any other combination prints one object with a key per section (coverage, explain, anchor_project, proofs_drift) plus the findings array.
- render_anchor_project_report returns its payload instead of printing it. explain_report_payload is split out of render_explain_report so the dispatch can fold the --explain data layer in; --explain with --output still writes the report to the file.

New integration test check_json_single_doc parses the stdout of both combinations as a single document. references/cli.md and SKILL.md document the new shape.