### PR TITLE
fix(proptest): sequence harness respects each property's preserved_by scope

### DIFF
--- a/crates/qedgen/src/codegen/proptest_gen_mir.rs
+++ b/crates/qedgen/src/codegen/proptest_gen_mir.rs
@@ -1991,6 +1991,34 @@ fn emit_sequence_test_for(
         out.push_str("            }\n");
     }
 
+    // Properties this section checks in the sequence: those with at least
+    // one obligated handler here. A pre-state snapshot lets each check
+    // assert the `preserved_by` obligation faithfully — `pre → post`, not
+    // just `post` (see the emission comment below).
+    let seq_props: Vec<(&&ParsedProperty, Vec<String>)> = all_props
+        .iter()
+        .filter_map(|prop| {
+            let pats: Vec<String> = handlers
+                .iter()
+                .filter(|h| prop.preserved_by.iter().any(|n| n == &h.name))
+                .map(|h| {
+                    let pascal = crate::codegen_shared::to_pascal_case(&h.name);
+                    if model_params(h).next().is_some() {
+                        format!("Op::{}(..)", pascal)
+                    } else {
+                        format!("Op::{}", pascal)
+                    }
+                })
+                .collect();
+            (!pats.is_empty()).then_some((prop, pats))
+        })
+        .collect();
+
+    // Snapshot the pre-state (State is `Copy`) before the transition so the
+    // check below can read the property at `pre`.
+    if !seq_props.is_empty() {
+        out.push_str("            let pre = s;\n");
+    }
     out.push_str("            if apply_op(&mut s, op) {\n");
 
     if has_lifecycle {
@@ -2008,18 +2036,37 @@ fn emit_sequence_test_for(
         }
     }
 
