### PR TITLE
feat(auditor): add known-non-findings reference and four catalog categories

### DIFF
--- a/crates/qedgen/src/probe/spec_predicates.rs
+++ b/crates/qedgen/src/probe/spec_predicates.rs
@@ -316,7 +316,7 @@ pub(crate) fn predicate_permissionless_state_writer(handler: &ParsedHandler) -> 
              unbounded amount params (compose with `unbounded_amount_param`), \
              missing per-actor PDA derivation. The corpus entry \
              `Frontrun the permissionless claim / crank` and Token-2022 \
-             `transfer_hook_reentrancy` are common amplifiers.",
+             `transfer_hook_untrusted_callback` are common amplifiers.",
             handler.name,
             mutated_fields.join(", ")
         ),

--- a/docs/security-primer.md
+++ b/docs/security-primer.md
@@ -53,8 +53,6 @@ verification.
    collateral-side lock.
 
 **Grep for:**
-- `load_instruction_at(` (deprecated; use
-  `load_instruction_at_checked`)
 - Any read of `Sysvar::Instructions` data without
   `solana_program::sysvar::instructions::ID` equality check
 - Anchor: `AccountInfo<'info>` for the instructions sysvar
@@ -62,6 +60,14 @@ verification.
 - More generally: any "well-known" account (token program, system
   program, rent, clock) typed as `AccountInfo` rather than its
   strongly-typed wrapper
+
+`load_instruction_at(` was the original signal and this entry used to
+lead with it. The unchecked variant was fixed in 2022 and later
+removed, so that grep is dead against any current toolchain. The
+account-typing signals above are the durable ones. Reporting the mere
+presence of an instruction-introspection call as a vulnerability is a
+misreport — see
+`skills/qedgen-auditor/references/known-non-findings.md`.
 
 **Composes with:** missing program-id check on CPI target;
 account type confusion (treating any AccountInfo as a sysvar).

--- a/skills/qedgen-auditor/SKILL.md
+++ b/skills/qedgen-auditor/SKILL.md
@@ -178,6 +178,10 @@ Read only the relevant detailed references:
   rules, the severity grading procedure, and the report format.
 - [audit handbook](references/audit-handbook.md): adversarial mindset, tool
   surface, and the reproducer-only contract.
+- [known non-findings](references/known-non-findings.md): always before filing
+  a reentrancy, closed-account-discriminator, float-determinism, token
+  self-transfer, instruction-introspection, partial-state-commitment, or
+  unchecked-CPI-return finding.
 - [trust-surface primitives](references/trust_surface_primitives.md): only when
   a small dependency supplies a security-critical primitive.
 - [data-structure dependency invariants](references/data_structure_dep_invariants.md):
@@ -236,7 +240,9 @@ Assign exactly one evidence state:
 - `structural`: source establishes the vulnerable and reachable path, but the
   execution environment could not run it.
 - `hypothesis`: intent, reachability, or a required precondition is unresolved.
-- `rejected`: disproved, framework-protected, unreachable, or suppressed.
+- `rejected`: disproved, framework-protected, unreachable, or suppressed. Name
+  the specific guarantee that rejects it; see
+  [known non-findings](references/known-non-findings.md).
 
 Then grade impact using [severity and evidence](references/severity-and-evidence.md).
 Hypotheses are not vulnerability findings and must appear in a separate

--- a/skills/qedgen-auditor/references/category-catalog.md
+++ b/skills/qedgen-auditor/references/category-catalog.md
@@ -597,6 +597,63 @@ the runtime would otherwise enforce.
   audit-firm reports as "manual lamport mutation freezes
   rent-exempt / executable accounts."
 
