### PR TITLE
fix(check): detect Pinocchio in regen-drift so its program crate is compared

### DIFF
--- a/crates/qedgen/src/probe/mod.rs
+++ b/crates/qedgen/src/probe/mod.rs
@@ -1379,7 +1379,12 @@ fn detect_runtime(root: &Path) -> Runtime {
 /// Pinocchio dep check. Matches `pinocchio = ...`, `pinocchio.workspace =
 /// true`, or `pinocchio-token`/`-system` siblings (siblings require the
 /// root pinocchio surface).
-fn has_pinocchio_dep(cargo_toml: &str) -> bool {
+///
+/// Line-oriented rather than a bare `contains("pinocchio")` so a mention in
+/// a comment or inside a longer crate name does not count. Shared with
+/// `verify::regen_drift` (#367) — a second copy there would be a third
+/// framework detector answering the same question a different way.
+pub(crate) fn has_pinocchio_dep(cargo_toml: &str) -> bool {
     for line in cargo_toml.lines() {
         let t = line.trim();
         if t.starts_with('#') {

--- a/crates/qedgen/src/probe/probe_repro.rs
+++ b/crates/qedgen/src/probe/probe_repro.rs
@@ -228,11 +228,15 @@ fn discover_deployed_program(project_root: &Path) -> Result<DeployedProgram, Con
             .flatten()
     });
     // FAIL CLOSED: require positive Anchor detection rather than refusing
-    // only the frameworks we happen to recognise. `target_from_text` knows
-    // Anchor and Quasar, so a Pinocchio project reads as `None` — treating
-    // "unknown" as "probably fine" would emit an Anchor-shaped harness
-    // against it and report "no bug" from a transaction that never reached
+    // only the frameworks we happen to recognise. Treating "unknown" as
+    // "probably fine" would emit an Anchor-shaped harness against another
+    // framework and report "no bug" from a transaction that never reached
     // the handler.
+    //
+    // The detector now covers all three targets (#367), so a Pinocchio
+    // project reports `Some(Pinocchio)` here instead of the `None` it used
+    // to — same refusal, but the reason names the framework rather than
+    // saying nothing was recognised.
     if detected != Some(crate::Target::Anchor) {
         return Err(ConstructFailure::BuildError(format!(
             "Parallax reproducers are Anchor-only today (detected: {detected:?}). The \

--- a/crates/qedgen/src/verify/regen_drift.rs
+++ b/crates/qedgen/src/verify/regen_drift.rs
@@ -352,14 +352,44 @@ pub(crate) fn detect_program_target(out_root: &Path) -> Result<Option<Target>> {
     Ok(lib_target.or(cargo_target))
 }
 
+/// Which greenfield target generated this `Cargo.toml` or `src/lib.rs`?
+///
+/// One arm per [`Target`] variant. `Target` is a closed three-variant enum,
+/// but this had only two arms and an `else None` (#367), so a Pinocchio
+/// crate read as "no target" — and `program_outputs` treats `None` as "skip
+/// this crate". The effect was not a silent pass: nothing regenerated into
+/// the temp tree, so every committed Pinocchio file reported as `missing
+/// generated counterpart` whether or not it had drifted. The gate could not
+/// tell a clean Pinocchio project from a drifted one, because it never
+/// compared either.
+///
+/// The `_ => None` fallback is deliberately absent. A fourth `Target`
+/// variant must fail to compile here rather than quietly become
+/// "undetectable", which is the shape that produced this bug.
 fn target_from_text(body: &str) -> Option<Target> {
-    if body.contains("anchor-lang") || body.contains("anchor_lang::prelude") {
-        Some(Target::Anchor)
-    } else if body.contains("quasar-lang") || body.contains("quasar_lang::prelude") {
-        Some(Target::Quasar)
-    } else {
-        None
+    // Order matters only in that each predicate must be specific to its
+    // framework; the three dependency sets are disjoint in practice.
+    for target in [Target::Anchor, Target::Quasar, Target::Pinocchio] {
+        let hit = match target {
+            Target::Anchor => body.contains("anchor-lang") || body.contains("anchor_lang::prelude"),
+            Target::Quasar => body.contains("quasar-lang") || body.contains("quasar_lang::prelude"),
+            // `has_pinocchio_dep` is line-oriented, so it matches the
+            // manifest (`pinocchio = "0.8"`, `pinocchio.workspace`,
+            // `pinocchio-token`) without firing on a passing mention. The
+            // `::` forms cover `src/lib.rs`, which imports
+            // `pinocchio::{account_info::AccountInfo, …}` and may declare its
+            // id via `pinocchio_pubkey::declare_id!`.
+            Target::Pinocchio => {
+                crate::probe::has_pinocchio_dep(body)
+                    || body.contains("pinocchio::")
+                    || body.contains("pinocchio_pubkey::")
+            }
+        };
+        if hit {
+            return Some(target);
+        }
     }
+    None
 }
 
 fn generate_existing_artifacts(root: &Path, temp_root: &Path, spec_path: &Path) -> Result<()> {
@@ -612,6 +642,85 @@ fn path_relative_to(path: &Path, base: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #367 — `Target` is a closed three-variant enum, but this detector
+    /// had two arms and an `else None`, so a Pinocchio crate read as "no
+    /// target" and `program_outputs` skipped it. Nothing regenerated, so
+    /// every committed file reported `missing generated counterpart`
+    /// whether or not it had drifted: the gate could not tell a clean
+    /// Pinocchio project from a drifted one.
+    #[test]
+    fn detects_every_target_from_manifest_and_lib() {
+        // Manifests, as `codegen` emits them.
+        assert_eq!(
+            target_from_text("[dependencies]\nanchor-lang = \"0.32.1\"\n"),
+            Some(Target::Anchor)
+        );
+        assert_eq!(
+            target_from_text("[dependencies]\nquasar-lang = { version = \"0.0.0\" }\n"),
+            Some(Target::Quasar)
+        );
+        assert_eq!(
+            target_from_text("[dependencies]\npinocchio = \"0.8\"\npinocchio-pubkey = \"0.3\"\n"),
+            Some(Target::Pinocchio)
+        );
+
+        // `src/lib.rs`, as `codegen` emits them.
+        assert_eq!(
+            target_from_text("use anchor_lang::prelude::*;\n"),
+            Some(Target::Anchor)
+        );
+        assert_eq!(
+            target_from_text("use quasar_lang::prelude::*;\n"),
+            Some(Target::Quasar)
+        );
+        assert_eq!(
+            target_from_text(
+                "use pinocchio::{account_info::AccountInfo, program_error::ProgramError};\n"
+            ),
+            Some(Target::Pinocchio)
+        );
+
+        // A crate belonging to none of them still reads as unknown, which is
+        // what lets `program_outputs` skip non-generated crates.
+        assert_eq!(target_from_text("[dependencies]\nserde = \"1\"\n"), None);
+    }
+
+    /// The Pinocchio arm must not fire on a passing mention — that is why it
+    /// routes through the line-oriented `has_pinocchio_dep` rather than a
+    /// bare `contains`. A false positive here is worse than the miss it
+    /// replaced: it would regenerate an Anchor crate as Pinocchio and report
+    /// every file as drifted.
+    ///
+    /// Note `has_pinocchio_dep` counts `pinocchio-*` siblings
+    /// (`pinocchio-token`, `pinocchio-system`) on purpose — they require the
+    /// root pinocchio surface — so the guard is against MENTIONS, not
+    /// against the sibling family.
+    #[test]
+    fn pinocchio_arm_does_not_fire_on_a_mention() {
+        // Manifest comment.
+        assert_eq!(
+            target_from_text(
+                "# Ported from a pinocchio prototype.\n\
+                 [dependencies]\nanchor-lang = \"0.32.1\"\n"
+            ),
+            Some(Target::Anchor)
+        );
+        // A dependency whose name merely ends in the word.
+        assert_eq!(
+            target_from_text("[dependencies]\nnot-pinocchio = \"1\"\n"),
+            None
+        );
+        // An Anchor lib.rs that names pinocchio in prose still reads Anchor:
+        // the arms are tried in order and Anchor matches first.
+        assert_eq!(
+            target_from_text(
+                "// Unlike pinocchio:: programs, this uses Anchor.\n\
+                 use anchor_lang::prelude::*;\n"
+            ),
+            Some(Target::Anchor)
+        );
+    }
 
     #[test]
     fn reports_missing_manifest_for_tracked_example() {

--- a/docs/framework-support.md
+++ b/docs/framework-support.md
@@ -28,6 +28,7 @@ sBPF assembly is selected by `pragma sbpf` in the spec, not by a `Target`.
 | Brownfield adapt → spec skeleton (`adapt/`) — *deprecated* | ✅ args + accounts + errors | ❌ no adapter | ⚠️ handlers-only skeleton | ⚠️ loose (no conventions) | ❌ |
 | Greenfield Rust scaffold (`codegen_mir`) | ✅ | ⚠️ generic CPI → `todo!()` | ⚠️ generic CPI → `todo!()`; imported mirrors error | n/a | n/a |
 | Scaffold compiles (`verify --scaffold`, #364) | ✅ gated (`generated_artifact_gate`) | ✅ gated (`generated_artifact_gate`, #372) | ⚠️ compiles, ungated ⁷ | n/a | n/a |
+| Regen-drift over the program crate (`check --regen-drift`) | ✅ | ✅ | ✅ (#367) | n/a | n/a |
 | Kani spec-model (`kani_mir`) | ✅ ¹ ⁴ | ✅ ¹ ⁴ | ✅ ¹ ⁴ | n/a | skip by design |
 | impl-Kani (`kani_impl`) | ✅ greenfield + state-struct (#162) + Context (#169) | ⚠️ greenfield shape only | ⚠️ own `#[repr(C)]` shape; some ix-data field types TODO | ❌ | ❌ |
 | proptest (`proptest_gen_mir`) | ✅ ⁵ | ✅ ⁵ | ✅ ⁵ | n/a | skip by design |


### PR DESCRIPTION
Closes #367.

`Target` is a closed three-variant enum, but `target_from_text` had two arms
and an `else None`, so a Pinocchio crate read as "no target" — and
`program_outputs` treats `None` as "skip this crate".

## The symptom is louder than the issue says

The issue describes a silent skip: *"Drift ... is invisible, and the gate
reports success."* Measured, it is worse than that. With **zero** drift, a
Pinocchio project reports five findings:

```
$ qedgen check --spec pino/ping.qedspec --regen-drift --examples-root exroot
Example codegen drift detected:
  pino: programs/Cargo.toml (missing generated counterpart)
  pino: programs/src/errors.rs (missing generated counterpart)
  pino: programs/src/guards.rs (missing generated counterpart)
  pino: programs/src/instructions/mod.rs (missing generated counterpart)
  pino: programs/src/state.rs (missing generated counterpart)
```

Nothing regenerated into the temp tree, so every committed file has no
counterpart to compare against. Planting real drift in `guards.rs` produces
the same output. So drift is genuinely invisible — not because the gate
passes, but because a clean project and a drifted one are indistinguishable,
both buried under the same false findings.

The issue's repro also assumes a Pinocchio example exists under an examples
root; none does, which is why this never showed up in CI.

## After

```
$ qedgen check ... --regen-drift --examples-root exroot
Example codegen drift check clean — 1 example(s) checked.

$ echo "// DELIBERATE DRIFT" >> pino/programs/src/state.rs
$ qedgen check ... --regen-drift --examples-root exroot
Example codegen drift detected:
  pino: programs/src/state.rs (changed)
```

## Fix

One arm per `Target` variant, iterating the variants so the match is
exhaustive and **the `_ => None` fallback is gone**. A fourth variant now
fails to compile here rather than quietly becoming "undetectable", which is
the shape that produced this bug (the same closed-enum discipline CLAUDE.md
describes for `Stmt` and `SeverityCounts`).

The Pinocchio predicate reuses `probe::has_pinocchio_dep` rather than adding
a third copy. That function is line-oriented, so it matches
`pinocchio = "0.8"` / `pinocchio.workspace` / `pinocchio-token` in a manifest
without firing on a passing mention; `pinocchio::` and `pinocchio_pubkey::`
cover `src/lib.rs`.

## What I did not do

The issue proposes collapsing the three framework detectors into one shared
`detect_framework`. I did not, because they answer different questions and
`docs/framework-support.md` opens by saying so: "Five *distinct* framework
notions exist — they are not one enum." `regen_drift` wants the greenfield
`Target`; `adapt::detect_adapter` wants `ProgramFramework` (anchor /
pinocchio / **native**, no quasar). Merging them would force one enum onto
two different domains. Sharing the Pinocchio predicate gets the
de-duplication that was actually available.

## Second effect, now accurate

`probe_repro` fails closed on `detected != Some(Target::Anchor)` and its
comment explained it had to treat "unknown" as "not Anchor" because Pinocchio
read as `None`. It now reports `Some(Pinocchio)` — same refusal, but the
reason names the framework instead of saying nothing was recognised. Comment
updated to match.

## Tests

- `detects_every_target_from_manifest_and_lib` — all three targets from both
  a manifest and a `src/lib.rs`, in the exact shapes codegen emits, plus an
  unrelated crate still reading `None` (which is what lets `program_outputs`
  skip non-generated crates).
- `pinocchio_arm_does_not_fire_on_a_mention` — a manifest comment, a
  `not-pinocchio` dependency, and an Anchor `lib.rs` whose prose mentions
  `pinocchio::`. A false positive here would be worse than the miss it
  replaces: it would regenerate an Anchor crate as Pinocchio and report every
  file as drifted.

Worth noting: my first draft of that second test asserted
`pinocchio-like-thing` should not match. It does, and correctly —
`has_pinocchio_dep` counts `pinocchio-*` siblings on purpose since they
require the root pinocchio surface. I fixed the test rather than the shared
function.

Full suite green (40 suites, 1655 tests). clippy and rustfmt clean.

## Notes

Stacked on #381 → #380 → #379 → #378 → #377 → #373. Merge in that order.