-    out.push_str("                // Check all properties after each successful transition\n");
-    if !all_props.is_empty() {
-        for prop in &all_props {
-            out.push_str(&format!(
-                "                prop_assert!({}(&s),\n",
-                prop.name
-            ));
-            out.push_str(&format!(
-                "                    \"{} violated after op {{:?}} (step {{}})\", op, i);\n",
-                prop.name
-            ));
-        }
+    // Check each property only against the handlers obligated to preserve
+    // it, and only as the `preserved_by` conditional `pre → post`:
+    //   - A property `preserved_by [deposit]` is an obligation on `deposit`
+    //     alone; another handler may legitimately leave it false (e.g.
+    //     `lock` growing a locked balance past the total), so it is not
+    //     asserted after those ops. `preserved_by all` expands to the full
+    //     handler list, so its match guard covers every op.
+    //   - Even for an obligated handler, preservation only requires that a
+    //     property TRUE before the op stays true after; a handler need not
+    //     RESTORE a property a prior op already broke. Guarding on the
+    //     pre-state value avoids a false counterexample there.
+    if !seq_props.is_empty() {
+        out.push_str("                // Check each preserved_by obligation as `pre -> post`\n");
+    }
+    for (prop, pats) in &seq_props {
+        let guarded = pats.len() != handlers.len();
+        let cond = if guarded {
+            format!("matches!(op, {}) && {}(&pre)", pats.join(" | "), prop.name)
+        } else {
+            format!("{}(&pre)", prop.name)
+        };
+        out.push_str(&format!("                if {cond} {{\n"));
+        out.push_str(&format!(
+            "                    prop_assert!({}(&s),\n",
+            prop.name
+        ));
+        out.push_str(&format!(
+            "                        \"{} violated after op {{:?}} (step {{}})\", op, i);\n",
+            prop.name
+        ));
+        out.push_str("                }\n");
     }
 
     out.push_str("            }\n");
@@ -2732,21 +2779,58 @@ fn emit_product_sequence_test(
     }
     out.push_str("            };\n");
     out.push_str("            let mut initialized = false;\n");
+    // Ghost properties this sequence checks, with the Op patterns of the
+    // handlers obligated to preserve each. Same `preserved_by` + `pre ->
+    // post` discipline as the single-account sequence (see there): assert a
+    // property only after an obligated handler, and only when it held
+    // before the op. `preserved_by all` covers every handler, so its guard
+    // is just the pre-state check.
+    let seq_ghost_props: Vec<(&&ParsedProperty, Vec<String>)> = ghost_props
+        .iter()
+        .filter_map(|prop| {
+            let pats: Vec<String> = spec
+                .handlers
+                .iter()
+                .filter(|h| prop.preserved_by.iter().any(|n| n == &h.name))
+                .map(|h| {
+                    let pascal = crate::codegen_shared::to_pascal_case(&h.name);
+                    if model_params(h).next().is_some() {
+                        format!("Op::{}(..)", pascal)
+                    } else {
+                        format!("Op::{}", pascal)
+                    }
+                })
+                .collect();
+            (!pats.is_empty()).then_some((prop, pats))
+        })
+        .collect();
     out.push_str("            for (i, op) in ops.iter().enumerate() {\n");
+    // Snapshot the pre-state (ProductState is `Copy`) for the `pre -> post` check.
+    if !seq_ghost_props.is_empty() {
+        out.push_str("                let pre = s;\n");
+    }
     out.push_str("                if apply_op(&mut s, op) {\n");
     out.push_str("                    if !initialized {\n");
     out.push_str("                        initialized = true;\n");
     out.push_str("                        continue;\n");
     out.push_str("                    }\n");
-    for prop in ghost_props {
+    for (prop, pats) in &seq_ghost_props {
+        let guarded = pats.len() != spec.handlers.len();
+        let cond = if guarded {
+            format!("matches!(op, {}) && {}(&pre)", pats.join(" | "), prop.name)
+        } else {
+            format!("{}(&pre)", prop.name)
+        };
+        out.push_str(&format!("                    if {cond} {{\n"));
         out.push_str(&format!(
-            "                    prop_assert!({}(&s),\n",
+            "                        prop_assert!({}(&s),\n",
             prop.name
         ));
         out.push_str(&format!(
-            "                        \"{} violated after op {{:?}} (step {{}})\", op, i);\n",
+            "                            \"{} violated after op {{:?}} (step {{}})\", op, i);\n",
             prop.name
         ));
+        out.push_str("                    }\n");
     }
     out.push_str("                }\n");
     out.push_str("            }\n");
@@ -3805,6 +3889,62 @@ property c_ge_d : state.c >= state.d preserved_by all
         assert!(
             arb.contains("c in 0u64..=1000u64") && arb.contains("d in 0u64..=1000u64"),
             "component {{c,d}} must borrow c's 1000, not the global min 10:\n{arb}"
+        );
+    }
+
+    /// The sequence harness must respect each property's `preserved_by`
+    /// scope: a property `preserved_by [grow_a]` is only asserted after
+    /// `grow_a`, and only as the `pre -> post` obligation (it held before →
+    /// it holds after). Asserting it after `grow_b` — which is not obligated
+    /// to preserve it — or when it was already false yields false
+    /// counterexamples on a correct spec.
+    #[test]
+    fn sequence_asserts_scoped_property_only_after_its_preserving_handler() {
+        let (_spec, body) = emit_full_harness(
+            r#"
+spec Scoped
+
+type S
+  | Active of { a : U64, b : U64 }
+  | Closed
+
+type Error
+  | Bad
+
+handler init : S.Uninitialized -> S.Active {
+  effect { a := 0  b := 0 }
+}
+
+handler grow_a (x : U64) : S.Active -> S.Active {
+  requires x > 0 else Bad
+  effect { a += x }
+}
+
+handler grow_b (x : U64) : S.Active -> S.Active {
+  requires x > 0 else Bad
+  effect { b += x }
+}
+
+property a_ge_b :
+  state.a >= state.b
+  preserved_by [grow_a]
+"#,
+        );
+
+        let start = body
+            .find("fn state_machine_sequence")
+            .expect("sequence present");
+        let seq = &body[start..];
+        // Pre-state snapshot for the `pre -> post` obligation.
+        assert!(
+            seq.contains("let pre = s;"),
+            "sequence must snapshot the pre-state:\n{seq}"
+        );
+        // `grow_a` is the sole preserver, so the guard is exactly that op
+        // plus the pre-state check — `grow_b` never appears.
+        assert!(
+            seq.contains("if matches!(op, Op::GrowA(..)) && a_ge_b(&pre) {"),
+            "scoped property must be guarded by its preserver and pre-state:\n{seq}"
         );
     }
 }

