### PR TITLE
fix(proptest): sequence restores the pre-state when an op is rejected

### DIFF
--- a/crates/qedgen/src/codegen/proptest_gen_mir.rs
+++ b/crates/qedgen/src/codegen/proptest_gen_mir.rs
@@ -2282,11 +2282,10 @@ fn emit_sequence_test_for(
         })
         .collect();
 
-    // Snapshot the pre-state (State is `Copy`) before the transition so the
-    // check below can read the property at `pre`.
-    if !seq_props.is_empty() {
-        out.push_str("            let pre = s;\n");
-    }
+    // Snapshot the pre-state (State is `Copy`) before the transition: the
+    // property checks below read it, and a rejected op restores from it.
+    // Unconditional — the rollback needs it even with no checked property.
+    out.push_str("            let pre = s;\n");
     out.push_str("            if apply_op(&mut s, op) {\n");
 
     if has_lifecycle {
@@ -2337,6 +2336,13 @@ fn emit_sequence_test_for(
         out.push_str("                }\n");
     }
 
+    // A rejected transition must not mutate the state. The generated
+    // transition fns assign field-by-field and `return false` from the
+    // middle when a later effect fails its checked arithmetic, so the
+    // earlier fields stay written. Restoring the snapshot keeps the
+    // sequence exploring only states a real transition can produce.
+    out.push_str("            } else {\n");
+    out.push_str("                s = pre; // rejected op must not half-apply\n");
     out.push_str("            }\n");
     out.push_str("        }\n");
     out.push_str("    }\n");
@@ -3073,10 +3079,10 @@ fn emit_product_sequence_test(
         })
         .collect();
     out.push_str("            for (i, op) in ops.iter().enumerate() {\n");
-    // Snapshot the pre-state (ProductState is `Copy`) for the `pre -> post` check.
-    if !seq_ghost_props.is_empty() {
-        out.push_str("                let pre = s;\n");
-    }
+    // Snapshot the pre-state (ProductState is `Copy`): the `pre -> post`
+    // checks read it, and a rejected op restores from it. Unconditional —
+    // the rollback needs it even with no checked ghost property.
+    out.push_str("                let pre = s;\n");
     out.push_str("                if apply_op(&mut s, op) {\n");
     out.push_str("                    if !initialized {\n");
     out.push_str("                        initialized = true;\n");
@@ -3100,6 +3106,11 @@ fn emit_product_sequence_test(
         ));
         out.push_str("                    }\n");
     }
+    // Rejected transitions must not half-apply — see the single-account
+    // sequence emitter for why the generated transition fns can leave
+    // partial state behind on a `false` return.
+    out.push_str("                } else {\n");
+    out.push_str("                    s = pre; // rejected op must not half-apply\n");
     out.push_str("                }\n");
     out.push_str("            }\n");
     out.push_str("        }\n");
@@ -4290,6 +4301,64 @@ property a_ge_b :
         assert!(
             seq.contains("if matches!(op, Op::GrowA(..)) && a_ge_b(&pre) {"),
             "scoped property must be guarded by its preserver and pre-state:\n{seq}"
+        );
+    }
+
+    /// A transition assigns field-by-field and can `return false` from the
+    /// middle when a later effect fails its checked arithmetic, leaving the
+    /// earlier fields written. The sequence harness must restore the
+    /// pre-state on a rejected op, or it explores states no real transition
+    /// produces. Regression for #385.
+    #[test]
+    fn sequence_restores_pre_state_when_an_op_is_rejected() {
+        let (_spec, body) = emit_full_harness(
+            r#"
+spec Atomic
+
+state { a : U64, b : U64 }
+
+type Error | Bad
+
+handler bump (x : U64) {
+  requires x > 0 else Bad
+  effect {
+    a += x
+    b += x
+  }
+}
+
+handler noop {
+  effect { a := state.a }
+}
+
+property a_eq_b :
+  state.a == state.b
+  preserved_by all
+"#,
+        );
+
+        // The half-apply shape this guards against: `a` commits before `b`
+        // can reject.
+        let bump_start = body.find("fn bump(").expect("bump present");
+        let bump = &body[bump_start..bump_start + body[bump_start..].find("\n}").unwrap_or(400)];
+        assert!(
+            bump.contains("s.a = __v") && bump.contains("None => return false"),
+            "transition should assign then be able to reject mid-body:\n{bump}"
+        );
+
+        let start = body
+            .find("fn state_machine_sequence")
+            .expect("sequence present");
+        let seq = &body[start..];
+        // Snapshot is unconditional — the rollback needs it regardless of
+        // whether any property is checked in this section.
+        assert!(
+            seq.contains("let pre = s;"),
+            "sequence must snapshot the pre-state:\n{seq}"
+        );
+        assert!(
+            seq.contains("} else {") && seq.contains("s = pre;"),
+            "a rejected op must restore the pre-state:\n{seq}"
         );
     }
 }

--- a/crates/qedgen/tests/snapshots/lending.proptest.rs
+++ b/crates/qedgen/tests/snapshots/lending.proptest.rs
@@ -246,6 +246,8 @@ mod pool {
                         prop_assert!(pool_solvency(&s),
                             "pool_solvency violated after op {:?} (step {})", op, i);
                     }
