### PR TITLE
fix(probe): size reproducer fixture bytes from the declared type, not a 32-byte guess

### DIFF
--- a/crates/qedgen/src/codegen/codegen_shared/tests.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/tests.rs
@@ -3285,5 +3285,78 @@ fn flat_state_fields_carry_the_synthesized_tail() {
     // Both synthesized fields are single bytes in the struct.
     for (name, ty) in fields.iter().filter(|(n, _)| n != "total") {
         assert_eq!(ty, "U8", "{name} must map to a single byte");
+
+// ── Fixed byte widths (#389) ─────────────────────────────────────────
+
+/// The widths a fixture emitter has to get right. The old repro-lane
+/// emitter knew `U8`..`U128` and gave everything else 32 bytes, which is
+/// correct for `Pubkey` and wrong for every row below it.
+#[test]
+fn fixed_byte_width_covers_the_scalar_universe() {
+    let spec = empty_spec();
+    let width = |ty: &str| fixed_byte_width(ty, &spec).unwrap();
+
+    for (ty, bytes) in [
+        ("U8", 1),
+        ("U16", 2),
+        ("U32", 4),
+        ("U64", 8),
+        ("U128", 16),
+        ("Bool", 1),
+        ("Pubkey", 32),
+        ("Bytes32", 32),
+    ] {
+        assert_eq!(width(ty), bytes, "{ty}");
+    }
+
+    // Signed integers were the silent half: `rust_int_type` returns `None`
+    // for all of them, so every one used to be sized at 32 bytes.
+    for (ty, bytes) in [("I8", 1), ("I16", 2), ("I32", 4), ("I64", 8), ("I128", 16)] {
+        assert_eq!(width(ty), bytes, "{ty}");
+    }
+
+    assert_eq!(width("Bytes64"), 64);
+}
+
+/// `Map[N] T` is N elements, not one pointer-sized anything.
+#[test]
+fn fixed_byte_width_multiplies_map_bounds() {
+    let spec = empty_spec();
+    assert_eq!(fixed_byte_width("Map[32] Pubkey", &spec).unwrap(), 1024);
+    assert_eq!(fixed_byte_width("Map[3] U8", &spec).unwrap(), 3);
+    // Nested, because a bound is a count of whatever follows it.
+    assert_eq!(fixed_byte_width("Map[2] Map[4] U64", &spec).unwrap(), 64);
+}
+
+/// A record is the sum of its fields; an alias resolves to its RHS.
+#[test]
+fn fixed_byte_width_walks_records_and_aliases() {
+    let mut spec = empty_spec();
+    spec.records.push(crate::check::ParsedRecordType {
+        name: "Entry".to_string(),
+        fields: vec![
+            ("who".to_string(), "Pubkey".to_string()),
+            ("amount".to_string(), "U64".to_string()),
+        ],
+    });
+    spec.type_aliases
+        .push(("Amount".to_string(), "U64".to_string()));
+
+    assert_eq!(fixed_byte_width("Entry", &spec).unwrap(), 40);
+    assert_eq!(fixed_byte_width("Amount", &spec).unwrap(), 8);
+    assert_eq!(fixed_byte_width("Map[2] Entry", &spec).unwrap(), 80);
+}
+
+/// Variable-length types have no fixed width, and `Fin[N]` has one only
+/// once a target is chosen. Both must refuse rather than return a number
+/// that reads as authoritative.
+#[test]
+fn fixed_byte_width_refuses_what_it_cannot_size() {
+    let spec = empty_spec();
+    for ty in ["Vec U64", "Option Pubkey", "Fin[8]"] {
+        assert!(
+            fixed_byte_width(ty, &spec).is_err(),
+            "{ty} must not produce a width"
+        );
     }
 }

--- a/crates/qedgen/src/codegen/codegen_shared/tests.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/tests.rs
@@ -3285,6 +3285,8 @@ fn flat_state_fields_carry_the_synthesized_tail() {
     // Both synthesized fields are single bytes in the struct.
     for (name, ty) in fields.iter().filter(|(n, _)| n != "total") {
         assert_eq!(ty, "U8", "{name} must map to a single byte");
+    }
+}
 
 // ── Fixed byte widths (#389) ─────────────────────────────────────────
 
@@ -3359,4 +3361,44 @@ fn fixed_byte_width_refuses_what_it_cannot_size() {
             "{ty} must not produce a width"
         );
     }
+}
+
+/// A self-referential alias must return an error, not exhaust the stack.
+///
+/// `check` does not catch this first: the known-types lint resolves aliases
+/// with its own cycle guard, stops when it sees a repeat, and validates the
+/// name it stopped on — which for a cycle is a declared alias, so the spec
+/// lints clean and arrives here.
+#[test]
+fn self_referential_types_error_instead_of_recursing() {
+    let mut spec = empty_spec();
+    spec.type_aliases.push(("A".to_string(), "B".to_string()));
+    spec.type_aliases.push(("B".to_string(), "A".to_string()));
+    spec.records.push(crate::check::ParsedRecordType {
+        name: "Node".to_string(),
+        fields: vec![("next".to_string(), "Node".to_string())],
+    });
+
+    for ty in ["A", "B", "Node"] {
+        let err = fixed_byte_width(ty, &spec)
+            .expect_err(&format!("{ty} expands into itself and has no width"));
+        assert!(
+            err.to_string().contains("expands into itself"),
+            "unexpected error for {ty}: {err}"
+        );
+    }
+
+    // The value emitter walks aliases too, and needs its own guard: it
+    // accepts `Fin[N]`, which the width function deliberately refuses, so
+    // it cannot simply delegate.
+    let err = emit_pod_bytes_append("A", "v", &spec, "", 0)
+        .expect_err("a cyclic alias has no fixed layout");
+    assert!(
+        err.to_string().contains("expands into itself"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        emit_pod_bytes_append("Fin[8]", "v", &spec, "", 0).is_ok(),
+        "the value emitter still supports Fin[N]"
+    );
 }

--- a/crates/qedgen/src/codegen/codegen_shared/types.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/types.rs
@@ -793,6 +793,23 @@ pub fn emit_pod_bytes_append(
 /// generation, because the alternative is a plausible fixed guess that turns
 /// into a wrong answer much later and much further away.
 pub fn fixed_byte_width(dsl_ty: &str, spec: &ParsedSpec) -> Result<usize> {
+    fixed_byte_width_guarded(dsl_ty, spec, &mut std::collections::BTreeSet::new())
+}
+
+/// `expanding` carries the alias and record names already on the stack, so a
+/// self-referential declaration returns an error instead of recursing until
+/// the stack runs out.
+///
+/// The guard is not theoretical and `check` is not the backstop. The
+/// known-types lint resolves aliases with its own cycle guard
+/// (`lints/known_types.rs`), and having stopped early it validates the name
+/// it stopped on, which for a cycle is a declared alias and therefore valid.
+/// So `type A = B` with `type B = A` passes `check` cleanly and arrives here.
+fn fixed_byte_width_guarded(
+    dsl_ty: &str,
+    spec: &ParsedSpec,
+    expanding: &mut std::collections::BTreeSet<String>,
+) -> Result<usize> {
     let dsl_ty = dsl_ty.trim();
 
     // `Map[N] T` → `[T; N]`, no length prefix in either layout.
@@ -803,7 +820,7 @@ pub fn fixed_byte_width(dsl_ty: &str, spec: &ParsedSpec) -> Result<usize> {
         let n: usize = resolve_map_bound(bound_src, spec)?
             .parse()
             .map_err(|_| anyhow::anyhow!("Map bound `{bound_src}` is not a usize"))?;
-        return Ok(n * fixed_byte_width(inner, spec)?);
+        return Ok(n * fixed_byte_width_guarded(inner, spec, expanding)?);
     }
 
     let width = match dsl_ty {
@@ -820,15 +837,24 @@ pub fn fixed_byte_width(dsl_ty: &str, spec: &ParsedSpec) -> Result<usize> {
         return Ok(width);
     }
 
+    let named = spec.type_aliases.iter().any(|(n, _)| n == dsl_ty)
+        || spec.records.iter().any(|r| r.name == dsl_ty);
+    if named && !expanding.insert(dsl_ty.to_string()) {
+        anyhow::bail!(
+            "type `{}` expands into itself, so it has no fixed byte width",
+            dsl_ty
+        );
+    }
+
     if let Some((_, rhs)) = spec.type_aliases.iter().find(|(n, _)| n == dsl_ty) {
-        return fixed_byte_width(rhs, spec);
+        return fixed_byte_width_guarded(rhs, spec, expanding);
     }
 
     // A record is the sum of its fields, in declaration order.
     if let Some(record) = spec.records.iter().find(|r| r.name == dsl_ty) {
         let mut total = 0;
         for (_, field_ty) in &record.fields {
-            total += fixed_byte_width(field_ty, spec)?;
+            total += fixed_byte_width_guarded(field_ty, spec, expanding)?;
         }
         return Ok(total);
     }

--- a/crates/qedgen/src/codegen/codegen_shared/types.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/types.rs
@@ -717,6 +717,29 @@ pub fn emit_pod_bytes_append(
     indent: &str,
     depth: usize,
 ) -> Result<String> {
+    emit_pod_bytes_guarded(
+        dsl_ty,
+        expr,
+        spec,
+        indent,
+        depth,
+        &mut std::collections::BTreeSet::new(),
+    )
+}
+
+/// `expanding` carries the alias names already on the stack. `type A = B`
+/// with `type B = A` passes `check` — the known-types lint stops at the
+/// cycle and validates the alias name it stopped on, which is declared — so
+/// an unguarded walk here recurses until the stack runs out rather than
+/// reporting anything. Same guard, same reason, as `fixed_byte_width`.
+fn emit_pod_bytes_guarded(
+    dsl_ty: &str,
+    expr: &str,
+    spec: &ParsedSpec,
+    indent: &str,
+    depth: usize,
+    expanding: &mut std::collections::BTreeSet<String>,
+) -> Result<String> {
     let dsl_ty = dsl_ty.trim();
 
     // `Map[N] T` → `[T; N]`: N elements back to back, no length prefix.
@@ -728,7 +751,8 @@ pub fn emit_pod_bytes_append(
         };
         let binder = format!("__e{depth}");
         let inner_indent = format!("{indent}    ");
-        let body = emit_pod_bytes_append(inner, &binder, spec, &inner_indent, depth + 1)?;
+        let body =
+            emit_pod_bytes_guarded(inner, &binder, spec, &inner_indent, depth + 1, expanding)?;
         return Ok(format!(
             "{indent}for {binder} in {expr}.iter().copied() {{\n{body}{indent}}}\n"
         ));
@@ -766,7 +790,13 @@ pub fn emit_pod_bytes_append(
 
     // Type alias: recurse on the RHS, matching `map_type_pod`.
     if let Some((_, rhs)) = spec.type_aliases.iter().find(|(n, _)| n == dsl_ty) {
-        return emit_pod_bytes_append(rhs, expr, spec, indent, depth);
+        if !expanding.insert(dsl_ty.to_string()) {
+            anyhow::bail!(
+                "type `{}` expands into itself, so it has no fixed layout",
+                dsl_ty
+            );
+        }
+        return emit_pod_bytes_guarded(rhs, expr, spec, indent, depth, expanding);
     }
 
     // Records, sums, `Vec`, and `Option` have no fixed alignment-1 layout
@@ -776,6 +806,9 @@ pub fn emit_pod_bytes_append(
         "cannot build account-fixture bytes for DSL type `{}` — supported: \
          U8/U16/U32/U64/U128, I8/I16/I32/I64/I128, Bool, Pubkey, Bytes32, \
          Bytes64, Fin[N], Map[N] T, and aliases of those",
+        dsl_ty
+    )
+}
 
 /// How many bytes a value of `dsl_ty` occupies in a fixed on-chain layout.
 ///

--- a/crates/qedgen/src/codegen/codegen_shared/types.rs
+++ b/crates/qedgen/src/codegen/codegen_shared/types.rs
@@ -776,6 +776,71 @@ pub fn emit_pod_bytes_append(
         "cannot build account-fixture bytes for DSL type `{}` — supported: \
          U8/U16/U32/U64/U128, I8/I16/I32/I64/I128, Bool, Pubkey, Bytes32, \
          Bytes64, Fin[N], Map[N] T, and aliases of those",
+
+/// How many bytes a value of `dsl_ty` occupies in a fixed on-chain layout.
+///
+/// Fixture emitters need the WIDTH even when they do not care about the
+/// value: an account built at the wrong length fails deserialization before
+/// the code under test runs, and the resulting failure reads as "the program
+/// rejected my input" (#389).
+///
+/// Both layouts this repo emits agree here. Anchor/Borsh and Quasar/Pod both
+/// store fixed scalars little-endian with no padding, `bool` in one byte, an
+/// address in 32, and `[T; N]` as N elements back to back. They diverge only
+/// on the variable-length types, which this function refuses for both.
+///
+/// Refusing is the point. A type whose width cannot be derived must stop
+/// generation, because the alternative is a plausible fixed guess that turns
+/// into a wrong answer much later and much further away.
+pub fn fixed_byte_width(dsl_ty: &str, spec: &ParsedSpec) -> Result<usize> {
+    let dsl_ty = dsl_ty.trim();
+
+    // `Map[N] T` → `[T; N]`, no length prefix in either layout.
+    if dsl_ty.starts_with("Map") {
+        let Some((bound_src, inner)) = split_map_type(dsl_ty) else {
+            anyhow::bail!("malformed Map type `{}` — expected `Map[BOUND] T`", dsl_ty);
+        };
+        let n: usize = resolve_map_bound(bound_src, spec)?
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Map bound `{bound_src}` is not a usize"))?;
+        return Ok(n * fixed_byte_width(inner, spec)?);
+    }
+
+    let width = match dsl_ty {
+        "U8" | "I8" | "Bool" => Some(1),
+        "U16" | "I16" => Some(2),
+        "U32" | "I32" => Some(4),
+        "U64" | "I64" => Some(8),
+        "U128" | "I128" => Some(16),
+        "Pubkey" | "Bytes32" => Some(32),
+        "Bytes64" => Some(64),
+        _ => None,
+    };
+    if let Some(width) = width {
+        return Ok(width);
+    }
+
+    if let Some((_, rhs)) = spec.type_aliases.iter().find(|(n, _)| n == dsl_ty) {
+        return fixed_byte_width(rhs, spec);
+    }
+
+    // A record is the sum of its fields, in declaration order.
+    if let Some(record) = spec.records.iter().find(|r| r.name == dsl_ty) {
+        let mut total = 0;
+        for (_, field_ty) in &record.fields {
+            total += fixed_byte_width(field_ty, spec)?;
+        }
+        return Ok(total);
+    }
+
+    // `Fin[N]` is deliberately absent. The two targets disagree: Quasar
+    // packs it as `PodU32` (4 bytes), Anchor maps it to `usize`, whose
+    // encoded width is not something to assume. A caller that needs it
+    // should decide per target rather than get a number from here.
+    anyhow::bail!(
+        "cannot derive a fixed byte width for DSL type `{}` — supported: \
+         U8/U16/U32/U64/U128, I8/I16/I32/I64/I128, Bool, Pubkey, Bytes32, \
+         Bytes64, Map[N] T, records of those, and aliases of those",
         dsl_ty
     )
 }

--- a/crates/qedgen/src/codegen/parallax_repro.rs
+++ b/crates/qedgen/src/codegen/parallax_repro.rs
@@ -67,6 +67,8 @@
 //! `signer` account and a caller-seeded PDA was not exploitable at all, and
 //! the reproducer correctly refused to confirm it.
 
+use anyhow::Result;
+
 use crate::check::{ParsedHandler, ParsedSpec};
 
 /// A generated Parallax reproducer: source plus the human-readable
@@ -130,7 +132,7 @@ pub fn generate(
     attack: ParallaxAttack,
     program_id: &str,
     program_path_expr: &str,
-) -> GeneratedParallaxRepro {
+) -> Result<GeneratedParallaxRepro> {
     let mut out = String::new();
     let test_fn = format!("probe_{}_{}", handler.name, attack.test_fn_suffix());
 
@@ -176,14 +178,14 @@ pub fn generate(
     out.push_str("}\n\n");
 
     if reads_existing_state(handler) {
-        emit_state_bytes_helper(&mut out, spec, handler);
+        emit_state_bytes_helper(&mut out, spec, handler)?;
     }
-    emit_test(&mut out, spec, handler, attack, &test_fn);
+    emit_test(&mut out, spec, handler, attack, &test_fn)?;
 
-    GeneratedParallaxRepro {
+    Ok(GeneratedParallaxRepro {
         source: out,
         attack: attack.describes(&handler.name),
-    }
+    })
 }
 
 /// Does this handler READ an account the program expects to already exist,
@@ -206,7 +208,11 @@ fn reads_existing_state(handler: &ParsedHandler) -> bool {
 /// fields in declaration order, then `bump` and `status`. This mirrors
 /// `codegen_mir`'s emitted `#[account]` struct; the layout is fully
 /// determined by the spec, so it is mechanical.
-fn emit_state_bytes_helper(out: &mut String, spec: &ParsedSpec, handler: &ParsedHandler) {
+fn emit_state_bytes_helper(
+    out: &mut String,
+    spec: &ParsedSpec,
+    handler: &ParsedHandler,
+) -> Result<()> {
     let state_name = format!(
         "{}Account",
         crate::codegen_shared::to_pascal_case(&spec.program_name)
@@ -228,7 +234,10 @@ fn emit_state_bytes_helper(out: &mut String, spec: &ParsedSpec, handler: &Parsed
     out.push_str("fn state_bytes(bump: u8) -> Vec<u8> {\n");
     out.push_str("    let mut data = ACCOUNT_DISCRIMINATOR.to_vec();\n");
     for (name, ty) in &spec.state_fields {
-        out.push_str(&format!("    {} // {name}: {ty}\n", zero_field_expr(ty)));
+        out.push_str(&format!(
+            "    {} // {name}: {ty}\n",
+            zero_field_expr(ty, spec)?
+        ));
     }
     out.push_str("    data.push(bump);\n");
     out.push_str(&format!(
@@ -238,19 +247,26 @@ fn emit_state_bytes_helper(out: &mut String, spec: &ParsedSpec, handler: &Parsed
     ));
     out.push_str("    data\n");
     out.push_str("}\n\n");
+    Ok(())
 }
 
 /// A zero value of the right WIDTH for a state field. The reproducer proves
 /// an absent guard, so field contents are irrelevant — but the byte length
-/// is not: a short buffer fails Anchor's deserialization before the guard.
-fn zero_field_expr(dsl_ty: &str) -> String {
-    match crate::codegen::repro_gen::rust_int_type(dsl_ty) {
-        Some("u8") => "data.push(0);".to_string(),
-        Some(rust_ty) => format!("data.extend_from_slice(&0{rust_ty}.to_le_bytes());"),
-        // Pubkey and anything else addressable is 32 bytes.
-        None if dsl_ty.trim() == "Bool" => "data.push(0);".to_string(),
-        None => "data.extend_from_slice(&[0u8; 32]);".to_string(),
-    }
+/// is not: a wrong-length buffer fails Anchor's deserialization before the
+/// guard, and the lane then reports "no bug" for entirely the wrong reason.
+///
+/// This used to ask `rust_int_type`, which knows `U8`..`U128` and nothing
+/// else, and gave every other type a flat 32 bytes (#389). That is right for
+/// `Pubkey` and wrong for every signed integer, `Bytes64`, and every
+/// `Map[N] T` — a `Map[32] Pubkey` field came out 992 bytes short. Width now
+/// comes from the shared `fixed_byte_width`, which refuses what it cannot
+/// size instead of guessing.
+fn zero_field_expr(dsl_ty: &str, spec: &ParsedSpec) -> Result<String> {
+    let width = crate::codegen_shared::fixed_byte_width(dsl_ty, spec)?;
+    Ok(match width {
+        1 => "data.push(0);".to_string(),
+        n => format!("data.extend_from_slice(&[0u8; {n}]);"),
+    })
 }
 
 /// The lifecycle discriminant the handler expects to find. Uses the declared
@@ -281,7 +297,7 @@ fn emit_test(
     handler: &ParsedHandler,
     attack: ParallaxAttack,
     test_fn: &str,
-) {
+) -> Result<()> {
     out.push_str("#[test]\n");
     out.push_str(&format!("fn {test_fn}() {{\n"));
     out.push_str("    let mut test = ctx();\n\n");
@@ -348,7 +364,7 @@ fn emit_test(
         for (name, ty) in &handler.takes_params {
             out.push_str(&format!(
                 "            data.extend_from_slice(&{}); // {name}: {ty}\n",
-                param_witness(ty)
+                param_witness(ty, spec)?
             ));
         }
         out.push_str("            data\n        },\n");
@@ -385,6 +401,7 @@ fn emit_test(
     out.push_str("    }\n");
 
     out.push_str("}\n");
+    Ok(())
 }
 
 /// Seed expressions for a declared PDA, matching the scaffold's rendering.
@@ -440,11 +457,18 @@ fn discriminator_literal(preimage: &str) -> String {
 /// value demonstrates an absent guard, so `1` is used for integers rather
 /// than a boundary value — this lane proves the guard is missing, not that
 /// arithmetic overflows (that is `repro_gen`'s job).
-fn param_witness(dsl_ty: &str) -> String {
-    match crate::codegen::repro_gen::rust_int_type(dsl_ty) {
-        Some(rust_ty) => format!("1{rust_ty}.to_le_bytes()"),
-        None => "[0u8; 32]".to_string(),
+///
+/// Non-integer parameters get zeros at their real width. The old flat
+/// `[0u8; 32]` was right only for `Pubkey`: it made a `Bool` parameter 32
+/// bytes of instruction data where the program reads 1, so the program
+/// failed to deserialize the instruction and the attack was recorded as
+/// refused (#389).
+fn param_witness(dsl_ty: &str, spec: &ParsedSpec) -> Result<String> {
+    if let Some(rust_ty) = crate::codegen::repro_gen::rust_int_type(dsl_ty) {
+        return Ok(format!("1{rust_ty}.to_le_bytes()"));
     }
+    let width = crate::codegen_shared::fixed_byte_width(dsl_ty, spec)?;
+    Ok(format!("[0u8; {width}]"))
 }
 
 #[cfg(test)]
@@ -504,7 +528,8 @@ handler bump_total (amount : U64) {
             ParallaxAttack::UnsignedInvocation,
             "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../program/target/deploy/vulnerable.so\")",
-        );
+        )
+        .expect("generate reproducer");
 
         assert!(
             !generated.source.contains(", true)"),
@@ -526,7 +551,8 @@ handler bump_total (amount : U64) {
                 attack,
                 "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
                 "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../program/target/deploy/vulnerable.so\")",
-            );
+            )
+        .expect("generate reproducer");
             assert!(
                 generated.source.contains("check(Outcome::success())"),
                 "{attack:?} must assert the attack commits:\n{}",
@@ -549,7 +575,8 @@ handler bump_total (amount : U64) {
             ParallaxAttack::UnsignedInvocation,
             "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "\"/tmp/vulnerable.so\"",
-        );
+        )
+        .expect("generate reproducer");
 
         assert!(generated
             .source
@@ -566,7 +593,8 @@ handler bump_total (amount : U64) {
             ParallaxAttack::Replay,
             "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../program/target/deploy/vulnerable.so\")",
-        );
+        )
+        .expect("generate reproducer");
         assert_eq!(
             generated.source.matches("test.execute(").count(),
             2,
@@ -588,7 +616,8 @@ handler bump_total (amount : U64) {
             ParallaxAttack::UnsignedInvocation,
             "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../program/target/deploy/vulnerable.so\")",
-        );
+        )
+        .expect("generate reproducer");
 
         assert!(
             generated
@@ -625,14 +654,109 @@ handler bump_total (amount : U64) {
             "the derived PDA must be installed with those bytes:\n{}",
             generated.source
         );
-        // Widths must match the emitted `#[account]` struct exactly: a short
-        // buffer fails deserialization just like an empty account.
+        // Widths must match the emitted `#[account]` struct exactly: a
+        // wrong-length buffer fails deserialization just like an empty
+        // account. The emitted form states the width literally (#389), so a
+        // wrong one is visible in the generated file rather than hidden
+        // behind a type name.
         assert!(generated
             .source
             .contains("data.extend_from_slice(&[0u8; 32]); // owner: Pubkey"));
         assert!(generated
             .source
-            .contains("data.extend_from_slice(&0u64.to_le_bytes()); // total: U64"));
+            .contains("data.extend_from_slice(&[0u8; 8]); // total: U64"));
+    }
+
+    /// #389 — the width gate. `zero_field_expr` asked `rust_int_type`, which
+    /// knows `U8`..`U128` and nothing else, and gave everything else a flat
+    /// 32 bytes. That is right for `Pubkey` and wrong for every signed
+    /// integer, `Bytes64`, and every `Map[N] T`.
+    ///
+    /// Asserted as a TOTAL length rather than per-type strings: the total is
+    /// what Anchor actually checks, and a per-type list only covers the
+    /// types someone thought to write down.
+    #[test]
+    fn state_bytes_length_matches_the_account_layout() {
+        let spec = chumsky_adapter::parse_str(
+            "spec Wide\n\
+             type State\n  \
+             | Uninitialized\n  \
+             | Active of { owner : Pubkey, members : Map[4] Pubkey, \
+             flags : Map[3] U8, delta : I64, sig : Bytes64, live : Bool, }\n\
+             type Error\n  | Nope\n\
+             pda vault [\"vault\"]\n\
+             handler bump : State.Active -> State.Active {\n  \
+             accounts { vault : writable, pda [\"vault\"] }\n  \
+             effect { delta := delta }\n}\n",
+        )
+        .expect("parse");
+
+        let generated = generate(
+            &spec,
+            &handler(&spec, "bump"),
+            ParallaxAttack::UnsignedInvocation,
+            "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+            "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/x.so\")",
+        )
+        .expect("generate reproducer");
+
+        // 8 discriminator + 32 owner + 4*32 members + 3*1 flags + 8 delta
+        // + 64 sig + 1 live + 1 bump + 1 status.
+        let expected = 8 + 32 + 128 + 3 + 8 + 64 + 1 + 1 + 1;
+        let emitted: usize = generated
+            .source
+            .lines()
+            .filter_map(emitted_byte_count)
+            .sum::<usize>()
+            + 8; // ACCOUNT_DISCRIMINATOR.to_vec()
+        assert_eq!(
+            emitted, expected,
+            "state_bytes builds the wrong number of bytes:\n{}",
+            generated.source
+        );
+    }
+
+    /// Bytes appended by one emitted line of `state_bytes`. Counts the two
+    /// shapes the emitter produces and ignores everything else.
+    fn emitted_byte_count(line: &str) -> Option<usize> {
+        let line = line.trim();
+        if line.starts_with("data.push(") {
+            return Some(1);
+        }
+        let rest = line.strip_prefix("data.extend_from_slice(&[0u8; ")?;
+        rest.split(']').next()?.parse().ok()
+    }
+
+    /// A type the emitter cannot size must stop generation. The alternative
+    /// is a guessed width that turns into a reproducer reporting "no bug"
+    /// for a reason unrelated to the finding.
+    #[test]
+    fn unsizable_state_field_refuses_to_generate() {
+        let spec = chumsky_adapter::parse_str(
+            "spec Dyn\n\
+             type State\n  \
+             | Uninitialized\n  \
+             | Active of { owner : Pubkey, notes : Vec U64, }\n\
+             type Error\n  | Nope\n\
+             pda vault [\"vault\"]\n\
+             handler bump : State.Active -> State.Active {\n  \
+             accounts { vault : writable, pda [\"vault\"] }\n  \
+             effect { owner := owner }\n}\n",
+        )
+        .expect("parse");
+
+        let err = generate(
+            &spec,
+            &handler(&spec, "bump"),
+            ParallaxAttack::UnsignedInvocation,
+            "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+            "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/x.so\")",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("fixed byte width"),
+            "unexpected error: {err}"
+        );
     }
 
     /// An `init` handler CREATES its PDA, so installing an account makes the
@@ -646,7 +770,8 @@ handler bump_total (amount : U64) {
             ParallaxAttack::UnsignedInvocation,
             "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../program/target/deploy/vulnerable.so\")",
-        );
+        )
+        .expect("generate reproducer");
 
         assert!(
             !generated.source.contains("state_bytes"),
@@ -674,7 +799,8 @@ handler bump_total (amount : U64) {
             ParallaxAttack::UnsignedInvocation,
             "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../program/target/deploy/vulnerable.so\")",
-        );
+        )
+        .expect("generate reproducer");
         assert!(generated
             .source
             .contains("Pubkey::find_program_address(&[b\"vault\", owner.as_ref()]"));
@@ -694,7 +820,8 @@ handler bump_total (amount : U64) {
             ParallaxAttack::UnsignedInvocation,
             "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../program/target/deploy/vulnerable.so\")",
-        );
+        )
+        .expect("generate reproducer");
         assert!(generated.source.contains("1u64.to_le_bytes()"));
     }
 }

--- a/crates/qedgen/src/codegen/parallax_repro.rs
+++ b/crates/qedgen/src/codegen/parallax_repro.rs
@@ -685,7 +685,7 @@ handler bump_total (amount : U64) {
              flags : Map[3] U8, delta : I64, sig : Bytes64, live : Bool, }\n\
              type Error\n  | Nope\n\
              pda vault [\"vault\"]\n\
-             handler bump : State.Active -> State.Active {\n  \
+             handler bump (flag : Bool) : State.Active -> State.Active {\n  \
              accounts { vault : writable, pda [\"vault\"] }\n  \
              effect { delta := delta }\n}\n",
         )
@@ -703,8 +703,7 @@ handler bump_total (amount : U64) {
         // 8 discriminator + 32 owner + 4*32 members + 3*1 flags + 8 delta
         // + 64 sig + 1 live + 1 bump + 1 status.
         let expected = 8 + 32 + 128 + 3 + 8 + 64 + 1 + 1 + 1;
-        let emitted: usize = generated
-            .source
+        let emitted: usize = state_bytes_body(&generated.source)
             .lines()
             .filter_map(emitted_byte_count)
             .sum::<usize>()
@@ -714,6 +713,20 @@ handler bump_total (amount : U64) {
             "state_bytes builds the wrong number of bytes:\n{}",
             generated.source
         );
+    }
+
+    /// The body of the generated `state_bytes` function, so the byte count
+    /// above measures the account fixture and nothing else. Scoped rather
+    /// than scanning the whole file, because instruction arguments append to
+    /// a `data` binding too: giving the fixture handler a parameter would
+    /// otherwise fold its witness bytes into the account total and the
+    /// assertion would fail for the wrong reason.
+    fn state_bytes_body(source: &str) -> &str {
+        let (_, after) = source
+            .split_once("fn state_bytes(bump: u8) -> Vec<u8> {")
+            .expect("generated source declares state_bytes");
+        let (body, _) = after.split_once("\n}").expect("state_bytes is closed");
+        body
     }
 
     /// Bytes appended by one emitted line of `state_bytes`. Counts the two

--- a/crates/qedgen/src/probe/probe_repro.rs
+++ b/crates/qedgen/src/probe/probe_repro.rs
@@ -451,13 +451,22 @@ pub fn write_parallax_repro(
     // The repro crate is ephemeral and machine-local, so it embeds the
     // artifact's ABSOLUTE path. `{:?}` quotes and escapes it into a Rust
     // string literal, which also survives spaces in the project path.
+    // A spec whose state or parameters carry a type the fixture emitter
+    // cannot size stops here rather than producing a reproducer built on a
+    // guessed width (#389). A wrong-width account fails deserialization
+    // before the guard under test runs, so such a reproducer would report
+    // "no bug" for a reason unrelated to the finding — a false negative in
+    // the one lane whose whole job is evidence.
     let generated = crate::codegen::parallax_repro::generate(
         ctx.spec,
         handler,
         attack,
         &program.address,
         &format!("{:?}", program.artifact.display().to_string()),
-    );
+    )
+    .map_err(|e| {
+        ConstructFailure::BuildError(format!("parallax reproducer not constructible: {e}"))
+    })?;
 
     let test_stem = format!("probe_{}", finding.id);
     let test_file = tests_dir.join(format!("{test_stem}.rs"));

--- a/crates/qedgen/tests/fixtures/parallax-repro-gate/vulnerable.qedspec
+++ b/crates/qedgen/tests/fixtures/parallax-repro-gate/vulnerable.qedspec
@@ -28,11 +28,24 @@ spec Vulnerable
 // the placeholder outright, so the spec has to carry the id.
 program_id "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
+// The wide fields are load-bearing, not decoration (#389). The reproducer
+// installs a pre-state account, and its byte WIDTH has to match what the
+// program decodes. The emitter used to size every non-`U*` field at 32
+// bytes, which is right for `Pubkey` and wrong for a signed integer or an
+// array — a `Map[4] Pubkey` came out 96 bytes short. The account then failed
+// deserialization before the guard under test ran, and the lane reported
+// "no bug" for a reason unrelated to the finding.
+//
+// A fixture of `Pubkey` and `U64` alone cannot catch that, because those are
+// the two types the old code sized correctly. Keep a signed field and an
+// array field here.
 type State
   | Uninitialized
   | Active of {
-      owner : Pubkey,
-      total : U64,
+      owner   : Pubkey,
+      total   : U64,
+      members : Map[4] Pubkey,
+      delta   : I64,
     }
 
 // `MathOverflow` is deliberately NOT declared: the checked add in `set_fee`


### PR DESCRIPTION
Closes #389.

The Parallax reproducer installs a pre-state account before driving its
attack. `zero_field_expr` sized that account by asking `rust_int_type`,
which knows `U8`..`U128` and returns `None` for everything else, and gave
every `None` a flat 32 bytes.

That is correct for `Pubkey`, which is the only reason the lane worked. It
is wrong for every signed integer, `Bytes64`, and every `Map[N] T`.

| state field | bytes emitted | bytes decoded |
|---|---|---|
| `Pubkey` | 32 | 32 ✅ |
| `U64` | 8 | 8 ✅ |
| `I64` | 32 | 8 ❌ |
| `Bytes64` | 32 | 64 ❌ |
| `Map[4] Pubkey` | 32 | 128 ❌ |

A wrong-length account fails Anchor deserialization before the guard under
test runs, so the attack is recorded as refused and the finding is dropped.
That is a false negative in the one lane whose entire job is evidence, and
it is the exact failure the emitter's own doc comment says it exists to
prevent.

## Width comes from the declared type

`codegen_shared::fixed_byte_width` derives the width from the DSL type:
scalars, `Bool`, addresses, `Bytes32`/`Bytes64`, `Map[N] T` recursively,
records as the sum of their fields, and aliases through their RHS.

Both layouts this repo emits agree on all of it. Anchor/Borsh and
Quasar/Pod both store fixed scalars little-endian with no padding, `bool` in
one byte, an address in 32, and `[T; N]` as N elements back to back. They
diverge only on the variable-length types, which the function refuses for
both. `Fin[N]` is deliberately absent: Quasar packs it as `PodU32` while
Anchor maps it to `usize`, so there is no single answer to give.

Refusing is half the fix. `generate` is now fallible, and a spec carrying a
type the emitter cannot size produces no reproducer and a stated reason
instead of one built on a guess. A reproducer that cannot be built faithfully
should not exist.

`param_witness` had the same `None => [0u8; 32]` fallback for instruction
arguments, so a `Bool` parameter sent 32 bytes where the program reads 1.
Fixed the same way.

The emitted form now states the width literally
(`data.extend_from_slice(&[0u8; 8]);` rather than `&0u64.to_le_bytes()`), so
a wrong width is visible in the generated file instead of hidden behind a
type name.

## The fixture is the gate

`vulnerable.qedspec` declared `owner : Pubkey` and `total : U64` — the two
types the old code sized correctly. That is why this survived. It now also
carries `members : Map[4] Pubkey` and `delta : I64`.

Verified end to end, both directions, with `cargo build-sbf` + LiteSVM:

- with the fix, `parallax_repro_gate` passes: the reproducers still confirm
  the genuinely unguarded handlers and still drop the guarded one.
- with `zero_field_expr` temporarily reverted to the old behaviour and the
  widened fixture in place, the gate fails with

  ```
  set_fee/missing_signer must be CONFIRMED — the program accepts the attack.
  confirmed: []
  ```

  which is the false negative, reproduced.

Unit coverage: the width table including every signed type, `Map` bounds
(nested), records and aliases, the refusal set, plus a `state_bytes` test
asserting the TOTAL emitted length against the account layout. A total
catches the whole class; per-type string assertions only catch the types
someone thought to list.

Full `cargo test` green (40 targets), clippy and rustfmt clean.