+### `lamport_balance_not_program_controlled` — HIGH
+An account's lamport balance is not program-controlled state. Anyone
+can increase it without the owning program's consent, and the runtime
+constrains when it may decrease. A program that treats the balance as
+its own accounting, or that depends on a push payment succeeding, is
+trusting something it does not own. Two sub-shapes share this root.
+
+**Read side, unsolicited credit.** The handler derives accounting
+truth from `account.lamports()` or a quantity computed from it: a
+deposit total, a share denominator, a "has this been funded" test, a
+solvency check. An attacker transfers lamports in directly, the
+program never sees an instruction, and the derived value is now wrong
+in the attacker's favour. This is the Solana form of a forced balance
+credit.
+
+**Write side, unpayable target.** The handler pushes lamports to an
+address taken from state or from caller input, and the program's
+liveness depends on that transfer succeeding. The runtime can refuse
+permanently, in three ways: the debit would drop the source below
+rent exemption; the target is executable, which the runtime rejects;
+or the target sits in the reserved account list and is silently
+demoted to read-only. An address stored earlier can become unpayable
+later, which bricks the handler with no way to recover.
+
+- **Detect (read side)** by grepping every `.lamports()` read and
+  sorting it into two piles: rent-exemption checks, which are fine,
+  and anything feeding accounting or a guard, which is the finding.
+  Ask whether an unsolicited transfer changes the result.
+- **Detect (write side)** by finding every payout whose destination
+  comes from stored state or an instruction argument, then asking what
+  the program does if that transfer can never succeed. If the answer
+  is "the handler always fails from now on", the finding is a
+  permanent denial of service, not a transient error.
+- **Anchor / Native:** the read-side tell is
+  `vault.lamports() - Rent::get()?.minimum_balance(...)` used as a
+  withdrawable amount. The write-side tell is a stored `Pubkey`
+  destination combined with `#[account(mut)]` and no check that the
+  target is neither executable nor reserved.
+- **When to suppress:** the lamport read only feeds a rent-exemption
+  assertion, or the payout target is a PDA the program derives and
+  controls.
+- **Fix pattern:** track deposits in explicit program state rather
+  than in the balance, and make payouts pull-based. Credit a claimable
+  amount to a PDA vault and let the recipient withdraw, so an
+  unpayable address cannot stall anyone else.
+- Compose-with-what: `pda_lifecycle_reuse_after_close` (an unsolicited
+  credit is also how a closed account gets revived); permissionless
+  deposit or claim (the attacker funds the skew themselves).
+- Distinct from `lamport_write_demotion`, which is about the direct
+  `try_borrow_mut_lamports` write mechanic freezing an account. This
+  category is about trusting the balance as state, and about pushing
+  payments to addresses the program does not control.
+- Corpus: public research on lamport transfer semantics and
+  reserved-account write demotion (2025-05), where a stored winner
+  address became read-only after a feature gate activated and the
+  reimbursement path could no longer run.
+
 ### `init_config_field_unanchored` — CRITICAL (DAMM-v2 shape)
 Spec-less only. The **write-side companion** to
 `field_chain_missing_root_anchor`. An init handler accepts a
@@ -766,6 +823,54 @@ When to suppress / downgrade:
   strand the funds. Remediation was doc-only (admin treated as trusted),
   so it was firm-rated MEDIUM; the strand-funds capability is HIGH absent
   that documented trust.
+
+### `compressed_nft_ownership_unverified` — HIGH (CRITICAL when it gates funds)
+A program grants a right — a vote, a claim, an airdrop, access, a
+transfer — on the strength of compressed NFT ownership. Unlike a
+regular NFT there is no account to own and no owner field to read.
+Ownership is a leaf in a concurrent Merkle tree, and it only exists as
+a proof supplied per transaction. Every guarantee therefore rests on
+the program recalculating the leaf from the signer and verifying the
+proof against the tree's live root.
+
+Four ways integrators lose that guarantee:
+
+1. Trusting a leaf, asset id, or owner supplied by the caller or read
+   from an off-chain indexer, instead of recalculating the leaf from
+   the signing account. The recalculation is the ownership check; skip
+   it and there is no check.
+2. Verifying against a caller-supplied root rather than the current
+   root in the tree account. A stale root plus its matching proof is a
+   replay of ownership the caller no longer has.
+3. Not pinning the Merkle tree account or its authority, so a caller
+   substitutes a tree they control and proves whatever they like.
+4. Caching a proof across transactions. The tree's `max_buffer_size`
+   changelog bounds how many mutations a proof survives; past that it
+   is stale.
+
+- **Detect** by tracing every right the program grants back to the
+  account that proves it. If the answer is a leaf or an asset id that
+  arrived as instruction data, the program is trusting the claimant.
+- **Anchor / Native:** look for leaf construction from unchecked input
+  (`LeafSchema::new_v1` and equivalents), CPI into the account
+  compression program with a root that came from the caller, and a
+  Merkle tree account typed as a bare `AccountInfo` with no equality
+  check against the expected tree.
+- **When to suppress:** the program CPIs into the account compression
+  program with the tree account itself, recalculates the leaf from the
+  signer, and lets that program verify against its own stored root.
+- **On canopy depth, do not file a finding.** The canopy is upper tree
+  nodes cached on-chain so the submitted proof is short enough to fit
+  the transaction size limit. It shortens the proof; it does not
+  weaken verification. Treat canopy depth as a liveness and
+  transaction-sizing constraint. It becomes reportable only when a
+  deep tree with too little canopy makes a required operation
+  unlandable, and that is a denial of service, not an ownership bug.
+- Compose-with-what: `field_chain_missing_root_anchor` (the same
+  unanchored-root shape on a different primitive); `arbitrary_cpi`
+  when the compression program itself is not pinned.
+- Corpus: public research on concurrent Merkle trees and compressed
+  NFT integration hazards.
 
 ### `transfer_hook_untrusted_callback` — HIGH (Token-2022 only)
 A Token-2022 mint carrying the `TransferHook` extension makes the
@@ -982,6 +1087,55 @@ high-impact when it materializes.
 - Corpus: recurring audit-firm pattern across DeFi programs; the
   two-step handshake is now the default safe form across mature
   Solana protocols.