+                } else {
+                    s = pre; // rejected op must not half-apply
                 }
             }
         }

--- a/crates/qedgen/tests/snapshots/multisig.codegen.txt
+++ b/crates/qedgen/tests/snapshots/multisig.codegen.txt
@@ -4525,6 +4525,8 @@ proptest! {
                     prop_assert!(votes_bounded(&s),
                         "votes_bounded violated after op {:?} (step {})", op, i);
                 }
+            } else {
+                s = pre; // rejected op must not half-apply
             }
         }
     }

--- a/crates/qedgen/tests/snapshots/multisig.proptest.rs
+++ b/crates/qedgen/tests/snapshots/multisig.proptest.rs
@@ -649,6 +649,8 @@ proptest! {
                     prop_assert!(votes_bounded(&s),
                         "votes_bounded violated after op {:?} (step {})", op, i);
                 }
+            } else {
+                s = pre; // rejected op must not half-apply
             }
         }
     }

--- a/crates/qedgen/tests/snapshots/product-state-ghosts.proptest.rs
+++ b/crates/qedgen/tests/snapshots/product-state-ghosts.proptest.rs
@@ -274,6 +274,8 @@ mod product {
                         prop_assert!(ghost_tracks_total(&s),
                             "ghost_tracks_total violated after op {:?} (step {})", op, i);
                     }
+                } else {
+                    s = pre; // rejected op must not half-apply
                 }
             }
         }

--- a/examples/rust/lending/tests/proptest.rs
+++ b/examples/rust/lending/tests/proptest.rs
@@ -246,6 +246,8 @@ mod pool {
                         prop_assert!(pool_solvency(&s),
                             "pool_solvency violated after op {:?} (step {})", op, i);
                     }
+                } else {
+                    s = pre; // rejected op must not half-apply
                 }
             }
         }

--- a/examples/rust/multisig/programs/tests/proptest.rs
+++ b/examples/rust/multisig/programs/tests/proptest.rs
@@ -649,6 +649,8 @@ proptest! {
                     prop_assert!(votes_bounded(&s),
                         "votes_bounded violated after op {:?} (step {})", op, i);
                 }
+            } else {
+                s = pre; // rejected op must not half-apply
             }
         }
     }

--- a/examples/rust/multisig/tests/proptest.rs
+++ b/examples/rust/multisig/tests/proptest.rs
@@ -649,6 +649,8 @@ proptest! {
                     prop_assert!(votes_bounded(&s),
                         "votes_bounded violated after op {:?} (step {})", op, i);
                 }
+            } else {
+                s = pre; // rejected op must not half-apply
             }
         }
     }


### PR DESCRIPTION
Closes #385.

## The bug

Generated transition fns assign field-by-field and `return false` from the middle when a later effect fails its checked arithmetic — the fields already written stay written:

```rust
fn bump(s: &mut State, x: u64) -> bool {
    if !(x > 0) { return false; }
    match s.a.checked_add(x) { Some(__v) => s.a = __v, None => return false }
    match s.b.checked_add(x) { Some(__v) => s.b = __v, None => return false }
    //                                      ^^^^^^^^^^^^ `s.a` is already mutated here
    true
}
```

`state_machine_sequence` is the one harness that reuses `s` across ops, and it discarded `pre` on a rejected op:

```rust
let pre = s;
if apply_op(&mut s, op) {   // false -> falls through, `s` stays half-applied
    ...
}
```

So every later op ran against a state no real transition can produce. That can fabricate a counterexample *and* mask a genuine one — the corrupted pre-state silently fails the `pre -> post` guard, so the property quietly stops being checked for the rest of the run.

## The fix

Snapshot the pre-state unconditionally and restore it when `apply_op` returns false, in both `emit_sequence_test_for` and `emit_product_sequence_test`:

```rust
let pre = s;
if apply_op(&mut s, op) {
    …
} else {
    s = pre; // rejected op must not half-apply
}
```

The snapshot already existed for the `preserved_by` guard (#375); it's now emitted regardless of whether the section checks any property, since the rollback needs it either way.

## Scope: why not full atomicity

This deliberately does **not** make the transition fns themselves atomic. The partial write is only observable where state is reused across calls, and the sequence is the only such harness:

| harness | on a `false` return | exposure |
|---|---|---|
| preservation | asserts nothing | inert |
| overflow | asserts nothing | inert |
| guard rejection | asserts the return value only | inert |
| **sequence** | **reuses `s` for the next op** | **fixed here** |

Full atomicity (compute every new value into locals, commit at the end) would touch the emitter shared with the Kani lane for no additional coverage. It stays documented in #385 as the heavier alternative should a future consumer reuse state after a rejection.

## Validation

- Regression test `sequence_restores_pre_state_when_an_op_is_rejected` pins both the half-apply shape it guards against and the emitted rollback.
- Lending / multisig / product-ghost snapshots and the bundled example harnesses pick up the `else { s = pre; }` branch — the only diff.
- The regenerated multisig example proptest still passes all 23 tests at 2000 cases.
- All gates green: `cargo test`, `fmt --check`, `clippy --all-targets -D warnings` (on 1.97, matching CI), `check --regen-drift`, `check-readme-drift.sh`, `release-gate.sh`, `codegen_smoke --ignored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)