--- a/crates/qedgen/tests/snapshots/lending.proptest.rs
+++ b/crates/qedgen/tests/snapshots/lending.proptest.rs
@@ -231,6 +231,7 @@ mod pool {
                 if next_lifecycle.is_none() {
                     continue; // skip ops not valid in current lifecycle state
                 }
+                let pre = s;
                 if apply_op(&mut s, op) {
                     if let Some(next) = next_lifecycle {
                         lifecycle = next;
@@ -239,9 +240,11 @@ mod pool {
                         initialized = true;
                         continue; // skip property checks on init transition
                     }
-                    // Check all properties after each successful transition
-                    prop_assert!(pool_solvency(&s),
-                        "pool_solvency violated after op {:?} (step {})", op, i);
+                    // Check each preserved_by obligation as `pre -> post`
+                    if pool_solvency(&pre) {
+                        prop_assert!(pool_solvency(&s),
+                            "pool_solvency violated after op {:?} (step {})", op, i);
+                    }
                 }
             }
         }

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -4506,6 +4506,7 @@ proptest! {
             if next_lifecycle.is_none() {
                 continue; // skip ops not valid in current lifecycle state
             }
+            let pre = s;
             if apply_op(&mut s, op) {
                 if let Some(next) = next_lifecycle {
                     lifecycle = next;
@@ -4514,11 +4515,15 @@ proptest! {
                     initialized = true;
                     continue; // skip property checks on init transition
                 }
-                // Check all properties after each successful transition
-                prop_assert!(threshold_bounded(&s),
-                    "threshold_bounded violated after op {:?} (step {})", op, i);
-                prop_assert!(votes_bounded(&s),
-                    "votes_bounded violated after op {:?} (step {})", op, i);
+                // Check each preserved_by obligation as `pre -> post`
+                if threshold_bounded(&pre) {
+                    prop_assert!(threshold_bounded(&s),
+                        "threshold_bounded violated after op {:?} (step {})", op, i);
+                }
+                if matches!(op, Op::CreateVault(..) | Op::Propose | Op::Execute(..) | Op::CancelProposal | Op::RemoveMember) && votes_bounded(&pre) {
+                    prop_assert!(votes_bounded(&s),
+                        "votes_bounded violated after op {:?} (step {})", op, i);
+                }
             }
         }
     }

--- a/crates/qedgen/tests/snapshots/multisig.proptest.rs
+++ b/crates/qedgen/tests/snapshots/multisig.proptest.rs
@@ -630,6 +630,7 @@ proptest! {
             if next_lifecycle.is_none() {
                 continue; // skip ops not valid in current lifecycle state
             }
+            let pre = s;
             if apply_op(&mut s, op) {
                 if let Some(next) = next_lifecycle {
                     lifecycle = next;
@@ -638,11 +639,15 @@ proptest! {
                     initialized = true;
                     continue; // skip property checks on init transition
                 }
-                // Check all properties after each successful transition
-                prop_assert!(threshold_bounded(&s),
-                    "threshold_bounded violated after op {:?} (step {})", op, i);
-                prop_assert!(votes_bounded(&s),
-                    "votes_bounded violated after op {:?} (step {})", op, i);
+                // Check each preserved_by obligation as `pre -> post`
+                if threshold_bounded(&pre) {
+                    prop_assert!(threshold_bounded(&s),
+                        "threshold_bounded violated after op {:?} (step {})", op, i);
+                }
+                if matches!(op, Op::CreateVault(..) | Op::Propose | Op::Execute(..) | Op::CancelProposal | Op::RemoveMember) && votes_bounded(&pre) {
+                    prop_assert!(votes_bounded(&s),
+                        "votes_bounded violated after op {:?} (step {})", op, i);
+                }
             }
         }
     }

