### PR TITLE
fix(probe): Pinocchio handler discovery, IDL root detection, honest bootstrap outcome

### DIFF
--- a/crates/qedgen/src/probe/idl_overlay.rs
+++ b/crates/qedgen/src/probe/idl_overlay.rs
@@ -136,8 +136,16 @@ fn discover_workspace_ancestor_idl(
         return Ok(None);
     };
     for ancestor in program_root.ancestors().skip(1) {
+        // `Anchor.toml` and a `programs/` parent are Anchor-shaped markers.
+        // A Pinocchio repo often has neither: a single crate at `program/`
+        // (singular) with the IDL committed at the repo root. Cargo's own
+        // `[workspace]` table is the runtime-agnostic marker for the same
+        // "this is the repo root" question, so accept it too.
         let is_workspace_root = ancestor.join("Anchor.toml").is_file()
-            || program_root.starts_with(ancestor.join("programs"));
+            || program_root.starts_with(ancestor.join("programs"))
+            || std::fs::read_to_string(ancestor.join("Cargo.toml"))
+                .map(|t| t.lines().any(|l| l.trim_start().starts_with("[workspace]")))
+                .unwrap_or(false);
         if is_workspace_root {
             return discover_workspace_program_idl(ancestor, &program_root, &fallback_name);
         }
@@ -551,6 +559,46 @@ fn apply_discovered_idl(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A non-Anchor repo: single crate at `program/` (singular), IDL
+    /// committed at the repo root, no `Anchor.toml` and no `programs/`
+    /// dir. The ancestor walk previously recognised neither marker, so the
+    /// IDL one level up was never found and Pinocchio got zero handlers.
+    #[test]
+    fn workspace_table_marks_the_repo_root_for_the_idl_walk() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"program\"]\nresolver = \"2\"\n",
+        )
+        .expect("write");
+        fs::create_dir_all(root.join("program").join("src")).expect("mkdir");
+        fs::write(
+            root.join("program").join("Cargo.toml"),
+            "[package]\nname = \"program\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write");
+        fs::create_dir_all(root.join("idl")).expect("mkdir");
+        fs::write(
+            root.join("idl").join("program.json"),
+            r#"{"instructions":[{"name":"deposit"}]}"#,
+        )
+        .expect("write");
+
+        let found = discover_idl(&root.join("program")).expect("discover");
+        assert!(
+            found.is_some(),
+            "a root [workspace] table must mark the repo root so the root idl/ is reachable"
+        );
+        let (path, _) = found.expect("some");
+        assert!(
+            path.ends_with("idl/program.json"),
+            "expected the root idl/, got {}",
+            path.display()
+        );
+    }
 
     fn mk_handler(name: &str) -> BootstrapHandler {
         BootstrapHandler {

--- a/crates/qedgen/src/probe/mod.rs
+++ b/crates/qedgen/src/probe/mod.rs
@@ -794,9 +794,11 @@ impl ProbeOutput {
             candidates: Vec::new(),
             engine_runs: Vec::new(),
             coverage: None,
-            // Overwritten by every real construction site; the neutral
-            // default suits a bare/empty envelope (bootstrap work list).
-            outcome: ProbeOutcome::PassedWithCoverage,
+            // Every real construction site sets this explicitly. The
+            // default is the weakest claim on purpose: a site that forgets
+            // to set it under-reports coverage rather than asserting a
+            // clean bill of health it never established.
+            outcome: ProbeOutcome::NoFindingsLowCoverage,
             clusters: None,
             idl_path: None,
             derivable_idl: None,
@@ -1177,6 +1179,14 @@ pub fn run_bootstrap(project_root: &Path) -> Result<ProbeOutput> {
             }
             _ => (Vec::new(), None),
         },
+        // Pinocchio has no `#[program]` mod, so it needs its own source
+        // walk. Without one it fell to the `_` arm below and depended
+        // entirely on the IDL overlay for handlers.
+        Runtime::Pinocchio => {
+            let h = discover_pinocchio_handlers(project_root);
+            let kind = (!h.is_empty()).then(|| "pinocchio_source".to_string());
+            (h, kind)
+        }
         _ => (Vec::new(), None),
     };
     let applicable = applicable_categories(&runtime);
@@ -1195,6 +1205,16 @@ pub fn run_bootstrap(project_root: &Path) -> Result<ProbeOutput> {
     let mut candidates = overlay.drift_candidates;
     candidates.extend(dead_guard_probe::scan_program(project_root).unwrap_or_default());
 
+    // A work list with no handlers means discovery found nothing to hand
+    // the auditor — not that the program is clean. Reporting
+    // `PassedWithCoverage` there is a false green: it reads as "probed,
+    // nothing found" when the truth is "nothing was probed".
+    let outcome = if handlers.is_empty() {
+        ProbeOutcome::NoFindingsLowCoverage
+    } else {
+        ProbeOutcome::PassedWithCoverage
+    };
+
     Ok(ProbeOutput {
         project_root: Some(project_root.display().to_string()),
         runtime: Some(runtime),
@@ -1204,6 +1224,7 @@ pub fn run_bootstrap(project_root: &Path) -> Result<ProbeOutput> {
         idl_path: overlay.idl_path,
         derivable_idl: overlay.derivable_idl,
         dispatcher_kind,
+        outcome,
         ..ProbeOutput::envelope(Mode::SpecLess)
     })
 }
@@ -1307,6 +1328,112 @@ fn has_qedgen_markers(root: &Path) -> bool {
         }
     }
     false
+}
+
+/// Source-level handler discovery for Pinocchio, which has no `#[program]`
+/// mod to parse. Two dispatch-body conventions appear in the wild and a
+/// program uses one or the other, never both:
+///
+/// 1. `pub fn process_<name>(..)` — the handler name is the fn name.
+/// 2. `pub fn process(..)`, one per `instructions/<name>.rs` module — the
+///    handler name is the file stem, because every fn is called `process`.
+///
+/// Before this existed, `run_bootstrap` fell through to the `_` arm and
+/// Pinocchio handlers could only ever come from the IDL overlay, so a
+/// repo with no discoverable IDL reported zero handlers.
+fn discover_pinocchio_handlers(root: &Path) -> Vec<BootstrapHandler> {
+    let rel = |p: &Path| -> String {
+        p.strip_prefix(root)
+            .map(|r| r.display().to_string())
+            .unwrap_or_else(|_| p.display().to_string())
+    };
+
+    // `entrypoint!(process_instruction)` names the dispatcher, which matches
+    // the `process_*` convention but is not a handler. Read the name out of
+    // the macro rather than hardcoding one: programs are free to call it
+    // anything.
+    let files = crate::fs_walk::collect_rs_files(root, crate::fs_walk::DEFAULT_SKIP_DIRS);
+    let dispatchers: std::collections::BTreeSet<String> = {
+        let re = regex::Regex::new(r"entrypoint!\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)")
+            .expect("static regex compiles");
+        files
+            .iter()
+            .filter_map(|f| std::fs::read_to_string(f).ok())
+            .flat_map(|t| {
+                re.captures_iter(&t)
+                    .map(|c| c[1].to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    };
+
+    // Convention 1: `process_*` fn names carry the handler name.
+    if let Ok(names) = crate::adapt::pinocchio_to_spec::enumerate_handlers(root) {
+        let names: Vec<String> = names
+            .into_iter()
+            .filter(|n| !dispatchers.contains(n))
+            .collect();
+        if !names.is_empty() {
+            return names
+                .into_iter()
+                .map(|name| {
+                    let needle = format!("pub fn {name}(");
+                    let source_file = files
+                        .iter()
+                        .find(|f| {
+                            std::fs::read_to_string(f)
+                                .map(|t| t.contains(&needle))
+                                .unwrap_or(false)
+                        })
+                        .map(|f| rel(f))
+                        .unwrap_or_default();
+                    BootstrapHandler {
+                        name,
+                        source_file,
+                        enum_variant: None,
+                        entry_fn: None,
+                        line: None,
+                        applicable_categories: None,
+                        intent_tag: None,
+                        idl_accounts: None,
+                        idl_args: None,
+                        discovered_via: Some("pinocchio_source".to_string()),
+                    }
+                })
+                .collect();
+        }
+    }
+
+    // Convention 2: bare `pub fn process(` — the module file names the
+    // handler. A file carrying `entrypoint!` is the dispatcher, not a
+    // handler module.
+    let mut out: Vec<BootstrapHandler> = files
+        .into_iter()
+        .filter(|f| {
+            f.file_stem().and_then(|s| s.to_str()) != Some("mod")
+                && std::fs::read_to_string(f)
+                    .map(|t| t.contains("pub fn process(") && !t.contains("entrypoint!"))
+                    .unwrap_or(false)
+        })
+        .filter_map(|f| {
+            let name = f.file_stem()?.to_str()?.to_string();
+            Some(BootstrapHandler {
+                name,
+                source_file: rel(&f),
+                enum_variant: None,
+                entry_fn: None,
+                line: None,
+                applicable_categories: None,
+                intent_tag: None,
+                idl_accounts: None,
+                idl_args: None,
+                discovered_via: Some("pinocchio_source".to_string()),
+            })
+        })
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out.dedup_by(|a, b| a.name == b.name);
+    out
 }
 
 /// Map `parse_anchor_project` instructions into `BootstrapHandler`
@@ -1481,6 +1608,120 @@ fn classify_shank_handler(
         return (tag_str, None);
     }
     (tag_str, Some(narrowed))
+}
+
+#[cfg(test)]
+mod pinocchio_bootstrap_tests {
+    use super::*;
+    use std::fs;
+
+    /// Minimal Pinocchio crate. `naming` picks the dispatch-body
+    /// convention: `"prefixed"` = `pub fn process_<name>`, `"bare"` =
+    /// `pub fn process(` one per instruction module.
+    fn pinocchio_crate(root: &std::path::Path, naming: &str) {
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\npinocchio = \"0.7\"\n",
+        )
+        .expect("write");
+        let src = root.join("src");
+        fs::create_dir_all(src.join("instructions")).expect("mkdir");
+        // The dispatcher lives outside lib.rs on purpose: that layout is
+        // what originally resolved zero handlers.
+        fs::write(
+            src.join("entrypoint.rs"),
+            "entrypoint!(process_instruction);\npub fn process_instruction(a: &[u8]) -> u8 { 0 }\n",
+        )
+        .expect("write");
+        fs::write(
+            src.join("lib.rs"),
+            "pub mod entrypoint;\npub mod instructions;\n",
+        )
+        .expect("write");
+        for name in ["deposit", "withdraw"] {
+            let body = if naming == "prefixed" {
+                format!("pub fn process_{name}(a: &[u8]) -> u8 {{ 0 }}\n")
+            } else {
+                "pub fn process(a: &[u8]) -> u8 { 0 }\n".to_string()
+            };
+            fs::write(src.join("instructions").join(format!("{name}.rs")), body).expect("write");
+        }
+    }
+
+    #[test]
+    fn pinocchio_prefixed_handlers_discovered_from_source() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        pinocchio_crate(dir.path(), "prefixed");
+        let out = run_bootstrap(dir.path()).expect("bootstrap");
+        let mut names: Vec<String> = out
+            .handlers
+            .unwrap_or_default()
+            .into_iter()
+            .map(|h| h.name)
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["process_deposit", "process_withdraw"],
+            "process_* handlers must be discovered without an IDL"
+        );
+    }
+
+    #[test]
+    fn pinocchio_bare_process_handlers_named_by_module() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        pinocchio_crate(dir.path(), "bare");
+        let out = run_bootstrap(dir.path()).expect("bootstrap");
+        let mut names: Vec<String> = out
+            .handlers
+            .unwrap_or_default()
+            .into_iter()
+            .map(|h| h.name)
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["deposit", "withdraw"],
+            "bare `pub fn process` handlers take their module's name"
+        );
+    }
+
+    #[test]
+    fn entrypoint_dispatcher_is_not_a_handler() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        pinocchio_crate(dir.path(), "prefixed");
+        let out = run_bootstrap(dir.path()).expect("bootstrap");
+        assert!(
+            !out.handlers
+                .unwrap_or_default()
+                .iter()
+                .any(|h| h.name == "process_instruction"),
+            "the fn named by entrypoint!() is the dispatcher, not a handler"
+        );
+    }
+
+    #[test]
+    fn empty_handler_list_reports_low_coverage_not_a_pass() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write");
+        fs::create_dir_all(root.join("src")).expect("mkdir");
+        fs::write(root.join("src").join("lib.rs"), "// no handlers\n").expect("write");
+        let out = run_bootstrap(root).expect("bootstrap");
+        assert!(
+            out.handlers.unwrap_or_default().is_empty(),
+            "no handlers expected"
+        );
+        assert_eq!(
+            out.outcome,
+            ProbeOutcome::NoFindingsLowCoverage,
+            "a work list with no handlers must not claim passed_with_coverage"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
An auditor benchmark sweep found `qedgen probe --bootstrap` reporting `passed_with_coverage` while resolving **zero handlers** on a Pinocchio program. Three independent defects combined to produce that false green.

The sweep ran two independent audit workers against the same program; both reported the probe contributed nothing, and both had to fall back entirely to manual review. A user reading `passed_with_coverage` would reasonably conclude their program had been probed clean.

## 1. Pinocchio had no source-level handler discovery

`run_bootstrap` matched Anchor, Quasar, QedgenCodegen and Native, then fell through:

```rust
_ => (Vec::new(), None),        // <- Pinocchio
```

So Pinocchio handlers could only ever come from the IDL overlay that runs afterwards, and a repo with no discoverable IDL got an empty work list. The doc comment above the match lists Anchor, Native, sBPF and qedgen-codegen; Pinocchio was never mentioned, so the omission was not even recorded.

`discover_pinocchio_handlers` now walks the source and handles both dispatch-body conventions that appear in real programs:

| Convention | Handler name from |
|---|---|
| `pub fn process_<name>(..)` | the function name |
| `pub fn process(..)`, one per `instructions/<name>.rs` | the module file stem |

Two real programs in the benchmark corpus use one convention each, so both were needed.

The function named by `entrypoint!(...)` is the dispatcher, not a handler, and is excluded. The identifier is read out of the macro rather than hardcoded, because a program is free to call its dispatcher anything.

## 2. The IDL ancestor walk only recognised Anchor-shaped repo roots

`discover_workspace_ancestor_idl` accepted an `Anchor.toml` or a `programs/` parent directory. A repo with a single crate at `program/` (singular) and its IDL committed at the root `idl/` matches neither, so the walk stopped before it could look one directory up.

Proof, same tree and same IDL, only `--root` differs:

| `--root` | handlers |
|---|---:|
| `tree/program` | 0 |
| `tree` | 13 |

Cargo's own `[workspace]` table now also marks the root. It answers the same "is this the repo root" question without assuming a framework.

## 3. The bootstrap outcome was optimistic by default

`envelope()` set `PassedWithCoverage` with this comment:

> Overwritten by every real construction site; the neutral default suits a bare/empty envelope (bootstrap work list).

That was false. `run_bootstrap` spread `..ProbeOutput::envelope(Mode::SpecLess)` and inherited the default, so an empty work list read as "probed, nothing found" when the truth was "nothing was probed". `PassedWithCoverage` is also not neutral; it is the strongest claim available.

`run_bootstrap` now reports `NoFindingsLowCoverage` when it discovered no handlers. The envelope default flips to the weak claim as well, so a construction site that forgets to set the outcome under-reports coverage instead of asserting a clean bill of health it never established.

The enum already carried the right variant, documented for exactly this case:

> `NoFindingsLowCoverage` — an empty result here is weak evidence, not a clean bill of health.

**Defect 3 is what made 1 and 2 silent.** Without it they would have surfaced as visibly low coverage rather than as a pass.

## Why the two Pinocchio programs disagreed

Each was covered by exactly one mechanism, and they were covered by different ones:

| | source enum (`process_*`) | IDL overlay | result |
|---|---|---|---|
| escrow | would find 14 | blocked by defect 2 | **0 handlers** |
| subscriptions | uses bare `pub fn process` | found the IDL | 14 handlers |

Fixing only one defect would have left the other program broken.

## Verified

| Target | Before | After |
|---|---:|---:|
| escrow (Pinocchio, crate dir) | 0 | **14** |
| subscriptions (Pinocchio) | 14 via IDL | 14 via source |
| smart-account (Anchor) | 39 | 39 |
| empty project outcome | `passed_with_coverage` | `no_findings_low_coverage` |

Full suite: 1595 passed, 0 failed (up from 1590, the 5 new tests).

An earlier revision of this change reported 15 handlers for escrow. The extra was `process_instruction` from `entrypoint.rs`, the dispatcher. That is what motivated reading the name out of `entrypoint!()`, and a regression test pins it.

## Tests

Four in `pinocchio_bootstrap_tests`: prefixed convention, bare-`process` convention, dispatcher exclusion, and empty-list outcome. One in `idl_overlay` for the `[workspace]` marker. Every Pinocchio fixture deliberately puts the dispatcher in `entrypoint.rs` rather than `lib.rs`, which is the layout that caused the original failure.

## Not in scope

The same sweep found two further gaps, untouched here:

- `engine_runs = 0` on all six audits, Anchor included. No engine ran anywhere. This may partly resolve now that Pinocchio handlers exist, but it needs its own investigation.
- `verify --probe-repros` refuses to run without a resolved `.qedspec`, so it is unusable in the spec-less brownfield audit it exists to serve.