+
+### `privileged_action_no_delay_window` — MEDIUM (operational hardening)
+Every privileged handler takes effect in the transaction that lands
+it. That is fine until the question is not "was this authorized" but
+"was this authorized *now*". A Solana signature anchored to a durable
+nonce does not expire, so an approval collected under one pretext can
+be submitted weeks later under another, and a leaked key is fatal the
+moment it is used. A protocol with no delay between request and effect
+has no window in which anyone can notice and revoke.
+
+`authority_transfer_missing_nominate_accept` covers exactly one
+handler, the authority transfer. This category covers the rest of the
+privileged surface: `withdraw_admin`, `set_config`, `set_oracle`,
+`whitelist_collateral`, `set_fee`, `pause`, `upgrade`. A nominate and
+accept handshake on `set_authority` is worth little if
+`whitelist_collateral` still executes instantly and can list an
+attacker's token.
+
+- **Detect** by listing every handler gated only on an admin signer,
+  then asking for each one: between the transaction landing and the
+  effect being irreversible, is there any interval in which an honest
+  party could intervene? Two-step handlers store a pending value plus
+  a `not_before` timestamp and refuse to apply early. One-step
+  handlers write the live field directly.
+- **Anchor:** the shape is `has_one = admin` plus `Signer<'info>` and
+  a direct field assignment, with no `pending_*` field on the config
+  account and no `Clock::get()` in the handler body. The absence of a
+  clock read in a privileged setter is the fastest signal.
+- **Native / Pinocchio:** same shape with the admin comparison done by
+  hand.
+- **When to suppress:** the action is genuinely emergency-scoped and
+  reversible, such as a pause that only ever restricts, where a delay
+  would defeat the purpose. Say which direction the action can move
+  before suppressing; a pause that can also unpause is not
+  one-directional.
+- **Severity note:** MEDIUM as hardening, HIGH when a single
+  privileged call can seize or strand user funds in one transaction,
+  since there the delay window is the only thing between a captured
+  signature and a loss.
+- Compose-with-what: single-key admin custody; an unanchored admin
+  field (`init_config_field_unanchored`) so the attacker is the admin;
+  approvals anchored to a durable nonce, which never expire and turn a
+  months-old signature into a live one.
+- Corpus: public research on multisig signing hygiene and durable
+  nonce replay (2025-02). The off-chain half of that work is signing
+  procedure, which an audit can recommend but not enforce. This
+  category is the on-chain half the program can actually implement.
+  See `docs/security-primer.md` Part 2 for the durable-nonce takeover
+  flow this defends against.
 
 ### `missing_rent_exemption_check_on_init` — HIGH
 Spec-less only. Account initialization accepts a caller-supplied