--- a/crates/qedgen/tests/snapshots/product-state-ghosts.proptest.rs
+++ b/crates/qedgen/tests/snapshots/product-state-ghosts.proptest.rs
@@ -264,13 +264,16 @@ mod product {
             };
             let mut initialized = false;
             for (i, op) in ops.iter().enumerate() {
+                let pre = s;
                 if apply_op(&mut s, op) {
                     if !initialized {
                         initialized = true;
                         continue;
                     }
-                    prop_assert!(ghost_tracks_total(&s),
-                        "ghost_tracks_total violated after op {:?} (step {})", op, i);
+                    if matches!(op, Op::Deposit(..)) && ghost_tracks_total(&pre) {
+                        prop_assert!(ghost_tracks_total(&s),
+                            "ghost_tracks_total violated after op {:?} (step {})", op, i);
+                    }
                 }
             }
         }

--- a/examples/rust/lending/tests/proptest.rs
+++ b/examples/rust/lending/tests/proptest.rs
@@ -231,6 +231,7 @@ mod pool {
                 if next_lifecycle.is_none() {
                     continue; // skip ops not valid in current lifecycle state
                 }
+                let pre = s;
                 if apply_op(&mut s, op) {
                     if let Some(next) = next_lifecycle {
                         lifecycle = next;
@@ -239,9 +240,11 @@ mod pool {
                         initialized = true;
                         continue; // skip property checks on init transition
                     }
-                    // Check all properties after each successful transition
-                    prop_assert!(pool_solvency(&s),
-                        "pool_solvency violated after op {:?} (step {})", op, i);
+                    // Check each preserved_by obligation as `pre -> post`
+                    if pool_solvency(&pre) {
+                        prop_assert!(pool_solvency(&s),
+                            "pool_solvency violated after op {:?} (step {})", op, i);
+                    }
                 }
             }
         }

--- a/examples/rust/multisig/programs/tests/proptest.rs
+++ b/examples/rust/multisig/programs/tests/proptest.rs
@@ -630,6 +630,7 @@ proptest! {
             if next_lifecycle.is_none() {
                 continue; // skip ops not valid in current lifecycle state
             }
+            let pre = s;
             if apply_op(&mut s, op) {
                 if let Some(next) = next_lifecycle {
                     lifecycle = next;
@@ -638,11 +639,15 @@ proptest! {
                     initialized = true;
                     continue; // skip property checks on init transition
                 }
-                // Check all properties after each successful transition
-                prop_assert!(threshold_bounded(&s),
-                    "threshold_bounded violated after op {:?} (step {})", op, i);
-                prop_assert!(votes_bounded(&s),
-                    "votes_bounded violated after op {:?} (step {})", op, i);
+                // Check each preserved_by obligation as `pre -> post`
+                if threshold_bounded(&pre) {
+                    prop_assert!(threshold_bounded(&s),
+                        "threshold_bounded violated after op {:?} (step {})", op, i);
+                }
+                if matches!(op, Op::CreateVault(..) | Op::Propose | Op::Execute(..) | Op::CancelProposal | Op::RemoveMember) && votes_bounded(&pre) {
+                    prop_assert!(votes_bounded(&s),
+                        "votes_bounded violated after op {:?} (step {})", op, i);
+                }
             }
         }
     }

