### PR TITLE
feat(verify): compile generated program scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,15 @@ qedgen init --name my_program --spec my_program.qedspec --target anchor
 qedgen check
 qedgen codegen --all
 
-# 3. Fill generated Rust handler TODOs, then run backend verification
-qedgen verify
+# 3. Fill generated Rust handler TODOs, then verify the program crate
+qedgen verify --program ./programs/my_program
 ```
+
+When `--program <crate>` is supplied without explicit backend flags, verify
+also runs the `scaffold` backend (`cargo check --tests`) so generated Rust
+compile failures surface inside QEDGen. Use `--scaffold` to combine that check
+with an explicitly selected backend. A scaffold pass proves buildability, not
+spec conformance, and cannot authorize `qedgen stamp`.
 
 ### Stuck? File feedback
 

--- a/crates/qedgen/src/cli.rs
+++ b/crates/qedgen/src/cli.rs
@@ -750,9 +750,11 @@ pub(crate) enum Commands {
 
     /// Run the generated harnesses against the generated implementation.
     ///
-    /// `check` validates the spec; `verify` validates the code the spec
-    /// produced. Default (no flags) runs every backend whose artifact is
-    /// present on disk. Use --proptest/--kani/--lean to target one backend.
+    /// `check` validates the spec; `verify` runs proof backends and can
+    /// compile a selected program crate. Default (no flags) runs every
+    /// backend whose artifact is present on disk. With `--program`, it also
+    /// runs `cargo check --tests` to establish buildability, not semantic
+    /// conformance. Use --proptest/--kani/--lean to target one backend.
     Verify {
         /// Path to the spec file (.qedspec). Optional — falls back to the
         /// `spec` field in the nearest `.qed/config.json` discovered by
@@ -760,16 +762,17 @@ pub(crate) enum Commands {
         #[arg(long)]
         spec: Option<PathBuf>,
 
-        /// Program crate whose implementation is exercised by an
-        /// implementation-bound backend. Required for verification evidence
-        /// that can authorize `qedgen stamp`: the source-tree hash recorded
-        /// here must still match the crate passed to `stamp`.
+        /// Program crate selected by source-bound backends. Its source-tree
+        /// hash is retained in verification evidence. Authorizing
+        /// `qedgen stamp` additionally requires a passing implementation-bound
+        /// backend, and the hash must still match the crate passed to `stamp`.
         #[arg(long)]
         program: Option<PathBuf>,
 
         /// Compile the selected program crate with `cargo check --tests`.
         /// Requires `--program`. With no explicit backend flags, supplying
-        /// `--program` enables this backend automatically.
+        /// `--program` enables this backend automatically. This establishes
+        /// buildability, not semantic conformance.
         #[arg(long, requires = "program")]
         scaffold: bool,
 
@@ -907,7 +910,9 @@ pub(crate) enum Commands {
         #[arg(long)]
         recursive: bool,
 
-        /// #332 — fail unless every backend obligation is `emitted`.
+        /// Fail if an enabled scaffold backend is skipped.
+        ///
+        /// #332 — also fail unless every backend obligation is `emitted`.
         /// Recomputes the reconciled backend-obligation manifest in
         /// memory (kani / lean / proptest) and exits 1 on any
         /// `unsupported` or `failed` entry: a passing strict verify

--- a/crates/qedgen/src/cli.rs
+++ b/crates/qedgen/src/cli.rs
@@ -767,6 +767,12 @@ pub(crate) enum Commands {
         #[arg(long)]
         program: Option<PathBuf>,
 
+        /// Compile the selected program crate with `cargo check --tests`.
+        /// Requires `--program`. With no explicit backend flags, supplying
+        /// `--program` enables this backend automatically.
+        #[arg(long, requires = "program")]
+        scaffold: bool,
+
         /// Run proptest harnesses (cargo test --release)
         #[arg(long)]
         proptest: bool,

--- a/crates/qedgen/src/run.rs
+++ b/crates/qedgen/src/run.rs
@@ -1462,6 +1462,7 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
         Commands::Verify {
             spec,
             program,
+            scaffold,
             proptest,
             proptest_path,
             kani,
@@ -1545,7 +1546,7 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 // When --check-upstream is the only verb, exit cleanly
                 // without firing the backend runners. Combine with
                 // --proptest etc. to do both in one invocation.
-                let any_backend_flag = proptest || kani || lean || miri || probe_repros;
+                let any_backend_flag = scaffold || proptest || kani || lean || miri || probe_repros;
                 if check_upstream && !any_backend_flag {
                     return Ok(());
                 }
@@ -1555,7 +1556,7 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 eprintln!(
                     "note: --upstream-stale-ok suppressed --check-upstream (offline-dev mode)"
                 );
-                let any_backend_flag = proptest || kani || lean || miri || probe_repros;
+                let any_backend_flag = scaffold || proptest || kani || lean || miri || probe_repros;
                 if !any_backend_flag {
                     return Ok(());
                 }
@@ -1592,7 +1593,7 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     );
                     std::process::exit(1);
                 }
-                let any_backend_flag = proptest || kani || lean || miri;
+                let any_backend_flag = scaffold || proptest || kani || lean || miri;
                 if !any_backend_flag {
                     record_verify_evidence(
                         &spec,
@@ -1611,7 +1612,12 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
 
             // No explicit backend flags -> run every backend whose artifact
             // is present on disk.
-            let any_flag = proptest || kani || lean || miri;
+            let any_flag = scaffold || proptest || kani || lean || miri;
+            let scaffold_enabled = if any_flag {
+                scaffold
+            } else {
+                program.is_some()
+            };
             // Project root used by Miri repro discovery — spec parent dir.
             let project_root = spec
                 .parent()
@@ -1632,14 +1638,16 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                 .and_then(|s| s.to_str())
                 .map(|s| s.starts_with("kani_impl"))
                 .unwrap_or(false);
-            // A source hash is meaningful only when the implementation-bound
-            // backend is mechanically rooted in the crate being recorded.
+            // A source hash is meaningful only when a source-bound backend is
+            // mechanically rooted in the crate being recorded.
             // This prevents `--program unrelated-crate` from attaching an
             // otherwise valid backend result to source it never exercised.
-            let evidence_program = program.as_deref().filter(|program| {
+            let source_bound_program = program.as_deref().filter(|program| {
                 let Ok(program_root) = program.canonicalize() else {
                     return false;
                 };
+                let scaffold_matches =
+                    scaffold_enabled && program_root.join("Cargo.toml").is_file();
                 let kani_matches = kani_impl_bound
                     && kani_path
                         .canonicalize()
@@ -1648,11 +1656,13 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
                     && project_root
                         .canonicalize()
                         .is_ok_and(|path| path == program_root);
-                kani_matches || miri_matches
+                scaffold_matches || kani_matches || miri_matches
             });
             let opts = if any_flag {
                 verify::VerifyOpts {
                     spec: spec.clone(),
+                    scaffold: scaffold_enabled,
+                    program_dir: program.clone(),
                     proptest,
                     proptest_path,
                     kani,
@@ -1666,6 +1676,8 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             } else {
                 verify::VerifyOpts {
                     spec: spec.clone(),
+                    scaffold: scaffold_enabled,
+                    program_dir: program.clone(),
                     proptest: proptest_path.exists(),
                     proptest_path,
                     kani: kani_path.exists(),
@@ -1704,10 +1716,10 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
 
             // Persist the evidence record `stamp` gates on — written on
             // pass AND fail (a failed run is still evidence of what ran).
-            if program.is_some() && evidence_program.is_none() {
+            if program.is_some() && source_bound_program.is_none() {
                 eprintln!(
-                    "warning: --program is not rooted at the implementation-bound backend \
-                     input; verification evidence will not authorize `stamp`"
+                    "warning: --program is not rooted at a source-bound backend input; \
+                     verification evidence will not retain its source hash"
                 );
             }
             // #332 — reconciled backend-obligation entries: digested into
@@ -1729,7 +1741,7 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
 
             record_verify_evidence(
                 &spec,
-                evidence_program,
+                source_bound_program,
                 &report,
                 kani_impl_bound,
                 probe_repros_passed,
@@ -1737,6 +1749,13 @@ pub(crate) async fn dispatch(cmd: Commands) -> Result<()> {
             );
 
             if strict {
+                if let Some(skipped) = verify::strict_scaffold_skip(&report, opts.scaffold) {
+                    eprintln!(
+                        "verify --strict: enabled scaffold backend was skipped — {}",
+                        skipped.detail.as_deref().unwrap_or("no reason reported")
+                    );
+                    std::process::exit(1);
+                }
                 crate::obligations::print_backend_summaries(&obligation_entries);
                 let problems = crate::obligations::problem_entries(&obligation_entries);
                 for problem in &problems {

--- a/crates/qedgen/src/verify/evidence.rs
+++ b/crates/qedgen/src/verify/evidence.rs
@@ -370,6 +370,19 @@ mod tests {
     }
 
     #[test]
+    fn scaffold_evidence_is_source_bound_but_not_stamp_authorizing() {
+        let spec = tmp_spec("scaffold");
+        let program = tmp_program(&spec);
+        let r = report(vec![("scaffold", BackendStatus::Passed)]);
+        let e = build(&spec, Some(&program), &r, false, None, None).unwrap();
+        assert_eq!(e.backends[0].name, "scaffold");
+        assert!(!e.backends[0].implementation_bound);
+        assert!(!e.implementation_verified);
+        assert!(e.program_hash.is_some());
+        let _ = std::fs::remove_dir_all(spec.parent().unwrap());
+    }
+
+    #[test]
     fn miri_pass_and_kani_impl_pass_count() {
         let spec = tmp_spec("impl");
         let program = tmp_program(&spec);

--- a/crates/qedgen/src/verify/mod.rs
+++ b/crates/qedgen/src/verify/mod.rs
@@ -113,8 +113,22 @@ impl VerifyReport {
     }
 }
 
+pub fn strict_scaffold_skip(
+    report: &VerifyReport,
+    scaffold_enabled: bool,
+) -> Option<&BackendReport> {
+    if !scaffold_enabled {
+        return None;
+    }
+    report.backends.iter().find(|backend| {
+        backend.name == "scaffold" && matches!(backend.status, BackendStatus::Skipped)
+    })
+}
+
 pub struct VerifyOpts {
     pub spec: PathBuf,
+    pub scaffold: bool,
+    pub program_dir: Option<PathBuf>,
     pub proptest: bool,
     pub proptest_path: PathBuf,
     pub kani: bool,
@@ -214,8 +228,13 @@ pub fn recursive_lake_walk(parsed: &crate::check::ParsedSpec) {
 
 pub fn run(opts: &VerifyOpts) -> Result<VerifyReport> {
     let mut backends = Vec::new();
-    let runners: [&dyn VerifyBackend; 4] =
-        [&ProptestBackend, &KaniBackend, &LeanBackend, &MiriBackend];
+    let runners: [&dyn VerifyBackend; 5] = [
+        &ScaffoldBackend,
+        &ProptestBackend,
+        &KaniBackend,
+        &LeanBackend,
+        &MiriBackend,
+    ];
 
     for runner in runners {
         if !runner.enabled(opts) {
@@ -248,6 +267,17 @@ struct ProptestBackend;
 struct KaniBackend;
 struct LeanBackend;
 struct MiriBackend;
+struct ScaffoldBackend;
+
+impl VerifyBackend for ScaffoldBackend {
+    fn enabled(&self, opts: &VerifyOpts) -> bool {
+        opts.scaffold
+    }
+
+    fn run(&self, opts: &VerifyOpts) -> BackendReport {
+        scaffold::run(opts.program_dir.as_deref())
+    }
+}
 
 impl VerifyBackend for ProptestBackend {
     fn enabled(&self, opts: &VerifyOpts) -> bool {

--- a/crates/qedgen/src/verify/mod.rs
+++ b/crates/qedgen/src/verify/mod.rs
@@ -1143,6 +1143,7 @@ pub(crate) mod miri_verify;
 pub(crate) mod ratchet;
 pub(crate) mod regen_drift;
 pub(crate) mod sbpf_verify;
+pub(crate) mod scaffold;
 pub(crate) mod upstream_check;
 pub(crate) mod verify_counterexample;
 pub(crate) mod verify_kani_parse;

--- a/crates/qedgen/src/verify/scaffold.rs
+++ b/crates/qedgen/src/verify/scaffold.rs
@@ -1,0 +1,140 @@
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+use std::time::Instant;
+
+use super::BackendReport;
+
+pub(super) fn run(program_dir: Option<&Path>) -> BackendReport {
+    run_with_cargo(program_dir, OsStr::new("cargo"))
+}
+
+fn run_with_cargo(program_dir: Option<&Path>, cargo_bin: &OsStr) -> BackendReport {
+    let start = Instant::now();
+    let Some(program_dir) = program_dir else {
+        return BackendReport::skipped(
+            "scaffold",
+            start,
+            Some("program crate not supplied (pass `--program <crate>`)".into()),
+        );
+    };
+    let manifest = program_dir.join("Cargo.toml");
+    if !manifest.is_file() {
+        return BackendReport::skipped(
+            "scaffold",
+            start,
+            Some(format!("Cargo.toml not found at {}", manifest.display())),
+        );
+    }
+
+    match Command::new(cargo_bin)
+        .args(["check", "--tests"])
+        .current_dir(program_dir)
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            BackendReport::passed("scaffold", start, Some("cargo check --tests passed".into()))
+        }
+        Ok(out) => BackendReport::failed(
+            "scaffold",
+            start,
+            Some(summarize_failure(&out.stdout, &out.stderr)),
+        ),
+        Err(error) => BackendReport::skipped(
+            "scaffold",
+            start,
+            Some(format!(
+                "Cargo is unavailable ({error}); install Cargo or add it to PATH"
+            )),
+        ),
+    }
+}
+
+fn summarize_failure(stdout: &[u8], stderr: &[u8]) -> String {
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(stdout),
+        String::from_utf8_lossy(stderr)
+    );
+    let lines: Vec<&str> = combined.lines().collect();
+    let start = lines
+        .iter()
+        .position(|line| line.trim_start().starts_with("error"))
+        .unwrap_or_else(|| lines.len().saturating_sub(20));
+    let mut selected: Vec<&str> = lines.iter().skip(start).take(24).copied().collect();
+    if let Some(final_line) = lines
+        .iter()
+        .rev()
+        .find(|line| line.contains("could not compile"))
+        .copied()
+    {
+        if !selected.contains(&final_line) {
+            selected.push(final_line);
+        }
+    }
+    format!("cargo check --tests failed\n{}", selected.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verify::BackendStatus;
+    use std::ffi::OsStr;
+
+    fn write_crate(dir: &Path, lib_rs: &str) {
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"scaffold_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("src/lib.rs"), lib_rs).unwrap();
+    }
+
+    #[test]
+    fn valid_program_crate_passes() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_crate(tmp.path(), "pub fn handler() {}\n");
+        let report = run_with_cargo(Some(tmp.path()), OsStr::new("cargo"));
+        assert_eq!(report.status, BackendStatus::Passed);
+        assert_eq!(report.name, "scaffold");
+    }
+
+    #[test]
+    fn rustc_failure_is_attached_to_report() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_crate(
+            tmp.path(),
+            "pub fn handler() { let _ = MissingGeneratedType; }\n",
+        );
+        let report = run_with_cargo(Some(tmp.path()), OsStr::new("cargo"));
+        assert_eq!(report.status, BackendStatus::Failed);
+        let detail = report.detail.unwrap();
+        assert!(detail.contains("cargo check --tests failed"), "{detail}");
+        assert!(detail.contains("MissingGeneratedType"), "{detail}");
+        assert!(detail.contains("src/lib.rs"), "{detail}");
+    }
+
+    #[test]
+    fn missing_manifest_skips_with_exact_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = run_with_cargo(Some(tmp.path()), OsStr::new("cargo"));
+        assert_eq!(report.status, BackendStatus::Skipped);
+        assert!(report
+            .detail
+            .unwrap()
+            .contains(tmp.path().join("Cargo.toml").to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn unavailable_cargo_skips_with_path_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_crate(tmp.path(), "pub fn handler() {}\n");
+        let report = run_with_cargo(
+            Some(tmp.path()),
+            OsStr::new("definitely-not-a-real-cargo-binary"),
+        );
+        assert_eq!(report.status, BackendStatus::Skipped);
+        assert!(report.detail.unwrap().contains("Cargo is unavailable"));
+    }
+}

--- a/crates/qedgen/tests/scaffold_verify_cli.rs
+++ b/crates/qedgen/tests/scaffold_verify_cli.rs
@@ -1,0 +1,149 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    spec: PathBuf,
+    program: PathBuf,
+}
+
+impl Fixture {
+    fn create(with_manifest: bool, lib_rs: &str) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let status = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let source_spec =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/descriptor/counter.qedspec");
+        let spec = root.join("counter.qedspec");
+        std::fs::copy(source_spec, &spec).unwrap();
+        let program = root.join("program");
+        std::fs::create_dir_all(program.join("src")).unwrap();
+        std::fs::write(program.join("src/lib.rs"), lib_rs).unwrap();
+        if with_manifest {
+            std::fs::write(
+                program.join("Cargo.toml"),
+                "[package]\nname = \"cli_scaffold\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        }
+        Self {
+            _tmp: tmp,
+            spec,
+            program,
+        }
+    }
+
+    fn broken_program() -> Self {
+        Self::create(true, "pub fn handler() { let _ = MissingGeneratedType; }\n")
+    }
+
+    fn without_program_manifest() -> Self {
+        Self::create(false, "pub fn handler() {}\n")
+    }
+
+    fn program_str(&self) -> &str {
+        self.program.to_str().unwrap()
+    }
+
+    fn verify(&self, extra_args: &[&str]) -> Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_qedgen"));
+        command
+            .arg("verify")
+            .arg("--spec")
+            .arg(&self.spec)
+            .current_dir(self._tmp.path());
+        command.args(extra_args).output().unwrap()
+    }
+
+    fn stderr(&self, output: &Output) -> String {
+        String::from_utf8_lossy(&output.stderr).into_owned()
+    }
+}
+
+#[test]
+fn flagless_program_auto_runs_scaffold_and_fails_on_broken_rust() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&["--program", fixture.program_str()]);
+    assert!(!out.status.success());
+    assert!(fixture.stderr(&out).contains("[FAIL] scaffold"));
+    assert!(fixture.stderr(&out).contains("MissingGeneratedType"));
+}
+
+#[test]
+fn explicit_backend_does_not_implicitly_run_scaffold() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--lean",
+        "--lean-dir",
+        "missing-proofs",
+    ]);
+    assert!(out.status.success(), "{}", fixture.stderr(&out));
+    assert!(!fixture.stderr(&out).contains("scaffold"));
+}
+
+#[test]
+fn scaffold_composes_with_explicit_backend_selection() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--lean",
+        "--lean-dir",
+        "missing-proofs",
+        "--scaffold",
+    ]);
+    assert!(!out.status.success());
+    assert!(fixture.stderr(&out).contains("[FAIL] scaffold"));
+}
+
+#[test]
+fn fail_fast_reports_only_scaffold_when_it_fails_first() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--lean",
+        "--lean-dir",
+        "missing-proofs",
+        "--scaffold",
+        "--fail-fast",
+        "--json",
+    ]);
+    assert!(!out.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(report["backends"].as_array().unwrap().len(), 1);
+    assert_eq!(report["backends"][0]["name"], "scaffold");
+}
+
+#[test]
+fn strict_rejects_an_enabled_scaffold_skip() {
+    let fixture = Fixture::without_program_manifest();
+    let out = fixture.verify(&["--program", fixture.program_str(), "--scaffold", "--strict"]);
+    assert!(!out.status.success());
+    assert!(fixture
+        .stderr(&out)
+        .contains("verify --strict: enabled scaffold backend was skipped"));
+}
+
+#[test]
+fn skipped_scaffold_is_nonfatal_without_strict() {
+    let fixture = Fixture::without_program_manifest();
+    let out = fixture.verify(&["--program", fixture.program_str(), "--scaffold"]);
+    assert!(out.status.success(), "{}", fixture.stderr(&out));
+    assert!(fixture.stderr(&out).contains("[SKIP] scaffold"));
+}
+
+#[test]
+fn scaffold_without_program_is_a_cli_usage_error() {
+    let fixture = Fixture::without_program_manifest();
+    let out = fixture.verify(&["--scaffold"]);
+    assert!(!out.status.success());
+    assert!(fixture.stderr(&out).contains("--program"));
+}

--- a/docs/superpowers/plans/2026-07-27-scaffold-verify-backend.md
+++ b/docs/superpowers/plans/2026-07-27-scaffold-verify-backend.md
@@ -1,0 +1,732 @@
+# Scaffold Verification Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `qedgen verify` compile the selected generated program crate through a first-class `scaffold` backend.
+
+**Architecture:** A focused `verify::scaffold` runner executes `cargo check --tests` and returns the existing `BackendReport` type. The CLI registers it before the model/proof backends, auto-enables it for flagless `verify --program`, persists it through existing evidence serialization, and makes strict mode reject a skipped enabled scaffold check.
+
+**Tech Stack:** Rust 2021, clap, Cargo subprocesses, serde JSON reports, tempfile-backed tests.
+
+## Global Constraints
+
+- `--scaffold` requires `--program`.
+- Flagless `verify --program <crate>` auto-enables scaffold compilation.
+- Explicit backend flags remain exact: `--program <crate> --kani` does not imply scaffold.
+- Run `cargo check --tests` in the selected program directory.
+- Scaffold compilation is recorded evidence but never authorizes `#[qed(verified)]`.
+- Ordinary skips are nonfatal; `verify --strict` fails when an enabled scaffold backend is skipped.
+- Do not add scaffold compilation to the semantic backend-obligation manifest.
+- Do not add dependencies or Cargo policy flags such as `--locked` or `--offline`.
+- Preserve the existing behavior of verify invocations without `--program`.
+
+---
+
+### Task 1: Implement the scaffold runner
+
+**Files:**
+- Create: `crates/qedgen/src/verify/scaffold.rs`
+- Modify: `crates/qedgen/src/verify/mod.rs`
+- Test: `crates/qedgen/src/verify/scaffold.rs`
+
+**Interfaces:**
+- Consumes: `super::{BackendReport, BackendStatus}`.
+- Produces: `pub(super) fn run(program_dir: Option<&Path>) -> BackendReport`.
+- Produces for tests: private `run_with_cargo(program_dir: Option<&Path>, cargo_bin: &OsStr) -> BackendReport`.
+
+- [ ] **Step 1: Register an empty scaffold module and write failing runner tests**
+
+Add `pub(crate) mod scaffold;` beside the other verify modules in
+`crates/qedgen/src/verify/mod.rs`. Create `scaffold.rs` with test helpers and
+the following tests before defining `run_with_cargo`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verify::BackendStatus;
+    use std::ffi::OsStr;
+
+    fn write_crate(dir: &Path, lib_rs: &str) {
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"scaffold_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("src/lib.rs"), lib_rs).unwrap();
+    }
+
+    #[test]
+    fn valid_program_crate_passes() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_crate(tmp.path(), "pub fn handler() {}\n");
+        let report = run_with_cargo(Some(tmp.path()), OsStr::new("cargo"));
+        assert_eq!(report.status, BackendStatus::Passed);
+        assert_eq!(report.name, "scaffold");
+    }
+
+    #[test]
+    fn rustc_failure_is_attached_to_report() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_crate(
+            tmp.path(),
+            "pub fn handler() { let _ = MissingGeneratedType; }\n",
+        );
+        let report = run_with_cargo(Some(tmp.path()), OsStr::new("cargo"));
+        assert_eq!(report.status, BackendStatus::Failed);
+        let detail = report.detail.unwrap();
+        assert!(detail.contains("cargo check --tests failed"), "{detail}");
+        assert!(detail.contains("MissingGeneratedType"), "{detail}");
+        assert!(detail.contains("src/lib.rs"), "{detail}");
+    }
+
+    #[test]
+    fn missing_manifest_skips_with_exact_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = run_with_cargo(Some(tmp.path()), OsStr::new("cargo"));
+        assert_eq!(report.status, BackendStatus::Skipped);
+        assert!(
+            report.detail.unwrap().contains(
+                tmp.path().join("Cargo.toml").to_string_lossy().as_ref()
+            )
+        );
+    }
+
+    #[test]
+    fn unavailable_cargo_skips_with_path_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_crate(tmp.path(), "pub fn handler() {}\n");
+        let report = run_with_cargo(
+            Some(tmp.path()),
+            OsStr::new("definitely-not-a-real-cargo-binary"),
+        );
+        assert_eq!(report.status, BackendStatus::Skipped);
+        assert!(report.detail.unwrap().contains("Cargo is unavailable"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p qedgen-solana-skills verify::scaffold::tests -- --nocapture
+```
+
+Expected: compilation fails because `run_with_cargo` is not defined.
+
+- [ ] **Step 3: Implement the minimal scaffold runner**
+
+Add these functions above the test module:
+
+```rust
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+use std::time::Instant;
+
+use super::BackendReport;
+
+pub(super) fn run(program_dir: Option<&Path>) -> BackendReport {
+    run_with_cargo(program_dir, OsStr::new("cargo"))
+}
+
+fn run_with_cargo(program_dir: Option<&Path>, cargo_bin: &OsStr) -> BackendReport {
+    let start = Instant::now();
+    let Some(program_dir) = program_dir else {
+        return BackendReport::skipped(
+            "scaffold",
+            start,
+            Some("program crate not supplied (pass `--program <crate>`)".into()),
+        );
+    };
+    let manifest = program_dir.join("Cargo.toml");
+    if !manifest.is_file() {
+        return BackendReport::skipped(
+            "scaffold",
+            start,
+            Some(format!("Cargo.toml not found at {}", manifest.display())),
+        );
+    }
+
+    match Command::new(cargo_bin)
+        .args(["check", "--tests"])
+        .current_dir(program_dir)
+        .output()
+    {
+        Ok(out) if out.status.success() => BackendReport::passed(
+            "scaffold",
+            start,
+            Some("cargo check --tests passed".into()),
+        ),
+        Ok(out) => BackendReport::failed(
+            "scaffold",
+            start,
+            Some(summarize_failure(&out.stdout, &out.stderr)),
+        ),
+        Err(error) => BackendReport::skipped(
+            "scaffold",
+            start,
+            Some(format!(
+                "Cargo is unavailable ({error}); install Cargo or add it to PATH"
+            )),
+        ),
+    }
+}
+
+fn summarize_failure(stdout: &[u8], stderr: &[u8]) -> String {
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(stdout),
+        String::from_utf8_lossy(stderr)
+    );
+    let lines: Vec<&str> = combined.lines().collect();
+    let start = lines
+        .iter()
+        .position(|line| line.trim_start().starts_with("error"))
+        .unwrap_or_else(|| lines.len().saturating_sub(20));
+    let mut selected: Vec<&str> = lines.iter().skip(start).take(24).copied().collect();
+    if let Some(final_line) = lines
+        .iter()
+        .rev()
+        .find(|line| line.contains("could not compile"))
+        .copied()
+    {
+        if !selected.contains(&final_line) {
+            selected.push(final_line);
+        }
+    }
+    format!("cargo check --tests failed\n{}", selected.join("\n"))
+}
+```
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p qedgen-solana-skills verify::scaffold::tests -- --nocapture
+```
+
+Expected: 4 passed, 0 failed.
+
+- [ ] **Step 5: Run formatting and commit**
+
+Run:
+
+```bash
+cargo fmt --check
+git diff --check
+git add crates/qedgen/src/verify/mod.rs crates/qedgen/src/verify/scaffold.rs
+git commit -m "feat(verify): add scaffold compilation runner"
+```
+
+### Task 2: Wire backend selection, ordering, strictness, and evidence
+
+**Files:**
+- Modify: `crates/qedgen/src/cli.rs`
+- Modify: `crates/qedgen/src/run.rs`
+- Modify: `crates/qedgen/src/verify/mod.rs`
+- Create: `crates/qedgen/tests/scaffold_verify_cli.rs`
+- Test: `crates/qedgen/tests/scaffold_verify_cli.rs`
+- Test: `crates/qedgen/src/verify/evidence.rs`
+
+**Interfaces:**
+- Consumes: `verify::scaffold::run`.
+- Extends: `VerifyOpts` with `scaffold: bool` and `program_dir: Option<PathBuf>`.
+- Produces: CLI flag `--scaffold`, requiring `--program`.
+- Produces: `pub fn strict_scaffold_skip(report: &VerifyReport, scaffold_enabled: bool) -> Option<&BackendReport>`.
+
+- [ ] **Step 1: Write black-box CLI tests before adding the flag**
+
+Create `crates/qedgen/tests/scaffold_verify_cli.rs`. Stage
+`crates/qedgen/tests/fixtures/descriptor/counter.qedspec` into a
+git-initialized temp directory, and create `program/Cargo.toml` plus
+`program/src/lib.rs`. Drive `env!("CARGO_BIN_EXE_qedgen")` with this fixture:
+
+```rust
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    spec: PathBuf,
+    program: PathBuf,
+}
+
+impl Fixture {
+    fn create(with_manifest: bool, lib_rs: &str) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let status = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let source_spec = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/descriptor/counter.qedspec");
+        let spec = root.join("counter.qedspec");
+        std::fs::copy(source_spec, &spec).unwrap();
+        let program = root.join("program");
+        std::fs::create_dir_all(program.join("src")).unwrap();
+        std::fs::write(program.join("src/lib.rs"), lib_rs).unwrap();
+        if with_manifest {
+            std::fs::write(
+                program.join("Cargo.toml"),
+                "[package]\nname = \"cli_scaffold\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        }
+        Self {
+            _tmp: tmp,
+            spec,
+            program,
+        }
+    }
+
+    fn broken_program() -> Self {
+        Self::create(
+            true,
+            "pub fn handler() { let _ = MissingGeneratedType; }\n",
+        )
+    }
+
+    fn without_program_manifest() -> Self {
+        Self::create(false, "pub fn handler() {}\n")
+    }
+
+    fn program_str(&self) -> &str {
+        self.program.to_str().unwrap()
+    }
+
+    fn verify(&self, extra_args: &[&str]) -> Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_qedgen"));
+        command
+            .arg("verify")
+            .arg("--spec")
+            .arg(&self.spec)
+            .current_dir(self._tmp.path());
+        command.args(extra_args).output().unwrap()
+    }
+
+    fn stderr(&self, output: &Output) -> String {
+        String::from_utf8_lossy(&output.stderr).into_owned()
+    }
+}
+```
+
+Add these tests:
+
+```rust
+#[test]
+fn flagless_program_auto_runs_scaffold_and_fails_on_broken_rust() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&["--program", fixture.program_str()]);
+    assert!(!out.status.success());
+    assert!(fixture.stderr(&out).contains("[FAIL] scaffold"));
+    assert!(fixture.stderr(&out).contains("MissingGeneratedType"));
+}
+
+#[test]
+fn explicit_backend_does_not_implicitly_run_scaffold() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--lean",
+        "--lean-dir",
+        "missing-proofs",
+    ]);
+    assert!(out.status.success(), "{}", fixture.stderr(&out));
+    assert!(!fixture.stderr(&out).contains("scaffold"));
+}
+
+#[test]
+fn scaffold_composes_with_explicit_backend_selection() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--lean",
+        "--lean-dir",
+        "missing-proofs",
+        "--scaffold",
+    ]);
+    assert!(!out.status.success());
+    assert!(fixture.stderr(&out).contains("[FAIL] scaffold"));
+}
+
+#[test]
+fn fail_fast_reports_only_scaffold_when_it_fails_first() {
+    let fixture = Fixture::broken_program();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--lean",
+        "--lean-dir",
+        "missing-proofs",
+        "--scaffold",
+        "--fail-fast",
+        "--json",
+    ]);
+    assert!(!out.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(report["backends"].as_array().unwrap().len(), 1);
+    assert_eq!(report["backends"][0]["name"], "scaffold");
+}
+
+#[test]
+fn strict_rejects_an_enabled_scaffold_skip() {
+    let fixture = Fixture::without_program_manifest();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--scaffold",
+        "--strict",
+    ]);
+    assert!(!out.status.success());
+    assert!(
+        fixture.stderr(&out).contains(
+            "verify --strict: enabled scaffold backend was skipped"
+        )
+    );
+}
+
+#[test]
+fn skipped_scaffold_is_nonfatal_without_strict() {
+    let fixture = Fixture::without_program_manifest();
+    let out = fixture.verify(&[
+        "--program",
+        fixture.program_str(),
+        "--scaffold",
+    ]);
+    assert!(out.status.success(), "{}", fixture.stderr(&out));
+    assert!(fixture.stderr(&out).contains("[SKIP] scaffold"));
+}
+
+#[test]
+fn scaffold_without_program_is_a_cli_usage_error() {
+    let fixture = Fixture::without_program_manifest();
+    let out = fixture.verify(&["--scaffold"]);
+    assert!(!out.status.success());
+    assert!(fixture.stderr(&out).contains("--program"));
+}
+```
+
+Also extend the evidence test helper in `verify/evidence.rs` with a report
+containing a passing `scaffold` backend:
+
+```rust
+let program = tmp_program(&spec);
+let r = report(vec![("scaffold", BackendStatus::Passed)]);
+let e = build(&spec, Some(&program), &r, false, None, None).unwrap();
+assert_eq!(e.backends[0].name, "scaffold");
+assert!(!e.backends[0].implementation_bound);
+assert!(!e.implementation_verified);
+assert!(e.program_hash.is_some());
+```
+
+This pins that the source hash is retained while compilation alone remains
+ineligible for `stamp`.
+
+- [ ] **Step 2: Run CLI tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p qedgen-solana-skills --test scaffold_verify_cli -- --nocapture
+```
+
+Expected: failures because clap does not recognize `--scaffold`, flagless
+`--program` does not compile the crate, and no scaffold report is emitted.
+
+- [ ] **Step 3: Add the CLI flag and backend fields**
+
+In `Commands::Verify`, add after `program`:
+
+```rust
+/// Compile the selected program crate with `cargo check --tests`.
+/// Requires `--program`. With no explicit backend flags, supplying
+/// `--program` enables this backend automatically.
+#[arg(long, requires = "program")]
+scaffold: bool,
+```
+
+Extend `VerifyOpts`:
+
+```rust
+pub scaffold: bool,
+pub program_dir: Option<PathBuf>,
+```
+
+Register the backend first:
+
+```rust
+struct ScaffoldBackend;
+
+impl VerifyBackend for ScaffoldBackend {
+    fn enabled(&self, opts: &VerifyOpts) -> bool {
+        opts.scaffold
+    }
+
+    fn run(&self, opts: &VerifyOpts) -> BackendReport {
+        scaffold::run(opts.program_dir.as_deref())
+    }
+}
+```
+
+Change the runner array to:
+
+```rust
+let runners: [&dyn VerifyBackend; 5] = [
+    &ScaffoldBackend,
+    &ProptestBackend,
+    &KaniBackend,
+    &LeanBackend,
+    &MiriBackend,
+];
+```
+
+- [ ] **Step 4: Implement exact/default selection and strict skip gating**
+
+Destructure `scaffold` in `run.rs`. Include it in every
+`any_backend_flag`/`any_flag` expression in the Verify arm. Compute the
+effective default once, then construct opts:
+
+```rust
+let any_flag = scaffold || proptest || kani || lean || miri;
+let scaffold_enabled = if any_flag { scaffold } else { program.is_some() };
+
+let opts = if any_flag {
+    verify::VerifyOpts {
+        spec: spec.clone(),
+        scaffold: scaffold_enabled,
+        program_dir: program.clone(),
+        proptest,
+        proptest_path,
+        kani,
+        kani_path,
+        lean,
+        lean_dir,
+        miri,
+        fail_fast,
+        project_root: project_root.clone(),
+    }
+} else {
+    verify::VerifyOpts {
+        spec: spec.clone(),
+        scaffold: scaffold_enabled,
+        program_dir: program.clone(),
+        proptest: proptest_path.exists(),
+        proptest_path,
+        kani: kani_path.exists(),
+        kani_path,
+        lean: lean_dir.join("lakefile.lean").exists()
+            || lean_dir.join("lakefile.toml").exists(),
+        lean_dir,
+        miri: miri_default,
+        fail_fast,
+        project_root: project_root.clone(),
+    }
+};
+```
+
+Use the same `scaffold_enabled` value when binding evidence to source. Rename
+the local `evidence_program` variable to `source_bound_program` and add
+scaffold to its path predicate:
+
+```rust
+let scaffold_matches =
+    scaffold_enabled && program_root.join("Cargo.toml").is_file();
+let source_matches = scaffold_matches || kani_matches || miri_matches;
+source_matches
+```
+
+Pass `source_bound_program` to `record_verify_evidence`. This retains the
+selected source hash for a scaffold run while leaving the evidence builder in
+control of semantic stamp eligibility.
+
+Add to `verify/mod.rs`:
+
+```rust
+pub fn strict_scaffold_skip(
+    report: &VerifyReport,
+    scaffold_enabled: bool,
+) -> Option<&BackendReport> {
+    if !scaffold_enabled {
+        return None;
+    }
+    report.backends.iter().find(|backend| {
+        backend.name == "scaffold"
+            && matches!(backend.status, BackendStatus::Skipped)
+    })
+}
+```
+
+After rendering and evidence recording, before the existing semantic
+obligation strict gate, add:
+
+```rust
+if strict {
+    if let Some(skipped) = verify::strict_scaffold_skip(&report, opts.scaffold) {
+        eprintln!(
+            "verify --strict: enabled scaffold backend was skipped — {}",
+            skipped.detail.as_deref().unwrap_or("no reason reported")
+        );
+        std::process::exit(1);
+    }
+}
+```
+
+Do not add `"scaffold"` to the implementation-bound arms in
+`verify::evidence::build`; the existing fallback must remain false.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p qedgen-solana-skills verify::scaffold -- --nocapture
+cargo test -p qedgen-solana-skills verify::evidence -- --nocapture
+cargo test -p qedgen-solana-skills --test scaffold_verify_cli -- --nocapture
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 6: Run formatting, lint the diff, and commit**
+
+Run:
+
+```bash
+cargo fmt --check
+git diff --check
+git add crates/qedgen/src/cli.rs crates/qedgen/src/run.rs crates/qedgen/src/verify/mod.rs crates/qedgen/src/verify/evidence.rs crates/qedgen/tests/scaffold_verify_cli.rs
+git commit -m "feat(verify): compile selected program scaffolds"
+```
+
+### Task 3: Document scaffold verification
+
+**Files:**
+- Modify: `references/cli/validation.md`
+- Modify: `README.md`
+- Modify: `crates/qedgen/src/cli.rs`
+
+**Interfaces:**
+- Documents the `--scaffold` flag and flagless `--program` auto-selection.
+- Documents that scaffold compilation is not semantic or stamp-authorizing evidence.
+
+- [ ] **Step 1: Update the verify reference**
+
+In `references/cli/validation.md`, add this example near the existing verify
+examples:
+
+```markdown
+# Compile the generated program crate as a verify backend.
+$QEDGEN verify --spec my_program.qedspec --program ./programs/my_program --scaffold
+```
+
+Add this row to the verify flags table:
+
+```markdown
+| `--scaffold` | bool | auto with flagless `--program` | Run `cargo check --tests` in the `--program` crate. Requires `--program`; explicit backend selection remains exact. Compilation proves buildability, not semantic conformance, and cannot authorize `stamp`. |
+```
+
+Extend the `--strict` row to state that an enabled but skipped scaffold
+backend also gates strict verification.
+
+- [ ] **Step 2: Update the README workflow**
+
+Near the primary `qedgen verify` example, add:
+
+```markdown
+When `--program <crate>` is supplied without explicit backend flags, verify
+also runs the `scaffold` backend (`cargo check --tests`) so generated Rust
+compile failures surface inside QEDGen. Use `--scaffold` to combine that check
+with an explicitly selected backend. A scaffold pass proves buildability, not
+spec conformance, and cannot authorize `qedgen stamp`.
+```
+
+Ensure the clap help on `program`, `scaffold`, and the Verify command summary
+uses the same terms: “program crate”, “cargo check --tests”, and
+“buildability, not semantic conformance”.
+
+- [ ] **Step 3: Run documentation and CLI drift checks**
+
+Run:
+
+```bash
+bash scripts/check-readme-drift.sh
+cargo run -p qedgen-solana-skills -- verify --help
+npm test
+```
+
+Expected: all commands exit 0, and help lists `--scaffold` as requiring
+`--program`.
+
+- [ ] **Step 4: Commit documentation**
+
+Run:
+
+```bash
+git diff --check
+git add README.md references/cli/validation.md crates/qedgen/src/cli.rs
+git commit -m "docs(verify): explain scaffold compilation checks"
+```
+
+### Task 4: Verify the complete implementation
+
+**Files:**
+- Verify only; modify files solely to correct failures found by these gates.
+
+**Interfaces:**
+- Confirms the complete branch satisfies issue #364 and repository gates.
+
+- [ ] **Step 1: Run focused acceptance tests**
+
+Run:
+
+```bash
+cargo test -p qedgen-solana-skills --test scaffold_verify_cli -- --nocapture
+cargo test -p qedgen-solana-skills verify::scaffold -- --nocapture
+cargo test -p qedgen-solana-skills verify::evidence -- --nocapture
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run the full Rust suite**
+
+Run:
+
+```bash
+cargo test
+```
+
+Expected: exit 0 with zero failed tests.
+
+- [ ] **Step 3: Run lint and package checks**
+
+Run:
+
+```bash
+cargo clippy -- -D warnings
+npm test
+git diff --check origin/main...HEAD
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Confirm branch contents**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --reverse origin/main..HEAD
+git diff --stat origin/main...HEAD
+```
+
+Expected: a clean `feat/364-scaffold-verify` worktree containing only the
+design, implementation, tests, and documentation for issue #364.

--- a/docs/superpowers/specs/2026-07-27-scaffold-verify-backend-design.md
+++ b/docs/superpowers/specs/2026-07-27-scaffold-verify-backend-design.md
@@ -1,0 +1,180 @@
+# Scaffold Verification Backend Design
+
+## Context
+
+Issue #364 identifies a gap in the user-facing verification loop: QEDGen can
+generate a program crate, report zero spec errors, and run model harnesses
+without ever compiling the generated program itself. Maintainer CI compiles a
+fixed example corpus, but that cannot cover the shapes in an arbitrary user's
+spec.
+
+The `verify` command already represents proptest, Kani, Lean, and Miri runs as
+`BackendReport` values. The scaffold compile check belongs in that same
+pipeline so it shares reporting, fail-fast behavior, JSON output, evidence
+recording, and exit handling.
+
+## Goals
+
+- Add a `scaffold` verification backend that runs `cargo check --tests` in the
+  program crate supplied by `--program`.
+- Add an explicit `--scaffold` CLI flag.
+- Auto-enable scaffold verification when `--program` is supplied and no
+  backend flags are selected.
+- Run scaffold verification before heavier backends so `--fail-fast` stops
+  promptly on uncompilable generated code.
+- Report actionable Cargo/rustc diagnostics through the existing human and
+  JSON `BackendReport` formats.
+- Persist the scaffold result in `.qed/verify-evidence.json` without allowing
+  compilation alone to authorize `#[qed(verified)]`.
+- Make `verify --strict` reject an enabled scaffold backend that could not run.
+
+## Non-goals
+
+- Do not add a post-codegen compile option.
+- Do not change code generation or repair compile failures.
+- Do not make scaffold compilation semantic conformance evidence.
+- Do not add scaffold compilation to the semantic backend-obligation manifest.
+- Do not add Cargo flags such as `--locked`, `--offline`, or target-specific
+  build arguments.
+- Do not change verification runs that omit `--program`.
+
+## CLI Behavior
+
+`--scaffold` is an explicit verify backend selector and requires `--program`.
+The selection rules are:
+
+| Invocation shape | Scaffold behavior |
+| --- | --- |
+| `verify --program <crate>` with no backend flags | Auto-enabled |
+| `verify --program <crate> --scaffold` | Enabled explicitly |
+| `verify --program <crate> --kani` | Not enabled |
+| `verify --program <crate> --kani --scaffold` | Enabled with Kani |
+| `verify` without `--program` | Unchanged |
+| `verify --scaffold` without `--program` | CLI usage error |
+
+The existing definition of "backend flag" expands to include `--scaffold`
+wherever `run.rs` decides whether a command is backend-only, whether it should
+return after an upstream or probe-reproducer stage, and whether it should
+perform on-disk backend discovery.
+
+## Architecture
+
+### Backend integration
+
+`VerifyOpts` gains:
+
+- `scaffold: bool`
+- `program_dir: Option<PathBuf>`
+
+`verify::run` registers `ScaffoldBackend` before Proptest, Kani, Lean, and
+Miri. Its `enabled` method reads `opts.scaffold`; its `run` method passes the
+selected program directory to a focused `run_scaffold` function.
+
+`run_scaffold`:
+
+1. Starts the backend timer.
+2. Returns `Skipped` when no program directory was supplied.
+3. Returns `Skipped` when `<program>/Cargo.toml` does not exist, naming the
+   missing manifest.
+4. Runs `cargo check --tests` with `current_dir` set to the program directory.
+5. Returns `Passed` on exit status zero.
+6. Returns `Failed` with a concise Cargo/rustc diagnostic on nonzero exit.
+7. Returns `Skipped` with an installation/path hint when Cargo cannot be
+   spawned.
+
+The program directory is not canonicalized before execution. Cargo and the
+existing evidence layer already provide path-specific errors, and preserving
+the user-provided display path keeps diagnostics understandable.
+
+### Default selection
+
+When any explicit backend flag is present, `run.rs` honors exactly those
+flags. When none is present, existing harness discovery remains intact and
+`scaffold` becomes true only if `--program` was supplied. This keeps
+`verify --program <crate> --kani` Kani-only while making the flagless
+`verify --program <crate>` close the compile gap automatically.
+
+### Failure summaries
+
+The scaffold backend combines Cargo stdout and stderr, then extracts a bounded,
+deterministic diagnostic:
+
+- begin at the first line starting with `error` when present;
+- retain that error block and nearby source context;
+- retain Cargo's final `could not compile` line when present;
+- cap the rendered detail so JSON and terminal output do not absorb an entire
+  dependency build log.
+
+If no structured error marker exists, the summary uses the final non-empty
+output lines. The detail must always explain that `cargo check --tests`
+failed.
+
+### Strict mode
+
+An ordinary skipped scaffold backend remains nonfatal, matching current
+missing-harness behavior. Under `--strict`, an enabled scaffold report with
+`Skipped` status causes exit code 1 after the report is printed. A `Failed`
+report already fails every verify run through `VerifyReport::ok`.
+
+This gate reads the backend report directly. The backend-obligation manifest
+continues to mean semantic obligations requested by the spec; adding a
+program-build pseudo-obligation would weaken that model.
+
+### Evidence semantics
+
+The existing evidence serializer records every backend name and status, so no
+schema change is required. `verify::evidence::build` must explicitly keep
+`scaffold` outside the set of implementation-bound conformance backends.
+A passing scaffold check proves that the selected source tree compiles, not
+that handlers implement the spec.
+
+## Error Handling
+
+- Missing program argument for explicit `--scaffold`: clap usage error.
+- Missing `Cargo.toml`: skipped with exact expected path.
+- Cargo executable unavailable: skipped with an actionable installation/PATH
+  message; strict mode turns the skip into a gate failure.
+- Cargo/rustc nonzero exit: failed backend with the relevant diagnostic.
+- A scaffold failure participates in `--fail-fast` because it runs first.
+- No failure path mutates generated source or the program manifest.
+
+## Testing
+
+Tests follow red-green TDD and use real temporary Cargo crates:
+
+1. A valid minimal crate returns a passing scaffold report.
+2. A crate with an unresolved Rust name returns a failed report containing the
+   rustc error and source location.
+3. A directory without `Cargo.toml` returns a skipped report naming the
+   manifest.
+4. CLI selection tests prove flagless `--program` auto-enables scaffold.
+5. CLI selection tests prove an explicit model backend does not auto-enable
+   scaffold.
+6. CLI selection tests prove `--scaffold` composes with another backend.
+7. A fail-fast test proves scaffold runs before later backends.
+8. A strict-mode test proves an enabled skipped scaffold exits nonzero.
+9. An evidence test proves a passing scaffold backend does not set
+   `implementation_verified`.
+10. Existing verify human/JSON rendering tests continue to cover the generic
+    report shape.
+
+Final verification runs the targeted tests, `cargo test`,
+`cargo clippy -- -D warnings`, and `npm test`.
+
+## Documentation
+
+Update the verify CLI help and the verify command reference to explain:
+
+- `--scaffold` requires `--program`;
+- flagless `verify --program <crate>` automatically checks the crate;
+- explicit backend selection remains exact;
+- compilation is not semantic verification or stamp authority;
+- skipped scaffold checks fail under `--strict`.
+
+## Compatibility
+
+The only newly failing default path is a flagless verify invocation that
+already supplies `--program` and points at a crate that does not compile. That
+is the intended behavior change. Invocations without `--program`, and
+invocations selecting explicit model backends without `--scaffold`, retain
+their existing behavior.

--- a/references/cli/validation.md
+++ b/references/cli/validation.md
@@ -142,7 +142,8 @@ the spec; `verify` validates the code the spec produced. With no backend
 flags, runs every backend whose artifact is present on disk
 (`./programs/tests/proptest.rs`, `./programs/tests/kani.rs`,
 `./formal_verification/`). Use `--proptest` / `--kani` / `--lean` to
-target one backend.
+target one backend. Supplying flagless `--program <crate>` also runs the
+`scaffold` backend (`cargo check --tests`) in that program crate.
 
 v2.44 — every run also records its evidence to
 `<spec_dir>/.qed/verify-evidence.json` (spec hash, optional program-source
@@ -163,6 +164,9 @@ $QEDGEN verify --spec my_program.qedspec --proptest
 $QEDGEN verify --spec my_program.qedspec --kani
 $QEDGEN verify --spec my_program.qedspec --lean
 
+# Compile the generated program crate as a verify backend.
+$QEDGEN verify --spec my_program.qedspec --program ./programs/my_program --scaffold
+
 # CI gating
 $QEDGEN verify --spec my_program.qedspec --fail-fast --json
 
@@ -181,7 +185,8 @@ $QEDGEN verify --spec my_program.qedspec --check-upstream --upstream-stale-ok
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--spec` | Path | required | Spec file (`.qedspec`) |
-| `--program` | Path | none | Program crate to hash into implementation-bound evidence; required before `stamp` can consume that evidence |
+| `--program` | Path | none | Program crate selected by source-bound backends and hashed into their evidence; required before `stamp` can consume eligible implementation-bound evidence |
+| `--scaffold` | bool | auto with flagless `--program` | Run `cargo check --tests` in the `--program` crate. Requires `--program`; explicit backend selection remains exact. Compilation proves buildability, not semantic conformance, and cannot authorize `stamp`. |
 | `--proptest` | bool | false | Run proptest harnesses (`cargo test --release`) |
 | `--proptest-path` | Path | `./programs/tests/proptest.rs` | Proptest harness file |
 | `--kani` | bool | false | Run Kani BMC harnesses (`cargo kani --tests`) |
@@ -202,5 +207,4 @@ $QEDGEN verify --spec my_program.qedspec --check-upstream --upstream-stale-ok
 | `--crucible-stateful` | bool | false | Stateful action-chain mode for `--crucible`. |
 | `--recursive` | bool | false | v2.27 Track D3 — DFS-walk the transitive proof-package closure (deduped by path) and run `lake build` per layer. Per-layer PASS/FAIL is reported; failed layers print the first ~10 lines of stderr/stdout. Exits non-zero on any layer failure; emits "every imported proof package built clean" when all pass. No-op success when the spec imports nothing with `verified = true` in `qed.lock`. |
 | `--require-verified` | bool | false | v2.27 Track D2 — exits non-zero before any backend dispatches if any imported Tier-1+ interface (binary_hash + `ensures`) did NOT ship a `.qed/proofs/<Iface>.lean + lakefile.lean` package alongside. Tier-0 (no ensures) and sentinel-pinned natives (all-zero binary_hash) are exempt. Default-off in v2.27 because the bundled stdlib still ships Stance 1 for `import System from "system"` (no bundled proof package for Pubkey-param handlers). |
-| `--strict` | bool | false | #332 — recompute the reconciled backend-obligation manifest (kani / lean / proptest, in memory) and exit 1 on any `unsupported` or `failed` entry. A passing strict verify means no requested obligation was silently dropped by a backend. Remaining `unsupported` shapes (v2.48.0): property preservation that spans account modules (kani/lean), Lean abort predicates with multi-projection account reads, CPI ensures composition at call sites without `state_binders`, and guard-rejection tests whose guard does not survive the simplified proptest model. Specs with these shapes fail strict verify by design. |
-
+| `--strict` | bool | false | Fail when an enabled scaffold backend is skipped. Also recompute the reconciled backend-obligation manifest (kani / lean / proptest, in memory) and exit 1 on any `unsupported` or `failed` entry. A passing strict verify means no requested obligation was silently dropped by a backend. Remaining `unsupported` shapes (v2.48.0): property preservation that spans account modules (kani/lean), Lean abort predicates with multi-projection account reads, CPI ensures composition at call sites without `state_binders`, and guard-rejection tests whose guard does not survive the simplified proptest model. Specs with these shapes fail strict verify by design. |


### PR DESCRIPTION
## Summary

- add a first-class scaffold verify backend that runs cargo check --tests in the selected program crate
- auto-enable scaffold for flagless verify --program while keeping explicit backend selection exact
- report bounded rustc diagnostics, gate enabled skips under --strict, and retain source-bound evidence without authorizing stamp
- document the workflow and its buildability-only trust boundary

The issue proposed adding scaffold to the semantic obligation manifest. This PR keeps it in verify evidence instead: compilation establishes buildability, not a qedspec semantic obligation, so it must not affect obligation coverage or stamp eligibility.

## Tests

- cargo test
- cargo clippy -- -D warnings
- npm test
- bash scripts/check-readme-drift.sh
- cargo test -p qedgen-solana-skills --test scaffold_verify_cli -- --nocapture

Closes #364