@@ -1304,6 +1458,10 @@ exhaustive; use as a thinking primer, not a checklist.
 | bounty_intent_drift (spec docstring claims behavior the spec body doesn't enforce) | + | qedgen-codegen mechanization | = | formal-verification artifacts (Lean / Kani / proptest) faithfully translate the broken spec — `lake build` green proves the broken behavior, **giving false confidence that the program is correct** (HIGH-CRIT depending on what the docstring claimed) |
 | spec_impl_drift_user_owned (body writes a state field the spec doesn't model) | + | downstream guard reads that field | = | unmodeled side-channel that formal verification is blind to (HIGH) |
 | lamport_write_demotion | + | rent-exempt PDA | = | silent rent extraction, downstream rent failure (MED→HIGH) |
+| lamport_balance_not_program_controlled (read side) | + | `withdrawable = lamports() - rent_minimum` | = | attacker donates lamports to inflate the withdrawable amount, then withdraws a surplus they never deposited (HIGH) |
+| lamport_balance_not_program_controlled (write side) | + | payout address stored at init | = | the stored address later becomes executable, reserved-and-demoted, or would fall below rent exemption, and the payout handler can never succeed again (MED→HIGH, permanent DoS with no recovery path) |
+| compressed_nft_ownership_unverified | + | claim / vote gated on cNFT ownership | = | replay a stale-root proof or prove against a self-owned tree to claim assets the caller never held (HIGH→CRIT) |
+| privileged_action_no_delay_window | + | durable-nonce-anchored approval | = | a signature collected months earlier under a different pretext lands and takes effect instantly, with no window for the honest signers to revoke (MED→CRIT depending on what the action controls) |
 | saturating_by_design (`+=!`) | + | amount-shaped field | = | silent value loss, no error path (MED→HIGH) |
 | payout_exceeds_recorded_principal | + | shared vault, permissionless claim | = | every claim draws its excess from other depositors' principal, turning a bounded per-position leak into a pool drain that no per-position check can see (HIGH→CRIT) |
 | token_account_role_anchoring (`<role>_token_account.owner` field not pinned) | + | authority-signed revoke / payout handler | = | authority redirects role's vested-but-unclaimed tokens to any same-mint wallet they control, no victim consent (CRIT) |

--- a/skills/qedgen-auditor/references/category-catalog.md
+++ b/skills/qedgen-auditor/references/category-catalog.md
@@ -767,17 +767,48 @@ When to suppress / downgrade:
   so it was firm-rated MEDIUM; the strand-funds capability is HIGH absent
   that documented trust.
 
-### `transfer_hook_reentrancy` — HIGH (Token-2022 only)
-Token-2022 transfer hooks can call back into the calling program
-during a transfer. Handler that updates state across a transfer
-boundary without the new state visible to the hook is reentrancy-
-vulnerable.
-- **Anchor / Native:** Token-2022 transfer (`transfer_checked` with
-  `mint = TOKEN_2022_PROGRAM_ID`) where program state is mutated
-  *after* the transfer with the pre-transfer state still trusted.
-- Corpus: first Solana-native reentrancy class; documented across
-  audit-firm Token-2022 advisories. No single famous public
-  incident yet — the extension shipped after the last large
+### `transfer_hook_untrusted_callback` — HIGH (Token-2022 only)
+A Token-2022 mint carrying the `TransferHook` extension makes the
+token program CPI into a hook program on every transfer. A handler
+that accepts a caller-supplied mint without constraining which mints
+it services therefore runs attacker-chosen code in the middle of its
+own handler, with attacker-chosen extra accounts.
+
+**The hook cannot call back into the calling program.** The runtime
+returns `ReentrancyNotAllowed` for `A -> B -> A`; only direct
+self-recursion (`A -> A`) is permitted, inside a stack depth of 5 (9
+with SIMD-0268). Filing this as reentrancy is a misreport — see
+[known non-findings](known-non-findings.md). The real mechanism is
+untrusted code in the caller's critical section:
+
+- The hook runs arbitrary logic chosen by whoever created the mint.
+- It receives the extra accounts resolved from the mint's
+  extra-account-metas list, which the mint creator also controls.
+- It can fail, turning every transfer into a griefing vector on a path
+  the caller assumed was infallible.
+- It can CPI into any program *not already on the stack*, including
+  one that reads the caller's accounts while the caller's invariants
+  are mid-update.
+
+- **Detect** by finding every `transfer_checked` reached through
+  `token_interface` or `Program<'info, Token2022>` where the mint is
+  caller-supplied. Then ask which of the caller's invariants are
+  temporarily false at the moment of the transfer, and whether a third
+  program could observe or act inside that window.
+- **Anchor / Native:** the shape is a transfer sitting between the two
+  halves of a state update. Mutating state *after* the transfer while
+  still trusting a pre-transfer read is the highest-value instance,
+  because the hook's window sits exactly in the gap.
+- **When to suppress:** the mint is pinned to an allowlist, the program
+  rejects mints configured with `TransferHook` at entry, or the program
+  accepts legacy `TOKEN_PROGRAM_ID` only. Catch the explicit rejection
+  in source before suppressing.
+- Compose-with-what: `token_2022_extension_arithmetic_skew` (same
+  untrusted-mint root cause, different consequence); any handler whose
+  solvency or accounting invariant is briefly false across the
+  transfer.
+- Corpus: documented across audit-firm Token-2022 advisories. No single
+  large public incident yet — the extension shipped after the last big
   exploit window.
 
 ### `rounding_direction_round_trip` — HIGH (DeFi-specific)
@@ -857,6 +888,64 @@ dust into a self-funding strategy.
 - Distinct from `rounding_direction_round_trip` because there's only
   one "round" — the user calls it multiple times, not two legs in one
   tx.
+
+### `payout_exceeds_recorded_principal` — HIGH (DeFi-specific)
+Spec-less only. A handler disburses funds from a computed schedule or
+accrual formula — vesting, streaming, reward accrual, interest — and
+the cumulative disbursement is never clamped to the principal that was
+actually deposited. The conservation invariant `sum(payouts) <=
+deposited` holds only as long as the formula is exactly right, so any
+error in the formula converts directly into an over-payment against the
+vault. Escalate to CRITICAL when the excess is repeatable rather than a
+single bounded unit, or when the vault is shared and the excess is
+drawn from other depositors' principal.
+
+The tell is structural, not arithmetic. Every operation can be
+`checked_*` and nothing overflows, and the result still exceeds the
+principal. Grepping for unchecked arithmetic will not find this.
+
+- **Detect** by evaluating each payout schedule at its boundary. Take
+  the maximum the formula can return (`now >= end_time`, the final
+  interval, the last epoch) and compare it to the recorded principal.
+  If they are not equal at the boundary, the difference is the leak.
+  The generic defect shape:
+
+  ```rust
+  // periods counts the *current* period as already released
+  let periods = elapsed.checked_div(period_len)?.checked_add(1)?;
+  periods.checked_mul(per_period)?.checked_sub(already_paid)
+  ```
+
+  At maturity this returns `principal + per_period`. Every operation is
+  checked; nothing wraps.
+
+- **Anchor:** find handlers that call a state-struct method
+  (`claimable`, `pending`, `accrued`, `releasable`) and pass the result
+  straight into `transfer` / `transfer_checked`, then add it to a
+  running total afterwards. The missing clamp against the stored
+  principal is the finding, not the formula's internals.
+- **Native / Pinocchio:** same shape with the schedule inlined in the
+  processor. Trace the value from its computation to the lamport or
+  token movement and ask what bounds it.
+- **When to suppress:** the handler clamps to the remaining principal
+  before transferring (`min(computed, principal - already_paid)`), or a
+  post-condition asserts the running total stays within the deposit. A
+  shared vault balance is **not** a ceiling — it only means the last
+  claimant absorbs the shortfall, which is the composition below, not a
+  mitigation.
+- Compose-with-what: permissionless claim / crank (the attacker fires
+  it themselves, no victim action); shared vault holding many
+  depositors' principal (converts a bounded per-position leak into a
+  pool drain); no reconciliation between recorded totals and the actual
+  vault balance (nothing ever notices).
+- Distinct from `arithmetic_overflow_wrapping` because every operation
+  is checked and nothing wraps. Distinct from
+  `rounding_direction_round_trip` because there is one leg, not two.
+  Distinct from `liquidation_rounding_dust_accumulation` because the
+  leak is a full schedule unit, not accumulated dust.
+- Corpus: public auditor-training material, interval-vesting escrow
+  (2026-07) — an off-by-one in the released-period count let the
+  recipient withdraw one full period beyond the escrowed amount.
 
 ### `flash_loan_amplified_governance` — HIGH (DeFi-specific)
 Spec-less only. Composition class: governance handler reads voting
@@ -1051,7 +1140,7 @@ codegen mechanizes them by construction:
   re-check is rarely productive unless the user added hand-written
   divergence.
 - `arbitrary_cpi`, `cpi_param_swap`, `account_not_reloaded_after_cpi`,
-  `transfer_hook_reentrancy`: codegen owns the CPI block (driven
+  `transfer_hook_untrusted_callback`: codegen owns the CPI block (driven
   by `transfers { }` or `call Interface.handler(...)`); user-owned
   bodies typically don't write `invoke` / `invoke_signed`. If the
   user *adds* hand-written CPI to a body, that's
@@ -1205,7 +1294,7 @@ exhaustive; use as a thinking primer, not a checklist.
 | account_not_reloaded_after_cpi | + | mid-handler trust on stale balance | = | CPI return-value trust → fund loss (HIGH) |
 | unvalidated_remaining_accounts | + | iterator-driven state mutation | = | injected accounts mutate authorized state (HIGH) |
 | discriminator_collision | + | shared deserializer between handlers | = | cross-type spoof → privileged action (HIGH) |
-| transfer_hook_reentrancy | + | mid-transfer state read | = | classic reentrancy (Solana-native, HIGH→CRIT) |
+| transfer_hook_untrusted_callback | + | caller invariant false across the transfer | = | attacker-authored hook code runs inside the window and can act on the inconsistent state through any program not already on the stack (HIGH→CRIT). Not reentrancy: the hook cannot re-enter the caller |
 | permissionless marker | + | unbounded amount param | = | griefing / draining via repeated calls (HIGH) |
 | permissionless init | + | unchecked authority field on init | = | attacker bakes their own pubkey as `mint_authority` / `withdraw_authority` / `admin` at init time → privileged CPI authority on every later operation (CRIT) |
 | field_chain_missing_root_anchor | + | typed-but-unanchored CPI authority field | = | forge a fake collateral chain that the validator accepts as internally-consistent → invoke privileged CPI (mint, withdraw) under the real authority (CRIT, forged-collateral-chain shape) |
@@ -1216,6 +1305,7 @@ exhaustive; use as a thinking primer, not a checklist.
 | spec_impl_drift_user_owned (body writes a state field the spec doesn't model) | + | downstream guard reads that field | = | unmodeled side-channel that formal verification is blind to (HIGH) |
 | lamport_write_demotion | + | rent-exempt PDA | = | silent rent extraction, downstream rent failure (MED→HIGH) |
 | saturating_by_design (`+=!`) | + | amount-shaped field | = | silent value loss, no error path (MED→HIGH) |
+| payout_exceeds_recorded_principal | + | shared vault, permissionless claim | = | every claim draws its excess from other depositors' principal, turning a bounded per-position leak into a pool drain that no per-position check can see (HIGH→CRIT) |
 | token_account_role_anchoring (`<role>_token_account.owner` field not pinned) | + | authority-signed revoke / payout handler | = | authority redirects role's vested-but-unclaimed tokens to any same-mint wallet they control, no victim consent (CRIT) |
 | token_account_role_anchoring | + | claimant-signed claim handler | = | malicious dapp UI tricks the claimant into signing with attacker's ATA in the destination slot → tokens leave the program to the attacker (HIGH, requires victim interaction) |
 | pda_lifecycle_reuse_after_close | + | dependent child PDAs not cascade-closed | = | re-create parent at same seeds revives stale children with carryover state (MED on its own; chains to higher when child state controls funds) |

--- a/skills/qedgen-auditor/references/known-non-findings.md
+++ b/skills/qedgen-auditor/references/known-non-findings.md
@@ -1,0 +1,147 @@
+# Known Non-Findings
+
+Patterns that are reported as Solana vulnerabilities but are not, because the
+runtime, the token program, or the framework already prevents the claimed
+attack. Read this before filing a finding in any of the classes below. Filing
+one of these as a vulnerability costs the audit its credibility on the findings
+that are real.
+
+Each entry states the claim, why it does not hold, and the narrow condition
+under which a related issue would be real. The narrow condition is the part
+worth investigating. It is usually a different bug than the one the pattern
+match suggested.
+
+These are runtime and version dependent. Confirm what the target's actual
+Solana version, Anchor version, and token program enforce before rejecting on
+the strength of this file alone. The same discipline the catalog applies to
+framework wrappers applies here: the guarantee is evidence, and evidence has a
+version.
+
+## Reentrancy across a CPI
+
+**Claim.** A handler that performs a CPI needs reentrancy protection, because
+the callee can call back in and re-enter before state is committed.
+
+**Why it does not hold.** The runtime rejects a CPI into a program that already
+appears on the invocation stack. `A -> B -> A` returns `ReentrancyNotAllowed`.
+The instruction stack depth is capped at 5, or 9 with SIMD-0268.
+
+**Where something real might be.** Direct self-recursion, `A -> A -> A`, is
+explicitly allowed and the rule above does not cover it. Separately, a callee
+that mutates accounts the caller re-reads afterwards is a real problem, but it
+is staleness rather than re-entry, and belongs under
+`account_not_reloaded_after_cpi`. Untrusted code executing inside a caller's
+critical section is also real and is also not re-entry: that is
+`transfer_hook_untrusted_callback`, which was named `transfer_hook_reentrancy`
+until 2026-07-30 and described a callback path the runtime does not permit.
+
+## Anchor closed-account discriminator
+
+**Claim.** Closing an Anchor account safely requires writing a special closed
+account discriminator, and a program that does not is vulnerable.
+
+**Why it does not hold.** Anchor has no closed-account discriminator. The
+mechanism it refers to was removed in Anchor v0.30.0.
+
+**Where something real might be.** Account closure is still sensitive, and the
+underlying concern is legitimate: lamports must move out, data must be zeroed,
+and ownership must return to the system program. A native program doing this by
+hand can get it wrong. File that as `pda_lifecycle_reuse_after_close` or
+`close_account_redirection` with the actual missing step named. Do not file the
+discriminator itself.
+
+## Float non-determinism
+
+**Claim.** Floating point in a Solana program is non-deterministic across
+validator hardware and risks a consensus split.
+
+**Why it does not hold.** Floating point operations are emulated with the
+available sBPF opcodes rather than executed on host floating point units, so
+there is no hardware level variance at the application layer.
+
+**Where something real might be.** Accuracy is a genuine concern. Interest and
+ratio math in floats produces precision loss, and can produce NaN or infinity
+that then propagates into a stored balance. Token-2022's scaled UI amount
+extension is a live example of float arithmetic that needs review. File the
+specific numeric failure, not determinism.
+
+## Token self-transfer
+
+**Claim.** A token transfer where source and destination are the same account
+always succeeds, so a user can bypass a fee, a staking requirement, or a
+cooldown by transferring to themselves.
+
+**Why it does not hold.** The token program is not short-circuiting. Mints must
+match, the source must be solvent, and neither account may be frozen. The
+transfer succeeds only after those checks pass, so it is not a free bypass.
+
+**Where something real might be.** Whether source equals destination matters to
+the calling program's own accounting is a design question worth asking. If the
+handler computes a delta or a fee assuming two distinct accounts, that is
+`duplicate_mutable_accounts_aliasing` and belongs under that category.
+
+## `load_instruction_at` and `load_current_index`
+
+**Claim.** These instruction-introspection calls let an attacker supply a
+forged sysvar and manipulate logic that depends on instruction ordering.
+
+**Why it does not hold.** The unchecked variants were fixed in 2022 and then
+removed. Contemporary code cannot call them.
+
+**Where something real might be.** The general shape is alive and is the reason
+`account_type_confusion` is CRITICAL: any well-known account passed as a bare
+`AccountInfo` instead of its strongly typed wrapper can be substituted. Check
+the account typing, not the function name.
+
+## Partial state commitment on a failed transaction
+
+**Claim.** A transaction that fails partway can leave some accounts updated and
+others not, producing inconsistent state.
+
+**Why it does not hold.** Solana rolls back all account state when a
+transaction reverts. The commitment is all or nothing.
+
+**Where something real might be.** Nothing at the transaction level. Multi
+transaction flows are a different matter: a protocol that requires two separate
+transactions to reach a consistent state can be interrupted between them. That
+is a lifecycle finding, not a commitment finding.
+
+## Unchecked CPI return values
+
+**Claim.** The program must check the error returned by a CPI or it will
+continue running in a corrupted state.
+
+**Why it does not hold.** A CPI error aborts the whole transaction. There is no
+catch, unlike the EVM. Omitting an explicit error check does not let execution
+continue.
+
+**Where something real might be.** Reading a callee's effect from a return
+value rather than from the modified accounts is a real correctness question,
+and so is failing to reload an account the callee changed. Both belong under
+`account_not_reloaded_after_cpi`.
+
+## Still real
+
+Two adjacent patterns are not on this list because they are genuine.
+
+Stack exhaustion in deeply nested Anchor account structs is real, and the
+mitigation depends on the Anchor and runtime versions in use.
+
+Duplicate mutable accounts is real. Anchor has historically allowed the same
+account to be passed for two mutable parameters of the same type. The catalog
+covers it as `duplicate_mutable_accounts_aliasing`.
+
+## How to use this in a report
+
+A pattern on this list is `rejected` under the evidence rules, with the reason
+recorded as the specific guarantee that prevents it. Name the guarantee. A
+report that says "rejected, see known non-findings" is not traceable; one that
+says "rejected: the runtime rejects a CPI into a program already on the stack"
+is.
+
+Do not carry these into the open-questions section either. An open question is
+something unresolved. These are resolved.
+
+If the target's runtime or framework version predates the fix that makes one of
+these safe, then it is not on this list for that target. Say which version you
+checked.

--- a/skills/qedgen-auditor/references/known-non-findings.md
+++ b/skills/qedgen-auditor/references/known-non-findings.md
@@ -40,15 +40,23 @@ until 2026-07-30 and described a callback path the runtime does not permit.
 **Claim.** Closing an Anchor account safely requires writing a special closed
 account discriminator, and a program that does not is vulnerable.
 
-**Why it does not hold.** Anchor has no closed-account discriminator. The
-mechanism it refers to was removed in Anchor v0.30.0.
+**Why it does not hold.** The `CLOSED_ACCOUNT_DISCRIMINATOR` sentinel, eight
+bytes of `0xFF`, was removed in Anchor v0.30.0 and appears nowhere in the
+current `anchor-lang` source. Anchor still protects the close path; it just no
+longer does it with a sentinel. `#[account(close = ...)]` moves the lamports
+out, assigns the account to the System Program, and resizes the data to zero,
+after which `is_closed` tests `owner == System::id() && data_is_empty()`.
 
-**Where something real might be.** Account closure is still sensitive, and the
-underlying concern is legitimate: lamports must move out, data must be zeroed,
-and ownership must return to the system program. A native program doing this by
-hand can get it wrong. File that as `pda_lifecycle_reuse_after_close` or
-`close_account_redirection` with the actual missing step named. Do not file the
-discriminator itself.
+The non-finding is narrow: "this program does not write the closed-account
+discriminator". Absence of the sentinel is not absence of protection.
+
+**Where something real might be.** Every step of that mechanism is worth
+checking when the program does not use `#[account(close)]`. A native or manual
+close has to move the lamports, drop the data, and hand ownership back on its
+own, and any one of those can be missed. A close that zeroes lamports while
+leaving data and owner intact is a real revival bug. File the specific missing
+step as `pda_lifecycle_reuse_after_close` or `close_account_redirection`, which
+is a different finding from the discriminator claim.
 
 ## Float non-determinism
 


### PR DESCRIPTION
Adds a false-positive reference to the auditor skill, then fixes the two catalog defects that writing it exposed.

## `references/known-non-findings.md`

Seven patterns that get reported as Solana vulnerabilities but are not, because the runtime, the token program, or the framework already prevents the claimed attack: CPI reentrancy, the Anchor closed-account discriminator, float non-determinism, token self-transfer, `load_instruction_at` / `load_current_index`, partial state commitment on a failed transaction, and unchecked CPI return values.

Each entry states the claim, why it does not hold, and the narrow condition under which a related issue would be real. The narrow condition is the useful part, since it is usually a different bug than the pattern match suggested. A short "still real" section covers stack exhaustion and duplicate mutable accounts so the file cannot be read as blanket permission to dismiss.

Routed from the SKILL.md reference list and from the `rejected` evidence state, which now requires naming the specific guarantee rather than citing the file. A report that says "rejected, see known non-findings" is not traceable.

## `transfer_hook_reentrancy` → `transfer_hook_untrusted_callback`

The old entry said a Token-2022 transfer hook "can call back into the calling program during a transfer". Solana's CPI documentation says otherwise: direct self-recursion `A -> A -> A` is allowed, indirect reentrancy `A -> B -> A` returns `ReentrancyNotAllowed`, and the instruction stack depth is 5 (9 with SIMD-0268). The described path is not reachable.

Renamed rather than patched. A category named reentrancy sitting next to a reference that lists reentrancy as a misreport is incoherent, and the name itself taught the false mechanism to every worker that reads the catalog.

The entry keeps HIGH and states the real mechanism: an unpinned caller-supplied mint runs attacker-authored code inside the caller's critical section, with attacker-controlled extra accounts, able to fail the transfer or CPI into any program not already on the stack. It says in bold what the hook cannot do. The compose-with-what row that claimed "classic reentrancy" was replaced, and the codegen-ownership list and one probe `investigation_hint` string were updated to match.

## New category `payout_exceeds_recorded_principal`

A handler disburses from a computed schedule or accrual formula (vesting, streaming, rewards, interest) and the cumulative disbursement is never clamped to the deposited principal, so `sum(payouts) <= deposited` holds only as long as the formula is exactly right.

The catalog had no home for this. Every nearby category is wrong for a specific reason, and the entry says so: `arithmetic_overflow_wrapping` does not apply because every operation is `checked_*` and nothing wraps, `rounding_direction_round_trip` because there is one leg not two, `liquidation_rounding_dust_accumulation` because the leak is a full schedule unit not accumulated dust. A category whose boundaries are not stated gets used as a catch-all.

The detection method is to evaluate each schedule at its boundary and compare the maximum against the recorded principal. The entry notes that grepping for unchecked arithmetic will not find this class.

## `docs/security-primer.md`

The sysvar-spoof entry led with a grep for `load_instruction_at(`. The unchecked variant was fixed in 2022 and later removed, so that grep is dead against any current toolchain. Promoted the account-typing signals, which are durable, and recorded why the old one was dropped.

## Verification

`cargo check --workspace` clean. `scripts/check-auditor-skill.sh` passes, which covers the new cross-reference resolving and the installed-copy sync. No test references the changed predicate string.

## Note on sourcing

These changes came out of building a labeled benchmark corpus from public teaching material. That corpus is local only and deliberately not committed.

The new category entry describes its defect shape generically and does not name the program it came from. Every audit worker reads the catalog, so naming a scored benchmark target there would hand over the answer. Teaching the shape is the point of the catalog; naming a specific corpus program is the line.

---

## Three further categories (second push)

Three classes the awesome-solana-security exploration surfaced, all confirmed absent from the catalog by grep before writing. Sources were read first; two of the three did not match the shape I expected.

### `lamport_balance_not_program_controlled` (HIGH)

An account's lamport balance is not program-controlled state. Anyone can raise it without the owning program's consent, and the runtime constrains when it may fall. Two sub-shapes share that root, so they share an entry.

Read side: the program derives accounting truth from `account.lamports()`, and an attacker transfers lamports in directly to skew it. Write side: the program pushes a payout to an address from state or caller input and depends on it succeeding, which the runtime can refuse permanently if the debit breaks rent exemption, the target is executable, or the target is reserved and silently demoted to read-only. An address stored at init can become unpayable later and brick the handler.

Bounded against the existing `lamport_write_demotion`, which is about the direct `try_borrow_mut_lamports` write mechanic rather than trusting the balance as state.

### `compressed_nft_ownership_unverified` (HIGH, CRITICAL when it gates funds)

A compressed NFT has no account to own and no owner field to read. Ownership is a Merkle leaf that exists only as a per-transaction proof, so every guarantee rests on recalculating the leaf from the signer and verifying against the tree's live root. The entry lists the four ways integrators lose that: trusting a caller- or indexer-supplied leaf, verifying against a caller-supplied root, not pinning the tree account, and caching a proof past the changelog buffer.

It also says explicitly **not** to file canopy depth as a vulnerability. The canopy shortens the submitted proof to fit the transaction size limit; it does not weaken verification. It is reportable only when too little canopy makes a required operation unlandable, which is a denial of service rather than an ownership bug.

### `privileged_action_no_delay_window` (MEDIUM, HIGH when one call can seize funds)

The source here turned out to be about signing procedure rather than a code pattern, so this is the on-chain half of it. A durable-nonce-anchored signature does not expire, so an approval collected under one pretext can land weeks later under another. A protocol with no interval between request and effect has no window in which anyone can notice and revoke.

`authority_transfer_missing_nominate_accept` covers one handler. This covers the rest of the privileged surface, and notes that a handshake on `set_authority` is worth little while `whitelist_collateral` still executes instantly. Fastest signal is the absence of a `Clock` read in a privileged setter.

Four cookbook rows added alongside. The catalog is now 47 categories.
