### PR TITLE
feat(qed): bump ratchet to 0.4.0 — 5 new rules, exact-length discriminators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ratchet-anchor"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6fb8559047050995c876d661a55090415d15c64b3a2f48dd130d502ebed545"
+checksum = "78f4fd07bef8f9a93bf0288e58cadcf4544bc560165d01a1634533079a66c216"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3577,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ratchet-core"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45230590839930db9c2a073aa871b4d310292ba8c0d40438de857965deb8f4e1"
+checksum = "4f45694b07659a92622849d1a65ae5296f50b6f4c644646ed01b32f8d2706d98"
 dependencies = [
  "serde",
  "serde_json",
@@ -3588,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ratchet-quasar"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ee265b95d491029144c3a34c4580925eebdfa82e07b1e759d1bae1498a9301"
+checksum = "0fa4968f336dabf14c8de76ff9056b36085a9fb8147b32cd527c3d6d6858da07"
 dependencies = [
  "anyhow",
  "serde",

--- a/crates/qedgen/Cargo.toml
+++ b/crates/qedgen/Cargo.toml
@@ -38,8 +38,8 @@ libc = "0.2"
 # already has on disk, never an on-chain pubkey. The `package = …`
 # aliases keep the import paths (`ratchet_core::`, `ratchet_anchor::`,
 # `ratchet_quasar::`) short without renaming the upstream crates.
-ratchet-core = { package = "solana-ratchet-core", version = "0.3.2" }
-ratchet-anchor = { package = "solana-ratchet-anchor", version = "0.3.2", default-features = false }
+ratchet-core = { package = "solana-ratchet-core", version = "0.4.0" }
+ratchet-anchor = { package = "solana-ratchet-anchor", version = "0.4.0", default-features = false }
 # `ratchet-quasar` covers Quasar IDLs end-to-end. Not RPC-bearing —
 # the loader reads JSON straight off disk, no fetch path to gate.
-ratchet-quasar = { package = "solana-ratchet-quasar", version = "0.3.2" }
+ratchet-quasar = { package = "solana-ratchet-quasar", version = "0.4.0" }

--- a/crates/qedgen/src/verify/ratchet.rs
+++ b/crates/qedgen/src/verify/ratchet.rs
@@ -366,10 +366,10 @@ mod tests {
             .iter()
             .map(|r| (r.id(), r.name()))
             .collect();
-        assert_eq!(entries.len(), 6);
+        assert_eq!(entries.len(), 7);
         assert!(entries.iter().all(|(id, _)| id.starts_with('P')));
         let ids: Vec<&str> = entries.iter().map(|(id, _)| *id).collect();
-        for expected in &["P001", "P002", "P003", "P004", "P005", "P006"] {
+        for expected in &["P001", "P002", "P003", "P004", "P005", "P006", "P007"] {
             assert!(ids.contains(expected), "missing {expected} in catalog");
         }
     }
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn list_rules_diff_covers_full_r_catalog() {
         let entries: Vec<_> = default_rules().iter().map(|r| (r.id(), r.name())).collect();
-        assert_eq!(entries.len(), 16);
+        assert_eq!(entries.len(), 20);
         assert!(entries.iter().all(|(id, _)| id.starts_with('R')));
         // Spot-check rule ids referenced by number in docs.
         let ids: Vec<&str> = entries.iter().map(|(id, _)| *id).collect();

--- a/crates/qedgen/src/verify/ratchet.rs
+++ b/crates/qedgen/src/verify/ratchet.rs
@@ -358,8 +358,8 @@ mod tests {
         assert!(format!("{err:#}").contains("parsing"));
     }
 
-    // Catalog-shape guards for `--list-rules`: counts pinned at the v0.3.1
-    // catalog (6 P + 16 R); bump when the upstream catalog grows.
+    // Catalog-shape guards for `--list-rules`: counts pinned at the v0.4.0
+    // catalog (7 P + 20 R); bump when the upstream catalog grows.
     #[test]
     fn list_rules_preflight_covers_full_p_catalog() {
         let entries: Vec<_> = default_preflight_rules()
@@ -381,7 +381,9 @@ mod tests {
         assert!(entries.iter().all(|(id, _)| id.starts_with('R')));
         // Spot-check rule ids referenced by number in docs.
         let ids: Vec<&str> = entries.iter().map(|(id, _)| *id).collect();
-        for expected in &["R001", "R006", "R007", "R013", "R016"] {
+        for expected in &[
+            "R001", "R006", "R007", "R013", "R016", "R017", "R018", "R019", "R020",
+        ] {
             assert!(ids.contains(expected), "missing {expected} in catalog");
         }
     }


### PR DESCRIPTION
Bumps the three `solana-ratchet-*` pins 0.3.2 → 0.4.0 ([release notes](https://github.com/saicharanpogul/ratchet/releases/tag/v0.4.0)).

## Why

- **Quasar discriminators now compare at exact length.** 0.3.2 zero-padded short selectors to 8 bytes internally, so a discriminator *length* change (`[0x05]` → `[0x05, 0x00]` — a real wire-format break) was invisible to qedgen's verify verdicts. 0.4.0 fixes the false negative.
- **Five new rules land through the existing `check`/`preflight` calls with no integration work**: R017 event-removed, R018 error-code-change, R019 type-shape-change (nested user-defined types were previously undiffed — verified exit-0 on state-corrupting upgrades), R020 serialization-change (Borsh ↔ zero-copy flips), P007 discriminator-prefix-collision.
- **Legacy pre-0.30 Anchor IDLs now error loudly** upstream with an `anchor idl convert` hint, instead of silently normalizing to zero-field surfaces where the layout rules could never fire.
- **Rule docs now state event-rule scope explicitly** (R016/R017/P004 fire only on programs that already declare events; ratchet never requires adding them) — closes out the R016 misreading an agent hit while using ratchet via qedgen.

## Changes

- `crates/qedgen/Cargo.toml`: three version pins
- `crates/qedgen/src/verify/ratchet.rs`: catalog-count assertions 16→20 R-rules, 6→7 P-rules (incl. P007 in the expected-ids list)
- `Cargo.lock`

No API changes required — qedgen's usage surface (`normalize`/`check`/`preflight`/`Severity`) is unaffected by 0.4.0's IR changes.

## Verification

`cargo test -p qedgen-solana-skills` on this branch: **1663 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXRKTBgURq6GwAKaWhgSjn