--- a/examples/rust/multisig/tests/proptest.rs
+++ b/examples/rust/multisig/tests/proptest.rs
@@ -630,6 +630,7 @@ proptest! {
             if next_lifecycle.is_none() {
                 continue; // skip ops not valid in current lifecycle state
             }
+            let pre = s;
             if apply_op(&mut s, op) {
                 if let Some(next) = next_lifecycle {
                     lifecycle = next;
@@ -638,11 +639,15 @@ proptest! {
                     initialized = true;
                     continue; // skip property checks on init transition
                 }
-                // Check all properties after each successful transition
-                prop_assert!(threshold_bounded(&s),
-                    "threshold_bounded violated after op {:?} (step {})", op, i);
-                prop_assert!(votes_bounded(&s),
-                    "votes_bounded violated after op {:?} (step {})", op, i);
+                // Check each preserved_by obligation as `pre -> post`
+                if threshold_bounded(&pre) {
+                    prop_assert!(threshold_bounded(&s),
+                        "threshold_bounded violated after op {:?} (step {})", op, i);
+                }
+                if matches!(op, Op::CreateVault(..) | Op::Propose | Op::Execute(..) | Op::CancelProposal | Op::RemoveMember) && votes_bounded(&pre) {
+                    prop_assert!(votes_bounded(&s),
+                        "votes_bounded violated after op {:?} (step {})", op, i);
+                }
             }
         }
     }


### PR DESCRIPTION
## The bug

`state_machine_sequence` asserted **every** property after **every** successful op, ignoring each property's `preserved_by` scope. A property `preserved_by [deposit]` is an obligation on `deposit` alone — another handler may legitimately leave it false — so asserting it after an unrelated op produces a **false counterexample on a correct spec**.

## Reproduction (generic ledger)

```
type Ledger | Active of { total : U64, locked : U64 } | Closed

handler deposit (amount : U64) : Ledger.Active -> Ledger.Active {
  requires amount > 0 else InvalidAmount
  effect { total += amount }
}
handler lock (amount : U64) : Ledger.Active -> Ledger.Active {
  requires amount > 0 else InvalidAmount
  effect { locked := state.locked + amount }
}
property total_ge_locked :
  state.total >= state.locked
  preserved_by [deposit]
```

`lock` grows `locked` and is **not** obligated to preserve `total_ge_locked`. The old harness asserted it after `lock` anyway:

```
Test failed: total_ge_locked violated after op Lock(1)
```

— a false failure on a correct spec.

## The fix

Two parts, applied to both `emit_sequence_test_for` and the product `emit_product_sequence_test`:

1. **Scope** — assert a property only after handlers in its `preserved_by` set. `preserved_by all` expands to the full handler list, so it still asserts after every op.
2. **Conditional** — `preserved_by` is `pre → post`: a handler must keep a property that held *before* it, but need not *restore* one a prior op already broke (`[lock(big), deposit(1)]` leaves it false before `deposit`). The loop snapshots the pre-state (`let pre = s;`; `State`/`ProductState` are `Copy`) and emits:

```rust
if matches!(op, Op::Deposit(..)) && total_ge_locked(&pre) {
    prop_assert!(total_ge_locked(&s), "...");
}
```

For `preserved_by all` the match guard is omitted (every op qualifies), leaving just the pre-state check.

## Still finds real bugs

The change is scope-aware, not a blanket weakening. A `preserved_by all` invariant a handler genuinely breaks still yields its minimal counterexample — verified with a generic `backing >= claim` spec whose `spend` handler drops `backing`:

```
backing_ge_claim violated after op Spend(1)
minimal failing input: [Fund(..), Spend(..)]
```

## Validation

- New regression test `sequence_asserts_scoped_property_only_after_its_preserving_handler`.
- Regenerated `lending` / `multisig` example proptests + the product-ghost snapshot (the change is the pre-snapshot plus the scoped guard). The regenerated multisig example proptest passes all 23 tests at 2000 cases.
- All gates green: `cargo test`, `fmt --check`, `clippy --all-targets -D warnings`, `check --regen-drift`, `check-readme-drift.sh`, `release-gate.sh`, `codegen_smoke --ignored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)